### PR TITLE
Update Rollup config

### DIFF
--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -80,7 +80,12 @@ export default {
     name: "app",
     file: "examples/build/pyscript.js",
     },
-    { file: "examples/build/pyscript.min.js", format: "iife", plugins: [terser()] },
+    {
+      file: "examples/build/pyscript.min.js",
+      format: "iife",
+      sourcemap: true,
+      plugins: [terser()],
+    },
   ],
   plugins: [
     svelte({


### PR DESCRIPTION
Hi,

This PR updates Rollup config to fix the following warning:

```
(!) Plugin typescript: @rollup/plugin-typescript: Rollup 'sourcemap' option must be set to generate source maps.
```