### PR TITLE
Add links to the libraries used in the examples

### DIFF
--- a/pyscriptjs/examples/index.html
+++ b/pyscriptjs/examples/index.html
@@ -41,66 +41,66 @@
     <hr/>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./matplotlib.html" target=”_blank”>Matplotlib</a></h2>
-    <p>Demonstrates rendering matplotlib figure as output of the py-script tag</p>
+    <p>Demonstrates rendering <a href="https://matplotlib.org/" class="text-blue-600" target=”_blank”>Matplotlib</a> figure as output of the py-script tag</p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./altair.html" target=”_blank”>Altair</a></h2>
-    <p>Demonstrates rendering altair plot as output of the py-script tag</p>
+    <p>Demonstrates rendering <a href="https://altair-viz.github.io/" class="text-blue-600" target=”_blank”>Altair</a> plot as output of the py-script tag</p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./folium.html" target=”_blank”>Folium</a></h2>
-    <p>Demonstrates rendering Folium map as output of the py-script tag</p>
+    <p>Demonstrates rendering <a href="https://python-visualization.github.io/folium/" class="text-blue-600" target=”_blank”>Folium</a> map as output of the py-script tag</p>
 
     <br>
     <h2 class="text-3xl font-bold">JS Interaction</h2>
     <hr/>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./d3.html" target=”_blank”>Simple d3 visualization</a></h2>
-    <p>Minimal d3 demo demonstrating how to create a visualization</p>
+    <p>Minimal <a href="https://d3js.org/" class="text-blue-600" target=”_blank”>D3</a> demo demonstrating how to create a visualization</p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./webgl/raycaster/index.html" target=”_blank”>Webgl Icosahedron Example</a></h2>
-    <p>Demo showing how a Simple Webgl scene would work in PyScript</code> tag</p>
+    <p>Demo showing how a Simple <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API" class="text-blue-600" target=”_blank”>WebGL</a> scene would work in PyScript</code> tag</p>
 
 
     <br>
     <h2 class="text-3xl font-bold">Visualizations & Dashboards</h2>
     <hr/>
     <h2 class="text-2xl font-bold text-blue-600"><a href="./bokeh.html" target=”_blank”>Simple Static Bokeh Plot</a></h2>
-    <p>Minimal Bokeh demo demonstrating how to create a simple bokeh plot from code</p>
+    <p>Minimal Bokeh demo demonstrating how to create a simple <a href="https://bokeh.org/" class="text-blue-600" target=”_blank”>Bokeh</a> plot from code</p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./bokeh_interactive.html" target=”_blank”>Bokeh Interactive</a></h2>
-    <p>Interactive demo using a Bokeh slider widget to dynamically change a value in the page
+    <p>Interactive demo using a <a href="https://bokeh.org/" class="text-blue-600" target=”_blank”>Bokeh</a> slider widget to dynamically change a value in the page
 
       WARNING: This examples takes a little longer to load. So be patient :)
     </p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./panel_kmeans.html" target=”_blank”>KMeans Demo in Panel</a></h2>
-    <p>Interactive KMeans Chart using Panel
+    <p>Interactive KMeans Chart using <a href="https://panel.holoviz.org/" class="text-blue-600" target=”_blank”>Panel</a>
 
       WARNING: This examples takes a little longer to load. So be patient :)
     </p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./panel_stream.html" target=”_blank”>Streaming Demo in Panel</a></h2>
-    <p>Interactive Streaming Table and Bokeh plot using Panel
+    <p>Interactive Streaming Table and Bokeh plot using <a href="https://panel.holoviz.org/" class="text-blue-600" target=”_blank”>Panel</a>
 
       WARNING: This examples takes a little longer to load. So be patient :)
     </p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./panel.html" target=”_blank”>Simple Panel Demo</a></h2>
-    <p>Simple demo showing Panel widgets interacting with parts of the page
+    <p>Simple demo showing <a href="https://panel.holoviz.org/" class="text-blue-600" target=”_blank”>Panel</a> widgets interacting with parts of the page
 
       WARNING: This examples takes a little longer to load. So be patient :)
     </p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./panel_deckgl.html" target=”_blank”>NYC Taxi Data Panel DeckGL Demo</a></h2>
-    <p>Interactive application exploring the NYC Taxi dataset using Panel and DeckGL
+    <p>Interactive application exploring the NYC Taxi dataset using <a href="https://panel.holoviz.org/" class="text-blue-600" target=”_blank”>Panel</a> and <a href="https://deck.gl/" class="text-blue-600" target=”_blank”>DeckGL</a>
 
       WARNING: This examples takes a little longer to load. So be patient :)
     </p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./toga/freedom.html" target=”_blank”>Freedom Units!</a></h2>
-    <p>A Toga application (a Fahrenheit to Celsius converter), rendered as a Single Page App</p>
+    <p>A <a href="https://beeware.org/project/projects/libraries/toga/" class="text-blue-600" target=”_blank”>Toga</a> application (a Fahrenheit to Celsius converter), rendered as a Single Page App</p>
 
     <h2 class="text-2xl font-bold text-blue-600"><a href="./numpy_canvas_fractals.html" target=”_blank”>Fractals with NumPy and canvas</a></h2>
-    <p>Visualization of Mandelbrot and Julia sets with NumPy and HTML5 canvas</p>
+    <p>Visualization of Mandelbrot and Julia sets with <a href="https://numpy.org/" class="text-blue-600" target=”_blank”>Numpy</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API" class="text-blue-600" target=”_blank”>HTML5 canvas</a></p>
 
   </body>
   </html>


### PR DESCRIPTION
This PR gives some more credits to the libraries used in the examples by adding a link to their website. This is how the links look like, they have the same color as the example link.

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/35924738/166887526-44a25233-f391-4f1a-a107-03c8c49b6607.png">