### PR TITLE
Improve type annotations

### DIFF
--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -4371,6 +4371,12 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -17,6 +17,7 @@
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-typescript": "^8.3.2",
     "@tsconfig/svelte": "^1.0.0",
+    "@types/js-yaml": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "autoprefixer": "^10.4.7",

--- a/pyscriptjs/src/components/pyenv.ts
+++ b/pyscriptjs/src/components/pyenv.ts
@@ -16,7 +16,7 @@ export class PyEnv extends HTMLElement {
     shadow: ShadowRoot;
     wrapper: HTMLElement;
     code: string;
-    environment: any;
+    environment: unknown;
     runtime: any;
     env: string[];
     paths: string[];
@@ -32,18 +32,21 @@ export class PyEnv extends HTMLElement {
         this.code = this.innerHTML;
         this.innerHTML = '';
 
-        const env = [];
+        const env: string[] = [];
         const paths: string[] = [];
 
         this.environment = jsyaml.load(this.code);
         if (this.environment === undefined) return;
 
-        for (const entry of this.environment) {
+        for (const entry of Array.isArray(this.environment) ? this.environment : []) {
             if (typeof entry == 'string') {
                 env.push(entry);
-            } else if (entry.hasOwnProperty('paths')) {
-                for (const path of entry.paths) {
-                    paths.push(path);
+            } else if (entry && typeof entry === 'object') {
+                const obj = <Record<string, unknown>>entry;
+                for (const path of Array.isArray(obj.paths) ? obj.paths : []) {
+                    if (typeof path === 'string') {
+                        paths.push(path);
+                    }
                 }
             }
         }

--- a/pyscriptjs/src/components/pyenv.ts
+++ b/pyscriptjs/src/components/pyenv.ts
@@ -51,6 +51,9 @@ export class PyEnv extends HTMLElement {
             }
         }
 
+        this.env = env;
+        this.paths = paths;
+
         async function loadEnv() {
             await loadPackage(env, runtime);
             console.log('environment loaded');


### PR DESCRIPTION
Hi,

This PR contains the following changes to fix some ESLint warnings of `PyEnv`:
- Install js-yaml type definition
- Use `unknown` instead of `any` and add type guards