### PR TITLE
Force the use of port 8080.

### DIFF
--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "NODE_ENV=production rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public",
+    "start": "sirv public --no-clear --port 8080",
     "validate": "svelte-check"
   },
   "devDependencies": {


### PR DESCRIPTION
The pyscript server defaults to port 5000. However, it turns out this is the default port used by the AirPlay receiver on macOS (see sveltejs/template#184), so it's not a safe port to use on macOS. 

sirv-cli 2.0.0 apparently changes to this port as a default (see sveltejs/template#278); this PR fixes the problem without updating sirv-cli.