### PR TITLE
add basic HTTP requests async demo with pyfetch

### DIFF
--- a/pyscriptjs/examples/index.html
+++ b/pyscriptjs/examples/index.html
@@ -36,6 +36,9 @@
     <h2 class="text-2xl font-bold text-blue-600"><a href="./todo-pylist.html" target=”_blank”>PyScript Native TODO App</a></h2>
     <p>Demo showing how would a Simple TODO App would look like only using PyScript native elements</code> tag</p>
 
+    <h2 class="text-2xl font-bold text-blue-600"><a href="./request.html" target=”_blank”>API HTTP Requests</a></h2>
+    <p>Basic API HTTP requests demo for asynchronus GET, POST, etc. HTTP requests with pyodide (requests module alternative).</p>
+
     <br>
     <h2 class="text-3xl font-bold">MIME Rendering</h2>
     <hr/>

--- a/pyscriptjs/examples/request.html
+++ b/pyscriptjs/examples/request.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <title>GET, POST, PUT, DELETE example</title>
+
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="stylesheet" href="../build/pyscript.css" />
+    
+    <script defer src="../build/pyscript.js"></script>
+    <py-env>
+        - paths:
+          - /request.py
+    </py-env>
+  </head>
+
+  <body><p>
+    Hello world request example! <br>
+    Here is the output of your request:
+    </p>
+    <py-script>
+import asyncio  # important!!
+import json
+from request import request
+
+baseurl = "https://jsonplaceholder.typicode.com/"
+
+# GET
+headers = {"Content-type": "application/json"}
+response = await request(baseurl+"posts/2", method="GET", headers=headers)
+print(f"GET request=> status:{response.status}, json:{await response.json()}")
+
+# POST
+body = json.dumps({"title":"test_title", "body":"test body", "userId":1})
+new_post = await request(baseurl+"posts", body=body, method="POST", headers=headers)
+print(f"POST request=> status:{new_post.status}, json:{await new_post.json()}")
+
+# PUT
+body = json.dumps({"id":1, "title":"test_title", "body":"test body", "userId":2})
+new_post = await request(baseurl+"posts/1", body=body, method="PUT", headers=headers)
+print(f"PUT request=> status:{new_post.status}, json:{await new_post.json()}")
+
+# DELETE
+new_post = await request(baseurl+"posts/1", method="DELETE", headers=headers)
+print(f"DELETE request=> status:{new_post.status}, json:{await new_post.json()}")
+    </py-script>
+
+    <div>
+    <p>
+        You can also use other methods. See fetch documentation: <br>
+        https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters 
+    </p>
+    </div>
+    <div>
+        <p>
+        See pyodide documentation for what to do with a FetchResponse object: <br>
+        https://pyodide.org/en/stable/usage/api/python-api.html#pyodide.http.FetchResponse
+        </p>
+    </div>
+  </body>
+</html>

--- a/pyscriptjs/examples/request.py
+++ b/pyscriptjs/examples/request.py
@@ -1,0 +1,25 @@
+from pyodide.http import pyfetch, FetchResponse
+from typing import Optional
+
+async def request(url:str, method:str = "GET", body:Optional[str] = None,
+ headers:Optional[dict[str,str]] = None) -> FetchResponse:
+    """
+    Async request function. Pass in Method and make sure to await!
+    Parameters:
+        method: str = {"GET", "POST", "PUT", "DELETE"} from javascript global fetch())
+        body: str = body as json string. Example, body=json.dumps(my_dict)
+        header: dict[str,str] = header as dict, will be converted to string... 
+            Example, header:json.dumps({"Content-Type":"application/json"})
+
+    Return: 
+        response: pyodide.http.FetchResponse = use with .status or await.json(), etc.
+    """
+    kwargs = {"method":method, "mode":"cors"}
+    if body and method not in ["GET", "HEAD"]:
+        kwargs["body"] = body
+    if headers:
+        kwargs["headers"] = headers
+    
+    
+    response = await pyfetch(url, **kwargs)
+    return response


### PR DESCRIPTION
### Summary
Add a basic asynchronus demo in pure python for using `pyodide.http.pyfetch` for making HTTP requests.

### Description
`pyfetch` is the `pyodide` alternative for python's widely used `requests` module (or other modules like httpx/urllib), since they are currently not supported in `pyodide`.

This demo uses the `pyodide` wrapper around javascript `fetch()`, called `pyfetch` to make "GET, POST, PUT, DELETE" requests to show how it can be done. Basically allows interfacing with a REST API from `pyscript`.

It's a simple modification of the Hello World demo to make a few requests to the free https://jsonplaceholder.typicode.com API.

### Reason
See several issues and posts on anaconda forum asking about the same question. 
Users are suprised that requests doesn't work and there are no existing simple python demos to show how it works.
(Especially for making POST requests with a body and headers, etc.)

Note: demo requires python>=3.10.

### Related issues:
#91 #111


### Requesting edits

Feel free to suggest or make changes, ask questions, etc., even if you are not a maintainer.