### PR TITLE
Adding `textwrap.dedent` for allowing indented html blocks

### DIFF
--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -259,7 +259,7 @@ class PyItemTemplate(Element):
 
         console.log("creating innerHtml")
         new_child._element.innerHTML = dedent(
-        f"""
+            f"""
         <label for="flex items-center p-2 ">
           <input class="mr-2" type="checkbox" class="task-check">
           <p class="m-0 inline">{self.render_content()}</p>

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -259,7 +259,7 @@ class PyItemTemplate(Element):
 
         console.log("creating innerHtml")
         new_child._element.innerHTML = dedent(
-            f"""
+        f"""
         <label for="flex items-center p-2 ">
           <input class="mr-2" type="checkbox" class="task-check">
           <p class="m-0 inline">{self.render_content()}</p>

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -260,11 +260,11 @@ class PyItemTemplate(Element):
         console.log("creating innerHtml")
         new_child._element.innerHTML = dedent(
             f"""
-        <label for="flex items-center p-2 ">
-          <input class="mr-2" type="checkbox" class="task-check">
-          <p class="m-0 inline">{self.render_content()}</p>
-        </label>
-        """
+            <label for="flex items-center p-2 ">
+              <input class="mr-2" type="checkbox" class="task-check">
+              <p class="m-0 inline">{self.render_content()}</p>
+            </label>
+            """
         )
 
         console.log("returning")

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -3,6 +3,7 @@ import base64
 import io
 import sys
 import time
+from textwrap import dedent
 
 import micropip  # noqa: F401
 from js import console, document
@@ -257,12 +258,12 @@ class PyItemTemplate(Element):
         console.log("creating values")
 
         console.log("creating innerHtml")
-        new_child._element.innerHTML = f"""
-<label for="flex items-center p-2 ">
-  <input class="mr-2" type="checkbox" class="task-check">
-  <p class="m-0 inline">{self.render_content()}</p>
-</label>
-    """
+        new_child._element.innerHTML = dedent(f"""
+        <label for="flex items-center p-2 ">
+          <input class="mr-2" type="checkbox" class="task-check">
+          <p class="m-0 inline">{self.render_content()}</p>
+        </label>
+        """)
 
         console.log("returning")
         return new_child

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -258,12 +258,14 @@ class PyItemTemplate(Element):
         console.log("creating values")
 
         console.log("creating innerHtml")
-        new_child._element.innerHTML = dedent(f"""
+        new_child._element.innerHTML = dedent(
+            f"""
         <label for="flex items-center p-2 ">
           <input class="mr-2" type="checkbox" class="task-check">
           <p class="m-0 inline">{self.render_content()}</p>
         </label>
-        """)
+        """
+        )
 
         console.log("returning")
         return new_child


### PR DESCRIPTION
Currently any html block, which ideally should be indented properly to enhance readability, cannot be written as is. Adding `textwrap.dedent` helps with this and allows one to write indented html blocks as strings and later properly render the html when it is generated.

- [x] write indented html string
- [x] but dedent it while generating html
- [x] textwrap.dedent is meant for this purpose

**Example**

https://github.com/pyscript/pyscript/blob/22ffbcb21dbfe62108d51339538b73f812eeb39c/pyscriptjs/src/pyscript.py#L254-L265

The update (via this PR) makes the following work.

https://github.com/sugatoray/pyscript/blob/1f076e76df426a90ed186e5d21dc0d3361c91a43/pyscriptjs/src/pyscript.py#L261-L266

![image](https://user-images.githubusercontent.com/10201242/167242066-25955149-a53e-4876-ae2d-46af1589aec0.png)
