### PR TITLE
Bundle the Python files into the output file

### DIFF
--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "svelte-app",
-  "version": "1.0.0",
+  "name": "pyscript",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "svelte-app",
-      "version": "1.0.0",
+      "name": "pyscript",
+      "version": "0.0.1",
       "dependencies": {
         "@codemirror/basic-setup": "^0.19.1",
-        "@codemirror/lang-python": "^0.19.4",
+        "@codemirror/lang-python": "^0.19.5",
         "@codemirror/state": "^0.19.9",
         "@codemirror/theme-one-dark": "^0.19.1",
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
-        "codemirror": "^5.65.2",
+        "codemirror": "^5.65.3",
         "js-yaml": "^4.1.0",
         "sirv-cli": "^1.0.0",
         "svelte-fa": "^2.4.0",
@@ -22,28 +22,30 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
-        "@rollup/plugin-typescript": "^8.1.0",
+        "@rollup/plugin-typescript": "^8.3.2",
         "@tsconfig/svelte": "^1.0.0",
+        "@types/js-yaml": "^4.0.5",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
-        "autoprefixer": "^10.2.3",
+        "autoprefixer": "^10.4.7",
         "eslint": "^8.14.0",
         "eslint-plugin-svelte3": "^3.4.1",
-        "postcss": "^8.2.4",
+        "postcss": "^8.4.13",
         "prettier": "^2.6.2",
         "prettier-plugin-svelte": "^2.7.0",
-        "rollup": "^2.3.4",
+        "rollup": "^2.71.1",
         "rollup-plugin-css-only": "^3.1.0",
         "rollup-plugin-livereload": "^2.0.0",
         "rollup-plugin-serve": "^1.1.0",
+        "rollup-plugin-string": "^3.0.0",
         "rollup-plugin-svelte": "^7.0.0",
         "rollup-plugin-terser": "^7.0.0",
-        "svelte": "^3.0.0",
+        "svelte": "^3.48.0",
         "svelte-check": "^1.0.0",
-        "svelte-preprocess": "^4.6.3",
+        "svelte-preprocess": "^4.10.6",
         "tailwindcss": "^2.0.2",
-        "tslib": "^2.0.0",
-        "typescript": "^4.1.3"
+        "tslib": "^2.4.0",
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -196,9 +198,9 @@
       }
     },
     "node_modules/@codemirror/lang-python": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.4.tgz",
-      "integrity": "sha512-eSH1JXbf0D30y+f3nWy/+bTLAIV8RmcQbbVD8DsBxkxOHMVKcILgxFRHCovba8YEMtmq45I1DoWcNt1CeKnrYQ==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.5.tgz",
+      "integrity": "sha512-MQf7t0k6+i9KCzlFCI8EY+jjwyXLy5AwjmXsMyMCMbOw/97j70jFZYrs7Mm7RJakNE2rypWhnLGlyBTSYMqR5g==",
       "dependencies": {
         "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
@@ -490,9 +492,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.1.tgz",
-      "integrity": "sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.2.tgz",
+      "integrity": "sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -540,6 +542,12 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -902,9 +910,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
+      "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
       "dev": true,
       "funding": [
         {
@@ -917,8 +925,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
+        "browserslist": "^4.20.3",
+        "caniuse-lite": "^1.0.30001335",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -972,9 +980,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
       "dev": true,
       "funding": [
         {
@@ -987,10 +995,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
+        "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -1055,9 +1063,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001323",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz",
-      "integrity": "sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true,
       "funding": [
         {
@@ -1112,9 +1120,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.2.tgz",
-      "integrity": "sha512-SZM4Zq7XEC8Fhroqe3LxbEEX1zUPWH1wMr5zxiBuiUF64iYOUH/JI88v4tBag8MiBS8B8gRv8O1pPXGYXQ4ErA=="
+      "version": "5.65.4",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.4.tgz",
+      "integrity": "sha512-tytrSm5Rh52b6j36cbDXN+FHwHCl9aroY4BrDZB2NFFL3Wjfq9nuYVLFFhaOYOczKAg3JXTr8BuT8LcE5QY4Iw=="
     },
     "node_modules/color": {
       "version": "4.2.1",
@@ -1373,9 +1381,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.103",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "node_modules/error-ex": {
@@ -2430,9 +2438,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -2457,9 +2465,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -2612,9 +2620,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
       "funding": [
         {
@@ -2627,7 +2635,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -2943,9 +2951,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "2.74.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.74.1.tgz",
+      "integrity": "sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3005,6 +3013,15 @@
       "dependencies": {
         "mime": ">=2.4.6",
         "opener": "1"
+      }
+    },
+    "node_modules/rollup-plugin-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-string/-/rollup-plugin-string-3.0.0.tgz",
+      "integrity": "sha512-vqyzgn9QefAgeKi+Y4A7jETeIAU1zQmS6VotH6bzm/zmUQEnYkpIGRaOBPY41oiWYV4JyBoGAaBjYMYuv+6wVw==",
+      "dev": true,
+      "dependencies": {
+        "rollup-pluginutils": "^2.4.1"
       }
     },
     "node_modules/rollup-plugin-svelte": {
@@ -3355,9 +3372,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.46.6",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.6.tgz",
-      "integrity": "sha512-o9nNft/OzCz/9kJpmWa1S52GAM+huCjPIsNWydYmgei74ZWlOA9/hN9+Z12INdklghu31seEXZMRHhS1+8DETw==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
+      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
       "engines": {
         "node": ">= 8"
       }
@@ -3461,9 +3478,9 @@
       "integrity": "sha512-0bnbMGbsE1LUnlioDcf27tl2O8kjuXlTXMXzIxC7LoIOWmqn0D+zd539HfLiQbdLuOHGTaynwN9V+4ehhEu1Jw=="
     },
     "node_modules/svelte-preprocess": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.4.tgz",
-      "integrity": "sha512-fuwol0N4UoHsNQolLFbMqWivqcJ9N0vfWO9IuPAiX/5okfoGXURyJ6nECbuEIv0nU3M8Xe2I1ONNje2buk7l6A==",
+      "version": "4.10.6",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.6.tgz",
+      "integrity": "sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3765,9 +3782,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -3816,9 +3833,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4711,9 +4728,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001335",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-      "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true
     },
     "chalk": {
@@ -4744,9 +4761,9 @@
       }
     },
     "codemirror": {
-      "version": "5.65.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.3.tgz",
-      "integrity": "sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ=="
+      "version": "5.65.4",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.4.tgz",
+      "integrity": "sha512-tytrSm5Rh52b6j36cbDXN+FHwHCl9aroY4BrDZB2NFFL3Wjfq9nuYVLFFhaOYOczKAg3JXTr8BuT8LcE5QY4Iw=="
     },
     "color": {
       "version": "4.2.1",
@@ -4953,9 +4970,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.134",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
-      "integrity": "sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "error-ex": {
@@ -5904,12 +5921,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.3",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -6115,9 +6132,9 @@
       }
     },
     "rollup": {
-      "version": "2.71.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.71.1.tgz",
-      "integrity": "sha512-lMZk3XfUBGjrrZQpvPSoXcZSfKcJ2Bgn+Z0L1MoW2V8Wh7BVM+LOBJTPo16yul2MwL59cXedzW1ruq3rCjSRgw==",
+      "version": "2.74.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.74.1.tgz",
+      "integrity": "sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -6161,6 +6178,15 @@
       "requires": {
         "mime": ">=2.4.6",
         "opener": "1"
+      }
+    },
+    "rollup-plugin-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-string/-/rollup-plugin-string-3.0.0.tgz",
+      "integrity": "sha512-vqyzgn9QefAgeKi+Y4A7jETeIAU1zQmS6VotH6bzm/zmUQEnYkpIGRaOBPY41oiWYV4JyBoGAaBjYMYuv+6wVw==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.4.1"
       }
     },
     "rollup-plugin-svelte": {

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -31,6 +31,7 @@
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-serve": "^1.1.0",
+    "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
     "svelte": "^3.48.0",

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -9,68 +9,7 @@ import css from "rollup-plugin-css-only";
 import serve from "rollup-plugin-serve";
 import { string } from "rollup-plugin-string";
 
-import path from "path";
-import fs from "fs";
-
-function copyPythonFiles(from, to, overwrite = false) {
-	return {
-		name: 'copy-files',
-		generateBundle() {
-			const log = msg => console.log('\x1b[36m%s\x1b[0m', msg)
-			log(`copy files: ${from} → ${to}`)
-
-      // create folder if it doesn't exist
-      if (!fs.existsSync(to)){
-        log(`Destination folder ${to} doesn't exist. Creating...`)
-        fs.mkdirSync(to);
-      }
-
-			fs.readdirSync(from).forEach(file => {
-				const fromFile = `${from}/${file}`
-				const toFile = `${to}/${file}`
-        if (fromFile.endsWith(`.py`)){
-          log(`----> ${fromFile} → ${toFile}`)
-          if (fs.existsSync(toFile) && !overwrite){
-            log(`skipping ${fromFile} → ${toFile}`)
-            return
-          }else{
-            fs.copyFileSync(
-              path.resolve(fromFile),
-              path.resolve(toFile)
-            );
-          }
-        }
-			})
-		}
-	}
-}
-
 const production = !process.env.ROLLUP_WATCH || (process.env.NODE_ENV === "production");
-
-function serve_() {
-  let server;
-
-  function toExit() {
-    if (server) server.kill(0);
-  }
-
-  return {
-    writeBundle() {
-      if (server) return;
-      server = require("child_process").spawn(
-        "npm",
-        ["run", "start", "--", "--dev"],
-        {
-          stdio: ["ignore", "inherit", "inherit"],
-          shell: true,
-        }
-      );
-
-      process.on("SIGTERM", toExit);
-      process.on("exit", toExit);
-    },
-  };
-}
 
 export default {
   input: "src/main.ts",
@@ -114,8 +53,6 @@ export default {
       sourceMap: !production,
       inlineSources: !production,
     }),
-    // Copy all the python files from source to the build folder
-    copyPythonFiles("./src/", "./examples/build", true),
     !production && serve(),
     !production && livereload("public"),
     // production && terser(),

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -6,7 +6,8 @@ import { terser } from "rollup-plugin-terser";
 import sveltePreprocess from "svelte-preprocess";
 import typescript from "@rollup/plugin-typescript";
 import css from "rollup-plugin-css-only";
-import serve from 'rollup-plugin-serve';
+import serve from "rollup-plugin-serve";
+import { string } from "rollup-plugin-string";
 
 import path from "path";
 import fs from "fs";
@@ -100,6 +101,10 @@ export default {
       },
     }),
     css({ output: "pyscript.css" }),
+    // Bundle all the Python files into the output file
+    string({
+      include: "./src/**/*.py",
+    }),
     resolve({
       browser: true,
       dedupe: ["svelte"],

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -1,4 +1,7 @@
-import { getLastPath, handleFetchError } from './utils';
+import { getLastPath } from './utils';
+// eslint-disable-next-line
+// @ts-ignore
+import pyscript from './pyscript.py';
 
 let pyodideReadyPromise;
 let pyodide;
@@ -19,19 +22,7 @@ const loadInterpreter = async function (indexUrl: string): Promise<any> {
     await pyodide.loadPackage('micropip');
 
     console.log('loading pyscript...');
-
-    // let's get the full path of where PyScript is running from so we can load the pyscript.py
-    // file from the same location
-    const loadedScript: HTMLScriptElement = document.querySelector(`script[src$='pyscript.js'], script[src$='pyscript.min.js']`);
-    const scriptPath = loadedScript.src.substring(0, loadedScript.src.lastIndexOf('/'));
-    const pyScriptPath = `${scriptPath}/pyscript.py`;
-
-    try {
-        await pyodide.runPythonAsync(await (await fetch(pyScriptPath)).text());
-    } catch (e) {
-        //Should we still export full error contents to console?
-        handleFetchError(e, pyScriptPath);
-    }
+    await pyodide.runPythonAsync(pyscript);
 
     console.log('done setting up environment');
     return pyodide;


### PR DESCRIPTION
Hi,

This PR updates Rollup config to bundle the Python files into the output file. This makes that the interpreter can load the Python logic directly.

Links:

- https://github.com/pyscript/pyscript/pull/207
- https://github.com/TrySound/rollup-plugin-string