### PR TITLE
Handle __repr__ of types

### DIFF
--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -66,7 +66,7 @@ def format_mime(obj):
     """
     Formats object using _repr_x_ methods.
     """
-    if isinstance(obj, str):
+    if isinstance(obj, (str, type)):
         return obj, 'text/plain'
 
     mimebundle = eval_formatter(obj, '_repr_mimebundle_')

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -50,14 +50,16 @@ def eval_formatter(obj, print_method):
     """
     Evaluates a formatter method.
     """
-    if hasattr(obj, print_method):
-        if print_method == 'savefig':
-            buf = io.BytesIO()
-            obj.savefig(buf, format='png')
-            buf.seek(0)
-            return base64.b64encode(buf.read()).decode('utf-8')
+    if print_method == '__repr__':
+         return repr(obj)
+    elif print_method == 'savefig':
+         buf = io.BytesIO()
+         obj.savefig(buf, format='png')
+         buf.seek(0)
+         return base64.b64encode(buf.read()).decode('utf-8')
+    elif hasattr(obj, print_method):
         return getattr(obj, print_method)()
-    if print_method == '_repr_mimebundle_':
+    elif print_method == '_repr_mimebundle_':
         return {}, {}
     return None
 
@@ -66,7 +68,7 @@ def format_mime(obj):
     """
     Formats object using _repr_x_ methods.
     """
-    if isinstance(obj, (str, type)):
+    if isinstance(obj, str):
         return obj, 'text/plain'
 
     mimebundle = eval_formatter(obj, '_repr_mimebundle_')

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -52,12 +52,12 @@ def eval_formatter(obj, print_method):
     """
     if print_method == '__repr__':
          return repr(obj)
-    elif print_method == 'savefig':
-         buf = io.BytesIO()
-         obj.savefig(buf, format='png')
-         buf.seek(0)
-         return base64.b64encode(buf.read()).decode('utf-8')
     elif hasattr(obj, print_method):
+        if print_method == 'savefig':
+            buf = io.BytesIO()
+            obj.savefig(buf, format='png')
+            buf.seek(0)
+            return base64.b64encode(buf.read()).decode('utf-8')
         return getattr(obj, print_method)()
     elif print_method == '_repr_mimebundle_':
         return {}, {}

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -59,8 +59,8 @@ def format_mime(obj):
     """
     Formats object using _repr_x_ methods.
     """
-    if isinstance(obj, str):
-        return obj, 'text/plain'
+    if isinstance(obj, (str, type)):
+        return str(obj), 'text/plain'
 
     mimebundle = eval_formatter(obj, '_repr_mimebundle_')
     if isinstance(mimebundle, tuple):

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -43,14 +43,16 @@ def eval_formatter(obj, print_method):
     """
     Evaluates a formatter method.
     """
-    if hasattr(obj, print_method):
-        if print_method == 'savefig':
-            buf = io.BytesIO()
-            obj.savefig(buf, format='png')
-            buf.seek(0)
-            return base64.b64encode(buf.read()).decode('utf-8')
+    if print_method == '__repr__':
+         return repr(obj)
+    elif print_method == 'savefig':
+         buf = io.BytesIO()
+         obj.savefig(buf, format='png')
+         buf.seek(0)
+         return base64.b64encode(buf.read()).decode('utf-8')
+    elif hasattr(obj, print_method):
         return getattr(obj, print_method)()
-    if print_method == '_repr_mimebundle_':
+    elif print_method == '_repr_mimebundle_':
         return {}, {}
     return None
 
@@ -59,8 +61,8 @@ def format_mime(obj):
     """
     Formats object using _repr_x_ methods.
     """
-    if isinstance(obj, (str, type)):
-        return str(obj), 'text/plain'
+    if isinstance(obj, str):
+        return obj, 'text/plain'
 
     mimebundle = eval_formatter(obj, '_repr_mimebundle_')
     if isinstance(mimebundle, tuple):
@@ -75,7 +77,7 @@ def format_mime(obj):
             output = format_dict[mime_type]
         else:
             output = eval_formatter(obj, method)
-        
+
         if output is None:
             continue
         elif mime_type not in MIME_RENDERERS:
@@ -84,7 +86,7 @@ def format_mime(obj):
         break
     if output is None:
         if not_available:
-            console.warning(f'Rendered object requested unavailable MIME renderers: {not_available}')  
+            console.warning(f'Rendered object requested unavailable MIME renderers: {not_available}')
         output = repr(output)
         mime_type = 'text/plain'
     elif isinstance(output, tuple):

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -45,12 +45,12 @@ def eval_formatter(obj, print_method):
     """
     if print_method == '__repr__':
          return repr(obj)
-    elif print_method == 'savefig':
-         buf = io.BytesIO()
-         obj.savefig(buf, format='png')
-         buf.seek(0)
-         return base64.b64encode(buf.read()).decode('utf-8')
     elif hasattr(obj, print_method):
+        if print_method == 'savefig':
+            buf = io.BytesIO()
+            obj.savefig(buf, format='png')
+            buf.seek(0)
+            return base64.b64encode(buf.read()).decode('utf-8')
         return getattr(obj, print_method)()
     elif print_method == '_repr_mimebundle_':
         return {}, {}


### PR DESCRIPTION
The problem here was that it was calling `type.__repr__` which is missing the self argument. Instead we should simply call `repr(type)`. There is however a secondary problem, which is that since we are rendering straight to the DOM the `<` and `>` in the type repr get taken as an HTML tag and we still don't get any output. We will have to consider whether to always escape `<` and `>` when rendered into the DOM which would unfortunately mean that we cannot have strings be directly interpreted as HTML (e.g. breaking @pzwang's rick-roll demo in the PyCon keynote).

Partially Fixes https://github.com/pyscript/pyscript/issues/120