### PR TITLE
Don't fail on an empty `<py-env></py-env>`

### DIFF
--- a/pyscriptjs/src/components/pyenv.ts
+++ b/pyscriptjs/src/components/pyenv.ts
@@ -39,7 +39,11 @@ export class PyEnv extends HTMLElement {
 
     let env = [];
     let paths = [];
+
     this.environment = jsyaml.load(this.code);
+    if (this.environment === undefined)
+       return
+
     for (let entry of this.environment) {
       if (typeof entry == "string" ){
         env.push(entry);


### PR DESCRIPTION
Previously failed with "Uncaught TypeError: this.environment is not iterable".