### PR TITLE
fixed the bug std-err attribute cannot set stderr elements properly

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -307,7 +307,7 @@ export class PyWidget extends HTMLElement {
             }
 
             if (this.hasAttribute('std-err')) {
-                this.outputElement = document.getElementById(this.getAttribute('std-err'));
+                this.errorElement = document.getElementById(this.getAttribute('std-err'));
             } else {
                 this.errorElement = this.outputElement;
             }

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -71,7 +71,7 @@ export class PyScript extends BaseEvalElement {
             }
 
             if (this.hasAttribute('std-err')) {
-                this.outputElement = document.getElementById(this.getAttribute('std-err'));
+                this.errorElement = document.getElementById(this.getAttribute('std-err'));
             } else {
                 this.errorElement = this.outputElement;
             }


### PR DESCRIPTION
original version shows the error at #stdout element, not #stderr 
```
    <h2>stdout</h2>
    <pre id="stdout"></pre>
    <h2>stderr</h2>
    <pre id="stderr"></pre>
    <py-script std-out="stdout" std-err="stderr">
error.is.occurred()
    </py-script>

```