### PR TITLE
Remove redundant minified js export

### DIFF
--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -39,12 +39,11 @@ export default {
   input: "src/main.ts",
   output:[
     {
-    sourcemap: true,
-    format: "iife",
-    name: "app",
-    file: "examples/build/pyscript.js",
+      sourcemap: true,
+      format: "iife",
+      name: "app",
+      file: "examples/build/pyscript.js",
     },
-    { file: "examples/build/pyscript.min.js", format: "iife", plugins: [terser()] },
   ],
   plugins: [
     svelte({
@@ -73,8 +72,8 @@ export default {
     production && terser(),
     !production && serve({
       port: 8080,
-      contentBase: 'examples'}
-      )
+      contentBase: 'examples'
+    }),
   ],
   watch: {
     clearScreen: false,


### PR DESCRIPTION
The rollup.config.js had a `pyscript.min.js` export although `pyscript.js` already gets minified on production builds due to `production && terser()` later in the file. This pr removes that which gets rid of one of the warnings (the `output.name` one) which is progress on #208.