### PR TITLE
Fix dedenting of <py-script> code

### DIFF
--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -9,8 +9,8 @@ const getLastPath = function (str) {
 };
 
 function htmlDecode(input) {
-    const doc = new DOMParser().parseFromString(input, 'text/html');
-    return ltrim(doc.documentElement.textContent);
+    const doc = new DOMParser().parseFromString(ltrim(input), 'text/html');
+    return doc.documentElement.textContent;
 }
 
 function ltrim(code: string): string {


### PR DESCRIPTION
Runs `ltrim` before HTML decoding the string. The HTMl decode strips the indentation of the first line and thereby caused `ltrim` to be a no-op.

Fixes https://github.com/pyscript/pyscript/issues/104