### PR TITLE
fixed REPL bugs

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -1,5 +1,5 @@
 import { loadedEnvironments, mode, pyodideLoaded } from '../stores';
-import { guidGenerator, addClasses } from '../utils';
+import { guidGenerator, addClasses, removeClasses } from '../utils';
 // Premise used to connect to the first available pyodide interpreter
 let runtime;
 let environments;
@@ -137,6 +137,19 @@ export class BaseEvalElement extends HTMLElement {
                 this.outputElement.style.display = 'block';
             }
 
+            // check if this REPL contains errors, delete them and remove error classes
+            const errorElements = document.querySelectorAll(`div[id^='${this.errorElement.id}'][error]`);
+            if (errorElements.length > 0) {
+                for (const errorElement of errorElements) {
+                    errorElement.classList.add('hidden');
+                    if(this.hasAttribute('std-err')) {
+                        this.errorElement.hidden = true;
+                        this.errorElement.style.removeProperty('display');
+                    }
+                }
+                removeClasses(this.errorElement, ['bg-red-200', 'p-2']);
+            }
+
             this.postEvaluate();
         } catch (err) {
             if (Element === undefined) {
@@ -146,6 +159,8 @@ export class BaseEvalElement extends HTMLElement {
 
             addClasses(this.errorElement, ['bg-red-200', 'p-2']);
             out.write.callKwargs(err, { append: true });
+
+            this.errorElement.children[this.errorElement.children.length - 1].setAttribute('error', '')
             this.errorElement.hidden = false;
             this.errorElement.style.display = 'block';
         }

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -171,16 +171,16 @@ export class PyRepl extends BaseEvalElement {
         this.outputElement.style.display = 'block';
 
         if (this.hasAttribute('auto-generate')) {
-            const allPyRepls = document.querySelectorAll('py-repl[exec-id]');
+            const allPyRepls = document.querySelectorAll(`py-repl[root='${this.getAttribute('root')}'][exec-id]`);
             const lastRepl = allPyRepls[allPyRepls.length -1 ];
             const lastExecId = lastRepl.getAttribute('exec-id');
             const nextExecId = parseInt(lastExecId) + 1;
             
             const newPyRepl = document.createElement('py-repl');
-
             newPyRepl.setAttribute('root', this.getAttribute('root'));
             newPyRepl.id = this.getAttribute('root') + '-' + nextExecId.toString();
-            newPyRepl.removeAttribute('auto-generate')
+            newPyRepl.setAttribute('auto-generate', '');
+            this.removeAttribute('auto-generate');
 
             if (this.hasAttribute('output')) {
                 newPyRepl.setAttribute('output', this.getAttribute('output'));

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -101,7 +101,7 @@ export class PyRepl extends BaseEvalElement {
         this.btnRun = document.createElement('button');
         this.btnRun.innerHTML =
             '<svg id="" class="svelte-fa svelte-ps5qeg" style="height:20px;width:20px;vertical-align:-.125em;transform-origin:center;overflow:visible;color:green" viewBox="0 0 384 512" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg"><g transform="translate(192 256)" transform-origin="96 0"><g transform="translate(0,0) scale(1,1)"><path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" fill="currentColor" transform="translate(-192 -256)"></path></g></g></svg>';
-        addClasses(this.btnRun, ['absolute', 'right-1', 'bottom-0', 'top-0', 'opacity-0', 'group-hover:opacity-100']);
+        addClasses(this.btnRun, ['absolute', 'right-1', 'bottom-1', 'opacity-0', 'group-hover:opacity-100']);
         this.editorNode.appendChild(this.btnRun);
 
         this.btnRun.onclick = wrap(this);

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -101,7 +101,7 @@ export class PyRepl extends BaseEvalElement {
         this.btnRun = document.createElement('button');
         this.btnRun.innerHTML =
             '<svg id="" class="svelte-fa svelte-ps5qeg" style="height:20px;width:20px;vertical-align:-.125em;transform-origin:center;overflow:visible;color:green" viewBox="0 0 384 512" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg"><g transform="translate(192 256)" transform-origin="96 0"><g transform="translate(0,0) scale(1,1)"><path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" fill="currentColor" transform="translate(-192 -256)"></path></g></g></svg>';
-        addClasses(this.btnRun, ['absolute', 'right-1', 'bottom-3', 'opacity-0', 'group-hover:opacity-100']);
+        addClasses(this.btnRun, ['absolute', 'right-1', 'bottom-0', 'top-0', 'opacity-0', 'group-hover:opacity-100']);
         this.editorNode.appendChild(this.btnRun);
 
         this.btnRun.onclick = wrap(this);

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -171,12 +171,16 @@ export class PyRepl extends BaseEvalElement {
         this.outputElement.style.display = 'block';
 
         if (this.hasAttribute('auto-generate')) {
-            const nextExecId = parseInt(this.getAttribute('exec-id')) + 1;
+            const allPyRepls = document.querySelectorAll('py-repl[exec-id]');
+            const lastRepl = allPyRepls[allPyRepls.length -1 ];
+            const lastExecId = lastRepl.getAttribute('exec-id');
+            const nextExecId = parseInt(lastExecId) + 1;
+            
             const newPyRepl = document.createElement('py-repl');
 
             newPyRepl.setAttribute('root', this.getAttribute('root'));
             newPyRepl.id = this.getAttribute('root') + '-' + nextExecId.toString();
-            newPyRepl.setAttribute('auto-generate', null);
+            newPyRepl.removeAttribute('auto-generate')
 
             if (this.hasAttribute('output')) {
                 newPyRepl.setAttribute('output', this.getAttribute('output'));

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -4,6 +4,12 @@ function addClasses(element: HTMLElement, classes: Array<string>) {
     }
 }
 
+function removeClasses(element: HTMLElement, classes: Array<string>) {
+    for (const entry of classes) {
+        element.classList.remove(entry);
+    }
+}
+
 function getLastPath(str: string): string {
     return str.split('\\').pop().split('/').pop();
 }
@@ -37,4 +43,4 @@ function guidGenerator(): string {
     return S4() + S4() + '-' + S4() + '-' + S4() + '-' + S4() + '-' + S4() + S4() + S4();
 }
 
-export { addClasses, getLastPath, ltrim, htmlDecode, guidGenerator };
+export { addClasses, removeClasses, getLastPath, ltrim, htmlDecode, guidGenerator };


### PR DESCRIPTION
Hey,

I think the play button in the REPL component was misaligned. My commit changes its position from

![1](https://user-images.githubusercontent.com/26199423/168421154-0f0d4a22-c452-4215-a824-1a8036862c19.PNG)

to

![2](https://user-images.githubusercontent.com/26199423/168421160-f5f9b885-fd71-41ef-a56b-8b024de172c0.PNG)

Was the initial alignment intended?

EDIT:
Fixed the auto-generate behavior to correctly remove the auto-generate attribute from generated children. Also added functionality to get the last exec-id and add to that, instead of the root elements exec-id.