### PR TITLE
updated-README-files-Contributing-Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out the [pyscriptjs/examples](pyscriptjs/examples) folder for more example
 
 ## How to Contribute
 
-To contribute see the [CONTRIBUTING](CONTRIBUTING.md) document.
+Read the [contributing guide](CONTRIBUTING.md) to learn about our development process, reporting bugs and improvements, creating issues and asking questions.
 
 ## Resources
 


### PR DESCRIPTION
Made changes in How to Contribute section of the README file because earlier version doesn't specified much. And also changed to **Contributing Guide** instead of **Contributing document**.