### PR TITLE
[PROPOSAL] change/fix the output management

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -124,11 +124,6 @@ export class PyRepl extends BaseEvalElement {
 
         if (this.hasAttribute('output')) {
             this.errorElement = this.outputElement = document.getElementById(this.getAttribute('output'));
-
-            // in this case, the default output-mode is append, if hasn't been specified
-            if (!this.hasAttribute('output-mode')) {
-                this.setAttribute('output-mode', 'append');
-            }
         } else {
             if (this.hasAttribute('std-out')) {
                 this.outputElement = document.getElementById(this.getAttribute('std-out'));
@@ -162,6 +157,8 @@ export class PyRepl extends BaseEvalElement {
     }
 
     postEvaluate(): void {
+        this.setOutputMode();
+
         this.outputElement.hidden = false;
         this.outputElement.style.display = 'block';
 
@@ -175,6 +172,7 @@ export class PyRepl extends BaseEvalElement {
             newPyRepl.setAttribute('root', this.getAttribute('root'));
             newPyRepl.id = this.getAttribute('root') + '-' + nextExecId.toString();
             newPyRepl.setAttribute('auto-generate', '');
+            newPyRepl.setAttribute('output-mode', this.appendOutput ? 'append' : 'replace');
             this.removeAttribute('auto-generate');
 
             if (this.hasAttribute('output')) {
@@ -196,7 +194,7 @@ export class PyRepl extends BaseEvalElement {
 
     getSourceFromElement(): string {
         const sourceStrings = [
-            `output_manager.change("` + this.outputElement.id + `")`,
+            `output_manager.change("${this.outputElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
             ...this.editor.state.doc.toString().split('\n'),
         ];
         return sourceStrings.join('\n');

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -410,7 +410,7 @@ class OutputManager:
         self._err_manager.change(err, output_to_console, append)
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
-        self.append = append
+        self._append = append
 
     def revert(self):
         self._out_manager.revert()

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -126,6 +126,8 @@ class PyScript:
             script_element = document.createRange().createContextualFragment(html)
             element.appendChild(script_element)
         else:
+            if html == "\n":
+                return
             element.innerHTML = html
 
     @staticmethod
@@ -396,18 +398,18 @@ class OutputCtxManager:
 class OutputManager:
     def __init__(self, out=None, err=None, output_to_console=True, append=True):
         sys.stdout = self._out_manager = OutputCtxManager(
-            out, output_to_console, append
+            out, output_to_console, append=append
         )
         sys.stderr = self._err_manager = OutputCtxManager(
-            err, output_to_console, append
+            err, output_to_console, append=append
         )
         self.output_to_console = output_to_console
         self._append = append
 
     def change(self, out=None, err=None, output_to_console=True, append=True):
-        self._out_manager.change(out, output_to_console, append)
+        self._out_manager.change(out, output_to_console, append=append)
         sys.stdout = self._out_manager
-        self._err_manager.change(err, output_to_console, append)
+        self._err_manager.change(err, output_to_console, append=append)
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
         self._append = append


### PR DESCRIPTION
Hey,

I would like to propose some changes to how we append output to elements.
That is mainly useful for the REPL. Please look at the example below.

Current behavior (default):
![FIXAPPEND1](https://user-images.githubusercontent.com/26199423/169240301-7e29d45e-4438-4ce7-984a-37e6c401037b.gif)

PR behavior (default is still the same, this py-repl has `output-mode="replace"` attribute set):
![FIXAPPEND2](https://user-images.githubusercontent.com/26199423/169240494-f6aa1870-1b53-4945-8d8a-aa618f47ead6.gif)

This PR also removes the empty outputs after every output we write.
Feel free to pull this PR and test with other types of components. I tested it with py-script and py-repl.

Any feedback is highly welcome, thanks!

Kind regards
Mariano
