### PR TITLE
[PROPOSAL] REPL output replacement

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -49,7 +49,7 @@ export class BaseEvalElement extends HTMLElement {
         this.outputElement.hidden = false;
     }
 
-    setOutputMode(defaultMode: string = "append") {
+    setOutputMode(defaultMode = "append") {
         const mode = this.hasAttribute('output-mode') ? this.getAttribute('output-mode') : defaultMode;
 
         switch (mode) {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -124,7 +124,7 @@ export class BaseEvalElement extends HTMLElement {
     async evaluate(): Promise<void> {
         console.log('evaluate');
         this.preEvaluate();
-    
+
         const pyodide = runtime;
         let source: string;
         let output;

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -41,12 +41,27 @@ export class BaseEvalElement extends HTMLElement {
         this.shadow = this.attachShadow({ mode: 'open' });
         this.wrapper = document.createElement('slot');
         this.shadow.appendChild(this.wrapper);
-        this.appendOutput = true;
+        this.setOutputMode("append");
     }
 
     addToOutput(s: string) {
         this.outputElement.innerHTML += '<div>' + s + '</div>';
         this.outputElement.hidden = false;
+    }
+
+    setOutputMode(defaultMode: string = "append") {
+        const mode = this.hasAttribute('output-mode') ? this.getAttribute('output-mode') : defaultMode;
+
+        switch (mode) {
+            case "append":
+                this.appendOutput = true;
+                break;
+            case "replace":
+                this.appendOutput = false;
+                break;
+            default:
+                console.log(`${this.id}: custom output-modes are currently not implemented`);
+        }
     }
 
     // subclasses should overwrite this method to define custom logic

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -32,6 +32,7 @@ export class BaseEvalElement extends HTMLElement {
     outputElement: HTMLElement;
     errorElement: HTMLElement;
     theme: string;
+    appendOutput: boolean;
 
     constructor() {
         super();
@@ -40,6 +41,7 @@ export class BaseEvalElement extends HTMLElement {
         this.shadow = this.attachShadow({ mode: 'open' });
         this.wrapper = document.createElement('slot');
         this.shadow.appendChild(this.wrapper);
+        this.appendOutput = true;
     }
 
     addToOutput(s: string) {
@@ -114,13 +116,13 @@ export class BaseEvalElement extends HTMLElement {
 
             if (source.includes('asyncio')) {
                 await pyodide.runPythonAsync(
-                    `output_manager.change("` + this.outputElement.id + `", "` + this.errorElement.id + `")`,
+                    `output_manager.change(out="${this.outputElement.id}", err="${this.errorElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
                 );
                 output = await pyodide.runPythonAsync(source);
                 await pyodide.runPythonAsync(`output_manager.revert()`);
             } else {
                 output = pyodide.runPython(
-                    `output_manager.change("` + this.outputElement.id + `", "` + this.errorElement.id + `")`,
+                    `output_manager.change(out="${this.outputElement.id}", err="${this.errorElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
                 );
                 output = pyodide.runPython(source);
                 pyodide.runPython(`output_manager.revert()`);
@@ -147,8 +149,8 @@ export class BaseEvalElement extends HTMLElement {
                         this.errorElement.style.removeProperty('display');
                     }
                 }
-                removeClasses(this.errorElement, ['bg-red-200', 'p-2']);
             }
+            removeClasses(this.errorElement, ['bg-red-200', 'p-2']);
 
             this.postEvaluate();
         } catch (err) {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -65,8 +65,14 @@ export class BaseEvalElement extends HTMLElement {
     }
 
     // subclasses should overwrite this method to define custom logic
+    // before code gets evaluated
+    preEvaluate(): void {
+        return null;
+    }
+
+    // subclasses should overwrite this method to define custom logic
     // after code has been evaluated
-    postEvaluate() {
+    postEvaluate(): void {
         return null;
     }
 
@@ -117,6 +123,8 @@ export class BaseEvalElement extends HTMLElement {
 
     async evaluate(): Promise<void> {
         console.log('evaluate');
+        this.preEvaluate();
+    
         const pyodide = runtime;
         let source: string;
         let output;

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -199,7 +199,7 @@ export class PyRepl extends BaseEvalElement {
                 newPyRepl.setAttribute('auto-generate', '');
                 this.removeAttribute('auto-generate');
             }
-            
+
             if(this.hasAttribute('output-append')) {
                 newPyRepl.setAttribute('output-append', '');
             }

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -219,14 +219,14 @@ export class PyRepl extends BaseEvalElement {
     }
 
     getSourceFromElement(): string {
+        if(!this.appendOutput) {
+            this.outputElement.innerHTML = '';
+        }
+        
         const sourceStrings = [
-            `output_manager.change(out="${this.outputElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
+            `output_manager.change(out="${this.outputElement.id}", append=True)`,
             ...this.editor.state.doc.toString().split('\n'),
         ];
-
-        if(!this.appendOutput) {
-            sourceStrings.splice(2, 0, `output_manager.change(out="${this.outputElement.id}", append=True)`);
-        }
 
         return sourceStrings.join('\n');
     }

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -61,11 +61,11 @@ export class PyRepl extends BaseEvalElement {
         this.editorNode = document.createElement('div');
         addClasses(this.editorNode, ['editor-box', 'border', 'border-gray-300', 'group', 'relative']);
         this.shadow.appendChild(this.wrapper);
-        this.setOutputMode("replace");
     }
 
     connectedCallback() {
         this.checkId();
+        this.setOutputMode("replace");
         this.code = this.innerHTML;
         this.innerHTML = '';
         const languageConf = new Compartment();

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -222,7 +222,7 @@ export class PyRepl extends BaseEvalElement {
         if(!this.appendOutput) {
             this.outputElement.innerHTML = '';
         }
-        
+
         const sourceStrings = [
             `output_manager.change(out="${this.outputElement.id}", append=True)`,
             ...this.editor.state.doc.toString().split('\n'),

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -143,13 +143,12 @@ export class PyRepl extends BaseEvalElement {
             this.setAttribute('root', this.id);
         }
 
+        if(!this.hasAttribute('output-append')) {
+            this.appendOutput = false;
+        }
+
         if (this.hasAttribute('output')) {
             this.errorElement = this.outputElement = document.getElementById(this.getAttribute('output'));
-
-            // in this case, the default output-mode is append, if hasn't been specified
-            if (!this.hasAttribute('output-mode')) {
-                this.setAttribute('output-mode', 'append');
-            }
         } else {
             if (this.hasAttribute('std-out')) {
                 this.outputElement = document.getElementById(this.getAttribute('std-out'));
@@ -195,8 +194,15 @@ export class PyRepl extends BaseEvalElement {
             const newPyRepl = document.createElement('py-repl');
             newPyRepl.setAttribute('root', this.getAttribute('root'));
             newPyRepl.id = this.getAttribute('root') + '-' + nextExecId.toString();
-            newPyRepl.setAttribute('auto-generate', '');
-            this.removeAttribute('auto-generate');
+
+            if(this.hasAttribute('auto-generate')) {
+                newPyRepl.setAttribute('auto-generate', '');
+                this.removeAttribute('auto-generate');
+            }
+            
+            if(this.hasAttribute('output-append')) {
+                newPyRepl.setAttribute('output-append', '');
+            }
 
             if (this.hasAttribute('output')) {
                 newPyRepl.setAttribute('output', this.getAttribute('output'));
@@ -216,10 +222,15 @@ export class PyRepl extends BaseEvalElement {
     }
 
     getSourceFromElement(): string {
-        const sourceStrings = [
-            `output_manager.change("` + this.outputElement.id + `")`,
+        let sourceStrings = [
+            `output_manager.change(out="${this.outputElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
             ...this.editor.state.doc.toString().split('\n'),
         ];
+
+        if(!this.appendOutput) {
+            sourceStrings.splice(2, 0, `output_manager.change(out="${this.outputElement.id}", append=True)`);
+        }
+
         return sourceStrings.join('\n');
     }
 

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -222,7 +222,7 @@ export class PyRepl extends BaseEvalElement {
     }
 
     getSourceFromElement(): string {
-        let sourceStrings = [
+        const sourceStrings = [
             `output_manager.change(out="${this.outputElement.id}", append=${this.appendOutput ? 'True' : 'False'})`,
             ...this.editor.state.doc.toString().split('\n'),
         ];

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -61,6 +61,7 @@ export class PyRepl extends BaseEvalElement {
         this.editorNode = document.createElement('div');
         addClasses(this.editorNode, ['editor-box', 'border', 'border-gray-300', 'group', 'relative']);
         this.shadow.appendChild(this.wrapper);
+        this.setOutputMode("replace");
     }
 
     connectedCallback() {
@@ -143,10 +144,6 @@ export class PyRepl extends BaseEvalElement {
             this.setAttribute('root', this.id);
         }
 
-        if(!this.hasAttribute('output-append')) {
-            this.appendOutput = false;
-        }
-
         if (this.hasAttribute('output')) {
             this.errorElement = this.outputElement = document.getElementById(this.getAttribute('output'));
         } else {
@@ -200,8 +197,8 @@ export class PyRepl extends BaseEvalElement {
                 this.removeAttribute('auto-generate');
             }
 
-            if(this.hasAttribute('output-append')) {
-                newPyRepl.setAttribute('output-append', '');
+            if(this.hasAttribute('output-mode')) {
+                newPyRepl.setAttribute('output-mode', this.getAttribute('output-mode'));
             }
 
             if (this.hasAttribute('output')) {

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -65,7 +65,6 @@ export class PyRepl extends BaseEvalElement {
 
     connectedCallback() {
         this.checkId();
-        this.setOutputMode("replace");
         this.code = this.innerHTML;
         this.innerHTML = '';
         const languageConf = new Compartment();
@@ -178,6 +177,13 @@ export class PyRepl extends BaseEvalElement {
         this.outputElement.hidden = false;
     }
 
+    preEvaluate(): void {
+        this.setOutputMode("replace");
+        if(!this.appendOutput) {
+            this.outputElement.innerHTML = '';
+        }
+    }
+
     postEvaluate(): void {
         this.outputElement.hidden = false;
         this.outputElement.style.display = 'block';
@@ -219,10 +225,6 @@ export class PyRepl extends BaseEvalElement {
     }
 
     getSourceFromElement(): string {
-        if(!this.appendOutput) {
-            this.outputElement.innerHTML = '';
-        }
-
         const sourceStrings = [
             `output_manager.change(out="${this.outputElement.id}", append=True)`,
             ...this.editor.state.doc.toString().split('\n'),

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -368,15 +368,17 @@ class PyListTemplate:
 
 
 class OutputCtxManager:
-    def __init__(self, out=None, output_to_console=True, append=True):
+    def __init__(self, out=None, err=None, output_to_console=True, append=True):
         self._out = out
+        self._err = err
         self._prev = out
         self.output_to_console = output_to_console
         self._append = append
 
     def change(self, out=None, err=None, output_to_console=True, append=True):
-        self._prev = self._out
+        self._prev = self._out or self._err
         self._out = out
+        self._err = err
         self.output_to_console = output_to_console
         self._append = append
         console.log("----> changed out to", self._out, self._append)
@@ -398,13 +400,11 @@ class OutputManager:
         sys.stdout = self._out_manager = OutputCtxManager(
             out=out, 
             output_to_console=output_to_console, 
-            append=append
-        )
+            append=append)
         sys.stderr = self._err_manager = OutputCtxManager(
             err=err,
             output_to_console=output_to_console,
-            append=append
-        )
+            append=append)
         self.output_to_console = output_to_console
         self._append = append
 
@@ -412,14 +412,12 @@ class OutputManager:
         self._out_manager.change(
             out=out, 
             output_to_console=output_to_console, 
-            append=append
-        )
+            append=append)
         sys.stdout = self._out_manager
         self._err_manager.change(
             err=err, 
             output_to_console=output_to_console, 
-            append=append
-        )
+            append=append)
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
         self._append = append

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -111,6 +111,18 @@ class PyScript:
     def run_until_complete(f):
         _ = loop.run_until_complete(f)
 
+    @staticmethod
+    def write(element_id, value, append=False, exec_id=0):
+        """Writes value to the element with id "element_id"""
+        Element(element_id).write(value=value, append=append)
+        console.warn(
+            dedent(
+                """PyScript Deprecation Warning: PyScript.write is
+        marked as deprecated and will be removed sometime soon. Please, use
+        Element(<id>).write instead."""
+            )
+        )
+
 
 class Element:
     def __init__(self, element_id, element=None):

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -390,7 +390,29 @@ class OutputCtxManager:
     def write(self, txt):
         console.log("writing to", self._out, txt, self._append)
         if self._out:
-            pyscript.write(self._out, txt, append=self._append)
+            out_element = document.querySelector(f"#{self._out}")
+            out_element_id = self._out
+
+            if not out_element:
+                return
+
+            if self._append:
+                child = document.createElement("div")
+                exec_id = out_element.childElementCount + 1
+                out_element_id = child.id = f"{self._out}-{exec_id}"
+                out_element.appendChild(child)
+            
+            out_element = document.querySelector(f"#{out_element_id}")
+            
+            html, mime_type = format_mime(txt)
+            if mime_type in ("application/javascript", "text/html"):
+                script_element = document.createRange().createContextualFragment(html)
+                out_element.appendChild(script_element)
+            else:
+                if html == "\n":
+                    return
+                out_element.innerHTML = html
+
         if self.output_to_console:
             console.log(self._out, txt)
 

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -410,7 +410,7 @@ class OutputManager:
         self._err_manager.change(err, output_to_console, append)
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
-        self.append = append
+        self._append = append
 
     def revert(self):
         self._out_manager.revert()

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -396,18 +396,30 @@ class OutputCtxManager:
 class OutputManager:
     def __init__(self, out=None, err=None, output_to_console=True, append=True):
         sys.stdout = self._out_manager = OutputCtxManager(
-            out, output_to_console, append
+            out=out, 
+            output_to_console=output_to_console, 
+            append=append
         )
         sys.stderr = self._err_manager = OutputCtxManager(
-            err, output_to_console, append
+            err=err,
+            output_to_console=output_to_console,
+            append=append
         )
         self.output_to_console = output_to_console
         self._append = append
 
     def change(self, out=None, err=None, output_to_console=True, append=True):
-        self._out_manager.change(out, output_to_console, append)
+        self._out_manager.change(
+            out=out, 
+            output_to_console=output_to_console, 
+            append=append
+        )
         sys.stdout = self._out_manager
-        self._err_manager.change(err, output_to_console, append)
+        self._err_manager.change(
+            err=err, 
+            output_to_console=output_to_console, 
+            append=append
+        )
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
         self._append = append

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -146,7 +146,7 @@ class Element:
             exec_id = self.element.childElementCount + 1
             out_element_id = child.id = f"{self.id}-{exec_id}"
             self.element.appendChild(child)
-        
+
         out_element = document.querySelector(f"#{out_element_id}")
 
         html, mime_type = format_mime(value)

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -401,9 +401,9 @@ class OutputCtxManager:
                 exec_id = out_element.childElementCount + 1
                 out_element_id = child.id = f"{self._out}-{exec_id}"
                 out_element.appendChild(child)
-            
+
             out_element = document.querySelector(f"#{out_element_id}")
-            
+
             html, mime_type = format_mime(txt)
             if mime_type in ("application/javascript", "text/html"):
                 script_element = document.createRange().createContextualFragment(html)
@@ -420,26 +420,22 @@ class OutputCtxManager:
 class OutputManager:
     def __init__(self, out=None, err=None, output_to_console=True, append=True):
         sys.stdout = self._out_manager = OutputCtxManager(
-            out=out, 
-            output_to_console=output_to_console, 
-            append=append)
+            out=out, output_to_console=output_to_console, append=append
+        )
         sys.stderr = self._err_manager = OutputCtxManager(
-            err=err,
-            output_to_console=output_to_console,
-            append=append)
+            err=err, output_to_console=output_to_console, append=append
+        )
         self.output_to_console = output_to_console
         self._append = append
 
     def change(self, out=None, err=None, output_to_console=True, append=True):
         self._out_manager.change(
-            out=out, 
-            output_to_console=output_to_console, 
-            append=append)
+            out=out, output_to_console=output_to_console, append=append
+        )
         sys.stdout = self._out_manager
         self._err_manager.change(
-            err=err, 
-            output_to_console=output_to_console, 
-            append=append)
+            err=err, output_to_console=output_to_console, append=append
+        )
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console
         self._append = append

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -418,7 +418,7 @@ class OutputManager:
         )
         sys.stdout = self._out_manager
         self._err_manager.change(
-            err=err, output_to_console=output_to_console, append=append
+            out=err, output_to_console=output_to_console, append=append
         )
         sys.stderr = self._err_manager
         self.output_to_console = output_to_console

--- a/pyscriptjs/src/pyscript.py
+++ b/pyscriptjs/src/pyscript.py
@@ -363,17 +363,15 @@ class PyListTemplate:
 
 
 class OutputCtxManager:
-    def __init__(self, out=None, err=None, output_to_console=True, append=True):
+    def __init__(self, out=None, output_to_console=True, append=True):
         self._out = out
-        self._err = err
         self._prev = out
         self.output_to_console = output_to_console
         self._append = append
 
-    def change(self, out=None, err=None, output_to_console=True, append=True):
-        self._prev = self._out or self._err
+    def change(self, out=None, output_to_console=True, append=True):
+        self._prev = self._out
         self._out = out
-        self._err = err
         self.output_to_console = output_to_console
         self._append = append
         console.log("----> changed out to", self._out, self._append)
@@ -397,7 +395,7 @@ class OutputManager:
             out=out, output_to_console=output_to_console, append=append
         )
         sys.stderr = self._err_manager = OutputCtxManager(
-            err=err, output_to_console=output_to_console, append=append
+            out=err, output_to_console=output_to_console, append=append
         )
         self.output_to_console = output_to_console
         self._append = append


### PR DESCRIPTION
Hey,

after working over my last PR, I now have a new proposal on handling output with py-repl.

Currently, the output gets stacked/appended to the output element. That does not seem like the expected behavior.
My PR proposes the `output-append` attribute to the REPL. The PR changes the default behavior of the REPL to replace its output with every execution. If `output-append` is set on the py-repl tag, the output is appended as before.

Here is a GIF of the new behavior:
![REPL](https://user-images.githubusercontent.com/26199423/169662849-a7813d88-0221-487b-857c-fd74521455ab.gif)

**Important note:** As the pyscript.py and base.ts files are modified for this to work, these changes need to be tested with other components/use cases.

Any feedback and discussion on how to do better are highly welcome, thanks!

Kind regards
Mariano