### PR TITLE
add components description in getting started

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -211,14 +211,16 @@ fig
 
 The `<py-repl>` tag creates a REPL component that is rendered to the page as a code editor, allowing you to write executable code inline.
 
+
 ## Visual components
 
-The following tags control visual attributes of your HTML page.
+The following tags can be used to add visual attributes of your HTML page.
 
 | Tag             | Description |
 | ---             | ----------- |
-| `<py-inputbox>` | TBD         |
-| `<py-box>`      | TBD         |
-| `<py-button>`   | TBD         |
-| `<py-list>`     | TBD         |
-| `<py-title>`    | TBD         |
+| `<py-inputbox>` | Adds an input box that can be used to prompt users to enter input values |
+| `<py-box>`      | Create a container object that can be used to host one or more visual components, allowing to define how elements of `<py-box>` should align and show on the page. |
+| `<py-button>`   | Adds a button allowing authors to add a label as well as event handlers for actions on the button, such as `on_focus` or `on_click`. |
+| `<py-title>`    | Adds a static text title component that will style the text inside the tag as a page title |
+
+NOTE: All the elements above are experimental and not implemented at their full functionality. Use them with the understanding that the APIs or full support might change or be removed until the visual components are more mature.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -213,7 +213,9 @@ The `<py-repl>` tag creates a REPL component that is rendered to the page as a c
 
 ## The py-config tag
 
-The `<py-config>` tag can be used to set and configure general metadata about your PyScript application. It's an optional tag that allows configuration in yaml format (if you are new to YAML, you may want to consider [this read](https://www.redhat.com/sysadmin/yaml-beginners) for more information about it) and can be used as follows:
+Use the `<py-config>` tag to set and configure general metadata about your PyScript application in YAML format. If you are unfamiliar with YAML, consider reading [Red Hat's YAML for beginners](https://www.redhat.com/sysadmin/yaml-beginners) guide for more information.  
+
+The `<py-config>` tag can be used as follows:
 
 ```
 <py-config>
@@ -226,25 +228,27 @@ The `<py-config>` tag can be used to set and configure general metadata about yo
 </py-config>
 ```
 
-The values supported by `<py-config>` are (all values are optional):
+The following values are supported by `<py-config>` (all values are optional):
 
-  * autoclose_loader (boolean): if false, PyScript will not close the loading splash screen when the startup operations are finished
-  * name (string): name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
-  * version (string): version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
-  * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expect the following fields:
-    * src (string): url to the runtime source.
-    * name (string), Optional: name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
-    * name (string), Optional: programming language supported by the runtime. This field can by used by the application author for better clarify and currently has no implications on how PyScript behave
+  * autoclose_loader (boolean): If false, PyScript will not close the loading splash screen when the startup operations finish.
+  * name (string): Name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
+  * version (string): Version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
+  * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
+    * src (string): URL to the runtime source.
+    * name (string), Optional: Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
+    * name (string), Optional: Programming language supported by the runtime. This field can by used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
 
-## Visual components
+## Visual component tags
 
-The following tags can be used to add visual attributes of your HTML page.
+The following tags can be used to add visual attributes to your HTML page.
 
 | Tag             | Description |
 | ---             | ----------- |
 | `<py-inputbox>` | Adds an input box that can be used to prompt users to enter input values |
-| `<py-box>`      | Create a container object that can be used to host one or more visual components, allowing to define how elements of `<py-box>` should align and show on the page. |
-| `<py-button>`   | Adds a button allowing authors to add a label as well as event handlers for actions on the button, such as `on_focus` or `on_click`. |
-| `<py-title>`    | Adds a static text title component that will style the text inside the tag as a page title |
+| `<py-box>`      | Creates a container object that can be used to host one or more visual components that define how elements of `<py-box>` should align and show on the page. |
+| `<py-button>`   | Adds a button to which authors can add labels and event handlers for actions on the button, such as `on_focus` or `on_click`. |
+| `<py-title>`    | Adds a static text title component that styles the text inside the tag as a page title |
 
-NOTE: All the elements above are experimental and not implemented at their full functionality. Use them with the understanding that the APIs or full support might change or be removed until the visual components are more mature.
+```{note}
+All the elements above are experimental and not implemented at their full functionality. Use them with the understanding that the APIs or full support might change or be removed until the visual components are more mature.
+```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -228,15 +228,15 @@ The `<py-config>` tag can be used as follows:
 </py-config>
 ```
 
-The following values are supported by `<py-config>` (all values are optional):
+The following optional values are supported by `<py-config>`:
 
   * autoclose_loader (boolean): If false, PyScript will not close the loading splash screen when the startup operations finish.
   * name (string): Name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
   * version (string): Version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
   * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
-    * src (string): URL to the runtime source.
-    * name (string), Optional: Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
-    * name (string), Optional: Programming language supported by the runtime. This field can by used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
+    * src (string, Required): URL to the runtime source.
+    * name (string): Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
+    * name (string): Programming language supported by the runtime. This field can by used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
 
 ## Visual component tags
 
@@ -244,10 +244,10 @@ The following tags can be used to add visual attributes to your HTML page.
 
 | Tag             | Description |
 | ---             | ----------- |
-| `<py-inputbox>` | Adds an input box that can be used to prompt users to enter input values |
+| `<py-inputbox>` | Adds an input box that can be used to prompt users to enter input values. |
 | `<py-box>`      | Creates a container object that can be used to host one or more visual components that define how elements of `<py-box>` should align and show on the page. |
 | `<py-button>`   | Adds a button to which authors can add labels and event handlers for actions on the button, such as `on_focus` or `on_click`. |
-| `<py-title>`    | Adds a static text title component that styles the text inside the tag as a page title |
+| `<py-title>`    | Adds a static text title component that styles the text inside the tag as a page title. |
 
 ```{note}
 All the elements above are experimental and not implemented at their full functionality. Use them with the understanding that the APIs or full support might change or be removed until the visual components are more mature.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -213,7 +213,7 @@ The `<py-repl>` tag creates a REPL component that is rendered to the page as a c
 
 ## The py-config tag
 
-Use the `<py-config>` tag to set and configure general metadata about your PyScript application in YAML format. If you are unfamiliar with YAML, consider reading [Red Hat's YAML for beginners](https://www.redhat.com/sysadmin/yaml-beginners) guide for more information.  
+Use the `<py-config>` tag to set and configure general metadata about your PyScript application in YAML format. If you are unfamiliar with YAML, consider reading [Red Hat's YAML for beginners](https://www.redhat.com/sysadmin/yaml-beginners) guide for more information.
 
 The `<py-config>` tag can be used as follows:
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -211,6 +211,30 @@ fig
 
 The `<py-repl>` tag creates a REPL component that is rendered to the page as a code editor, allowing you to write executable code inline.
 
+## The py-config tag
+
+The `<py-config>` tag can be used to set and configure general metadata about your PyScript application. It's an optional tag that allows configuration in yaml format (if you are new to YAML, you may want to consider [this read](https://www.redhat.com/sysadmin/yaml-beginners) for more information about it) and can be used as follows:
+
+```
+<py-config>
+  - autoclose_loader: false
+  - runtimes:
+    -
+      src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
+      name: pyodide-0.20
+      lang: python
+</py-config>
+```
+
+The values supported by `<py-config>` are (all values are optional):
+
+  * autoclose_loader (boolean): if false, PyScript will not close the loading splash screen when the startup operations are finished
+  * name (string): name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
+  * version (string): version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
+  * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expect the following fields:
+    * src (string): url to the runtime source.
+    * name (string), Optional: name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
+    * name (string), Optional: programming language supported by the runtime. This field can by used by the application author for better clarify and currently has no implications on how PyScript behave
 
 ## Visual components
 


### PR DESCRIPTION
Fixes #415 

@idanenglander I've also added `<py-config>`. Not sure if it belongs to getting-started to may be more somewhere "more advanced" but thought it'd be good to add the content and let you figure out the best placement. :)