### PR TITLE
fix misspelled logs

### DIFF
--- a/pyscriptjs/src/components/pyenv.ts
+++ b/pyscriptjs/src/components/pyenv.ts
@@ -50,7 +50,7 @@ export class PyEnv extends HTMLElement {
 
         async function loadEnv() {
             await loadPackage(env, runtime);
-            console.log('enviroment loaded');
+            console.log('environment loaded');
         }
 
         async function loadPaths() {
@@ -63,6 +63,6 @@ export class PyEnv extends HTMLElement {
 
         addInitializer(loadEnv);
         addInitializer(loadPaths);
-        console.log('enviroment loading...', this.env);
+        console.log('environment loading...', this.env);
     }
 }


### PR DESCRIPTION
Fix misspelled logs "enviroment" -> "environment" in pyenv.ts 

close #200