### PR TITLE
Updated `link` and `script` source location

### DIFF
--- a/pyscriptjs/examples/hello_world.html
+++ b/pyscriptjs/examples/hello_world.html
@@ -7,9 +7,8 @@
     <title>PyScript Hello World</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
The location of the `pyscript.css` and `pyscript.js` where outdated.
Using the last references at https://pyscript.net/ and absolute URLs.