### PR TITLE
Don't load distutils in the Python standard library

### DIFF
--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -420,6 +420,7 @@ const loadInterpreter = async function (): Promise<any> {
     pyodide = await loadPyodide({
         stdout: console.log,
         stderr: console.log,
+        fullStdLib: false
     });
 
     // now that we loaded, add additional convenience functions


### PR DESCRIPTION
distutils is a deprecated and quite large (around to 1MB) stdlib module that would be removed in Python 3.12 . 

![image](https://user-images.githubusercontent.com/630936/166982239-9d45131e-5598-442a-b57a-997b4e58264e.png)


Most users likely don't need it, and if they do, they can add it explicitly as a dependency in py-env. 
This PR disables loading it by default. Though maybe it would be good to wait until examples are tested #152 before merging this, just in case. 