### PR TITLE
Avoid using a deprecated method

### DIFF
--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -23,7 +23,7 @@ const loadInterpreter = async function (indexUrl:string): Promise<any> {
     // let's get the full path of where PyScript is running from so we can load the pyscript.py
     // file from the same location
     const loadedScript: HTMLScriptElement = document.querySelector(`script[src$='pyscript.js']`);
-    const scriptPath = loadedScript.src.substr(0, loadedScript.src.lastIndexOf('/'));
+    const scriptPath = loadedScript.src.substring(0, loadedScript.src.lastIndexOf('/'));
     await pyodide.runPythonAsync(await (await fetch(`${scriptPath}/pyscript.py`)).text());
 
     console.log(scriptPath);


### PR DESCRIPTION
Hi,

This PR changes deprecated `substr()` to `substring()`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr