### PR TITLE
Change the metadata format

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -217,7 +217,7 @@ Use the `<py-config>` tag to set and configure general metadata about your PyScr
 
 The `<py-config>` tag can be used as follows:
 
-```
+```html
 <py-config>
   autoclose_loader: false
   runtimes:
@@ -229,13 +229,14 @@ The `<py-config>` tag can be used as follows:
 
 The following optional values are supported by `<py-config>`:
 
-  * autoclose_loader (boolean): If false, PyScript will not close the loading splash screen when the startup operations finish.
-  * name (string): Name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
-  * version (string): Version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
-  * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
-    * src (string, Required): URL to the runtime source.
-    * name (string): Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
-    * lang (string): Programming language supported by the runtime. This field can be used by the application author to provide clarification. It currently has no implications on how PyScript behaves.
+  * `autoclose_loader` (boolean): If false, PyScript will not close the loading splash screen when the startup operations finish.
+  * `name` (string): Name of the user application. This field can be any string and is to be used by the application author for their own customization purposes.
+  * `version` (string): Version of the user application. This field can be any string and is to be used by the application author for their own customization purposes. It is not related to the PyScript version.
+  * `runtimes` (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
+    * `src` (string, Required): URL to the runtime source.
+    * `name` (string): Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
+    * `lang` (string): Programming language supported by the runtime. This field can be used by the application author to provide clarification. It currently has no implications on how PyScript behaves.
+
 
 ## Visual component tags
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -219,10 +219,9 @@ The `<py-config>` tag can be used as follows:
 
 ```
 <py-config>
-  - autoclose_loader: false
-  - runtimes:
-    -
-      src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
+  autoclose_loader: false
+  runtimes:
+    - src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
       name: pyodide-0.20
       lang: python
 </py-config>

--- a/examples/simple_clock.html
+++ b/examples/simple_clock.html
@@ -15,10 +15,9 @@
       - ./utils.py
     </py-env>
     <py-config>
-      - autoclose_loader: false
-      - runtimes:
-        -
-          src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
+      autoclose_loader: false
+      runtimes:
+        - src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
           name: pyodide-0.20
           lang: python
     </py-config>

--- a/examples/simple_clock.html
+++ b/examples/simple_clock.html
@@ -7,9 +7,9 @@
     <title>Simple Clock Demo</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
+    <link rel="stylesheet" href="./build/pyscript.css" />
 
-    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
+    <script defer src="./build/pyscript.js"></script>
     <py-env>
     - paths:
       - ./utils.py

--- a/pyscriptjs/src/components/pyconfig.ts
+++ b/pyscriptjs/src/components/pyconfig.ts
@@ -159,7 +159,9 @@ export class PyConfig extends BaseEvalElement {
                 autoclose_loader: true,
             };
         } else {
-            this.values = Object.assign({}, ...loadedValues);
+            // eslint-disable-next-line
+            // @ts-ignore
+            this.values = loadedValues;
         }
         if (this.values.runtimes === undefined) {
             this.values.runtimes = [DEFAULT_RUNTIME];


### PR DESCRIPTION
Hi,

This PR changes the metadata format written in `<py-config>` tag.

The current metadata format is like this:

```yaml
# from https://github.com/pyscript/pyscript/blob/48e6b1a84efb0d41609258b0c2b5b525ca571719/docs/tutorials/getting-started.md#the-py-config-tag
- autoclose_loader: false
- runtimes:
  -
    src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
    name: pyodide-0.20
    lang: python
```

Representing it as JSON is like this:

```json
[
  {
    "autoclose_loader": false
  },
  {
    "runtimes": [
      {
        "src": "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js",
        "name": "pyodide-0.20",
        "lang": "python"
      }
    ]
  }
]
```

I think this should be like this:

```yaml
autoclose_loader: false
runtimes:
  - src: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js"
    name: pyodide-0.20
    lang: python
```

Representing it as JSON is like this:

```json
{
  "autoclose_loader": false,
  "runtimes": [
    {
      "src": "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js",
      "name": "pyodide-0.20",
      "lang": "python"
    }
  ]
}
```
