### PR TITLE
Fixed the hello.html Hello World example.

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -34,7 +34,7 @@ open an HTML by double clicking it in your file explorer.
     <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
     <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
   </head>
-  <body> <py-script> print('Hello, World!') </py-script> </body>
+  <body> <py-script>print('Hello, World!')</py-script> </body>
 </html>
 ```
 


### PR DESCRIPTION
The example had a space after the <py-script> tag and before the print('Hello, World!') which was invalid in python and just produced a red bar (which presumably should have been followed by syntax error message)