### PR TITLE
move check id out of constructor

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -45,9 +45,7 @@ export class BaseEvalElement extends HTMLElement {
         this.shadow = this.attachShadow({ mode: 'open'});
         this.wrapper = document.createElement('slot');
         this.shadow.appendChild(this.wrapper);
-        if (!this.id)
-	  this.id = this.constructor.name+"-"+guidGenerator()
-      }
+    }
 
     addToOutput(s: string) {
         this.outputElement.innerHTML += "<div>"+s+"</div>";
@@ -56,6 +54,11 @@ export class BaseEvalElement extends HTMLElement {
 
     postEvaluate(){
 
+    }
+
+    checkId(){
+        if (!this.id)
+            this.id = this.constructor.name+"-"+guidGenerator();
     }
 
     getSourceFromElement(): string{
@@ -164,6 +167,8 @@ export class BaseEvalElement extends HTMLElement {
         }
     } // end eval
   }
+
+
 
   function createWidget(name: string, code: string, klass: string){
       

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -59,26 +59,27 @@ export class PyRepl extends BaseEvalElement {
 
 
     connectedCallback() {
-        this.code = this.innerHTML;
-        this.innerHTML = '';
+      this.checkId()
+      this.code = this.innerHTML;
+      this.innerHTML = '';
 
-        let extensions = [
-          basicSetup,
-            languageConf.of(python()),
-            keymap.of([
-                  ...defaultKeymap,
-                  { key: "Ctrl-Enter", run: createCmdHandler(this) },
-                  { key: "Shift-Enter", run: createCmdHandler(this) }
-            ]),
-            
-            // Event listener function that is called every time an user types something on this editor
-          //   EditorView.updateListener.of((v:ViewUpdate) => {
-          //     if (v.docChanged) {
-          //       console.log(v.changes);
+      let extensions = [
+        basicSetup,
+          languageConf.of(python()),
+          keymap.of([
+                ...defaultKeymap,
+                { key: "Ctrl-Enter", run: createCmdHandler(this) },
+                { key: "Shift-Enter", run: createCmdHandler(this) }
+          ]),
 
-          //     }
-          // })
-        ];
+          // Event listener function that is called every time an user types something on this editor
+        //   EditorView.updateListener.of((v:ViewUpdate) => {
+        //     if (v.docChanged) {
+        //       console.log(v.changes);
+
+        //     }
+        // })
+      ];
         
         if (!this.hasAttribute('theme')) {
           this.theme = this.getAttribute('theme');

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -98,6 +98,7 @@ export class PyScript extends BaseEvalElement {
       }
 
     connectedCallback() {
+      this.checkId()
         this.code = this.innerHTML;
         this.innerHTML = '';
         let startState = EditorState.create({


### PR DESCRIPTION
Moving the check id out of the constructor. Apparently, web components shouldn't read or modify attributes in the constructor. It was causing REPL to break with an error when creating a new instance for auto-generate