### PR TITLE
Allow `import d3` instead of `from esm import d3`

### DIFF
--- a/pyscriptjs/examples/d3.html
+++ b/pyscriptjs/examples/d3.html
@@ -109,7 +109,7 @@ for (const d of data) {
 
 <py-script>
 from pyodide import create_proxy, to_js
-from esm import d3
+import d3
 
 fruits = [
   dict(name="🍊", count=21),

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -247,8 +247,6 @@ export class PyScript extends HTMLElement {
     }
 
     protected async _register_esm(pyodide: PyodideInterface): Promise<void> {
-      const imports: {[key: string]: unknown} = {}
-
       for (const node of document.querySelectorAll("script[type='importmap']")) {
         const importmap = (() => {
           try {
@@ -265,17 +263,19 @@ export class PyScript extends HTMLElement {
           if (typeof name != "string" || typeof url != "string")
             continue
 
+          let exports: object
           try {
             // XXX: pyodide doesn't like Module(), failing with
             // "can't read 'name' of undefined" at import time
-            imports[name] = {...await import(url)}
+            exports = {...await import(url)}
           } catch {
-            console.error(`failed to fetch '${url}' for '${name}'`)
+            console.warn(`failed to fetch '${url}' for '${name}'`)
+            continue
           }
+
+          pyodide.registerJsModule(name, exports)
         }
       }
-
-      pyodide.registerJsModule("esm", imports)
     }
 
     async evaluate(): Promise<void> {


### PR DESCRIPTION
Allows for more natural way of importing modules. This also permits `from d3 import pie` style of imports (not showed in this PR).