### PR TITLE
Run scripts after loading pyodide to fix #95

### DIFF
--- a/pyscriptjs/examples/create_dynamic.html
+++ b/pyscriptjs/examples/create_dynamic.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <title>PyScript Create Dynamic</title>
+
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="stylesheet" href="../build/pyscript.css" />
+    
+    <script defer src="../build/pyscript.js"></script>
+  </head>
+
+  <body>
+    Create dynamically a <code>py-script</code> tag.<br>
+    This is the current date and time, as computed by Python:
+     <script>
+      setTimeout(function() {
+        var pyscript = document.createElement('py-script');
+
+        pyscript.innerHTML = `
+from datetime import datetime
+now = datetime.now()
+
+now.strftime("%m/%d/%Y %H:%M:%S")
+        `
+        document.body.appendChild(pyscript);
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/pyscriptjs/examples/index.html
+++ b/pyscriptjs/examples/index.html
@@ -59,6 +59,8 @@
     <h2 class="text-2xl font-bold text-blue-600"><a href="./webgl/raycaster/index.html" target=”_blank”>Webgl Icosahedron Example</a></h2>
     <p>Demo showing how a Simple Webgl scene would work in PyScript</code> tag</p>
 
+    <h2 class="text-2xl font-bold text-blue-600"><a href="./create_dynamic.html" target=”_blank”>Create Dynamic</a></h2>
+    <p>Dynamic creation of <code>&lt;py-script&gt;</code> tag</p>
 
     <br>
     <h2 class="text-3xl font-bold">Visualizations & Dashboards</h2>

--- a/pyscriptjs/src/App.svelte
+++ b/pyscriptjs/src/App.svelte
@@ -12,6 +12,13 @@
 
     let pyodideReadyPromise;
 
+    const executeScripts = () => {
+        for (let script of $scriptsQueue) {
+            script.evaluate();
+        }
+        scriptsQueue.set([]);
+    }
+
     const initializePyodide = async () => {
         pyodideReadyPromise = loadInterpreter();
         const pyodide = await pyodideReadyPromise;
@@ -34,10 +41,8 @@
 
         // now we can actually execute the page scripts if we are in play mode
         if ($mode == 'play') {
-            for (let script of $scriptsQueue) {
-                script.evaluate();
-            }
-            scriptsQueue.set([]);
+            executeScripts();
+            setInterval(executeScripts, 200);
         }
 
         // now we call all post initializers AFTER we actually executed all page scripts


### PR DESCRIPTION
Here is a fix for https://github.com/pyscript/pyscript/issues/95. There is a queue of scripts to execute which are currently only executed when pyiodide loads; however, if something else in the page creates a `<py-script>` tag, they won't be executed unless we monitor this queue and execute them later on.