### PR TITLE
Fixing typescript error in build process

### DIFF
--- a/pyscriptjs/src/components/pybox.ts
+++ b/pyscriptjs/src/components/pybox.ts
@@ -54,7 +54,7 @@ export class PyBox extends HTMLElement {
 
         this.widths.forEach((width, index)=>{
             const node: ChildNode = mainDiv.childNodes[index];
-            addClasses(node, [width, 'mx-1'])
+            addClasses(node as HTMLElement, [width, 'mx-1'])
 
         })
 


### PR DESCRIPTION
When running npm build you get the following error, casting ChildNode as HTMLElement will fix:

```
!) Plugin typescript: @rollup/plugin-typescript TS2345: Argument of type 'ChildNode' is not assignable to parameter of type 'HTMLElement'.
  Type 'ChildNode' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 223 more.
src/components/pybox.ts: (57:24)

57             addClasses(node, [width, 'mx-1'])
                          ~~~~
```