### PR TITLE
fix autogenerated element

### DIFF
--- a/pyscriptjs/examples/todo.html
+++ b/pyscriptjs/examples/todo.html
@@ -18,7 +18,7 @@
 
   <body class="container">
     <!-- <py-repl id="my-repl" auto-generate="true"> </py-repl> -->
-  <py-script src="/todo.py">  </py-script>
+  <py-script src="./todo.py">  </py-script>
 
   <main class="max-w-xs mx-auto mt-4">
     <section>

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -84,7 +84,7 @@ export default {
       file: "examples/build/pyscript.min.js",
       format: "iife",
       sourcemap: true,
-      // plugins: [terser()],
+      plugins: [terser()],
     },
   ],
   plugins: [

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -54,7 +54,7 @@ export class BaseEvalElement extends HTMLElement {
     }
 
     checkId() {
-        if (!this.id) this.id = this.constructor.name + '-' + guidGenerator();
+        if (!this.id) this.id = 'py-' + guidGenerator();
     }
 
     getSourceFromElement(): string {


### PR DESCRIPTION
#395 was a temporary fix but this should be the real fix that closes #370 and other issues reporting errors with `querySelector` selecting elements starting with a `-[1-9]` value. This fixes the underlying issue. 

We were using this.constructor.name that doesn't seem to work well with the current config of `terser`. Independently of that, the goal here was to generate a meaningful unique id. We can do that with just the static string (at least I can't come up with really strong reasons for having the id to change based on the class name, besides personal taste for semantics).