### PR TITLE
[PROPOSAL] py-upload component

### DIFF
--- a/pyscriptjs/examples/upload.html
+++ b/pyscriptjs/examples/upload.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <title>PyScript Upload Demo</title>
+
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="stylesheet" href="./build/pyscript.css" />
+
+    <script defer src="./build/pyscript.js"></script>
+    <style>
+      .lds-dual-ring {
+        display: inline-block;
+        width: 30px;
+        height: 30px;
+      }
+      .lds-dual-ring:after {
+        content: " ";
+        display: block;
+        width: 30px;
+        height: 30px;
+        margin-top: 8px;
+        border-radius: 50%;
+        border: 3px solid #000;
+        border-color: #000 transparent #000 transparent;
+        animation: lds-dual-ring 1.2s linear infinite;
+      }
+      @keyframes lds-dual-ring {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <py-script>
+      def log_files(*args, **kwargs):
+        files = args[0].detail
+        for file in files:
+          with open(f"/{file}", "rb") as f:
+            print(f.read().decode('ascii'))
+    </py-script>
+    <py-upload pys-onUpload="log_files" multiple></py-upload>
+  </body>
+</html>

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -130,7 +130,8 @@ export class PyScript extends BaseEvalElement {
 /** Defines all possible pys-on* and their corresponding event types  */
 const pysAttributeToEvent: Map<string, string> = new Map<string, string>([
         ["pys-onClick", "click"],
-        ["pys-onKeyDown", "keydown"]
+        ["pys-onKeyDown", "keydown"],
+        ["pys-onUpload", "upload"]
 ]);
 
 /** Initialize all elements with pys-on* handlers attributes  */

--- a/pyscriptjs/src/components/pyupload.ts
+++ b/pyscriptjs/src/components/pyupload.ts
@@ -19,7 +19,7 @@ export class PyUpload extends BaseEvalElement {
 
   connectedCallback() {
     this.checkId();
-    
+
     const uploadElement = document.createElement('input');
     uploadElement.id = this.id;
     uploadElement.type = 'file';
@@ -28,7 +28,7 @@ export class PyUpload extends BaseEvalElement {
     loaderElement.id = `${this.id}-loader`;
     loaderElement.classList.add('lds-dual-ring');
     loaderElement.style.display = 'none';
-    
+
     this.id = `${this.id}-container`;
     this.appendChild(loaderElement);
     this.appendChild(uploadElement);
@@ -45,14 +45,14 @@ export class PyUpload extends BaseEvalElement {
       const filePromises = Array.from(files).map((file) => {
         return new Promise((resolve, reject) => {
           const reader = new FileReader();
-      
+
           reader.onload = async (e) => {
             try {
               const fileURL = e.target.result;
-                
+
               const code = `
                 import asyncio
-      
+
                 from pyodide.http import pyfetch
 
                 response = await pyfetch("${fileURL}")
@@ -60,9 +60,9 @@ export class PyUpload extends BaseEvalElement {
                   with open("/${file.name}", "wb") as f:
                     f.write(await response.bytes())
               `;
-      
+
               this.code = code;
-      
+
               await this.evaluate();
               resolve(file.name);
             } catch(err) {
@@ -73,7 +73,7 @@ export class PyUpload extends BaseEvalElement {
           reader.onerror = (error) => {
             reject (error);
           };
-          
+
           reader.readAsDataURL(file);
         });
       });

--- a/pyscriptjs/src/components/pyupload.ts
+++ b/pyscriptjs/src/components/pyupload.ts
@@ -1,0 +1,94 @@
+import { BaseEvalElement } from "./base";
+import { pyodideLoaded } from '../stores';
+
+let pyodide;
+
+pyodideLoaded.subscribe(value => {
+    pyodide = value;
+});
+
+export class PyUpload extends BaseEvalElement {
+  constructor() {
+    super();
+  }
+
+  override async evaluate() {
+    await pyodide.runPythonAsync(this.code);
+    return true;
+  }
+
+  connectedCallback() {
+    this.checkId();
+    
+    const uploadElement = document.createElement('input');
+    uploadElement.id = this.id;
+    uploadElement.type = 'file';
+
+    const loaderElement = document.createElement('div');
+    loaderElement.id = `${this.id}-loader`;
+    loaderElement.classList.add('lds-dual-ring');
+    loaderElement.style.display = 'none';
+    
+    this.id = `${this.id}-container`;
+    this.appendChild(loaderElement);
+    this.appendChild(uploadElement);
+
+    if(this.hasAttribute('multiple')) {
+      uploadElement.setAttribute('multiple', '');
+    }
+
+    uploadElement.onchange = async () => {
+      const files = uploadElement.files;
+
+      loaderElement.style.display = 'inline-block';
+
+      const filePromises = Array.from(files).map((file) => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+      
+          reader.onload = async (e) => {
+            try {
+              const fileURL = e.target.result;
+                
+              const code = `
+                import asyncio
+      
+                from pyodide.http import pyfetch
+                response = await pyfetch("${fileURL}")
+                total_size_bytes = (int(${file.size}))
+                if response.status == 200:
+                  with open("/${file.name}", "wb") as f:
+                    f.write(await response.bytes())
+                file_manager.add_file("${file.name}")
+              `;
+      
+              this.code = code;
+      
+              await this.evaluate();
+              resolve(file.name);
+            } catch(err) {
+              reject(err);
+            }
+          };
+
+          reader.onprogress = (e) => {
+            console.log(e.total / e.loaded);
+          };
+
+          reader.onerror = (error) => {
+            reject (error);
+          };
+          
+          reader.readAsDataURL(file);
+        });
+      });
+
+      const fileNames = await Promise.all(filePromises);
+      
+      loaderElement.style.display = 'none';
+
+      const uploadEvent = new CustomEvent('upload', { detail: fileNames });
+      this.dispatchEvent(uploadEvent);
+    }
+  }
+}

--- a/pyscriptjs/src/components/pyupload.ts
+++ b/pyscriptjs/src/components/pyupload.ts
@@ -54,12 +54,11 @@ export class PyUpload extends BaseEvalElement {
                 import asyncio
       
                 from pyodide.http import pyfetch
+
                 response = await pyfetch("${fileURL}")
-                total_size_bytes = (int(${file.size}))
                 if response.status == 200:
                   with open("/${file.name}", "wb") as f:
                     f.write(await response.bytes())
-                file_manager.add_file("${file.name}")
               `;
       
               this.code = code;
@@ -71,10 +70,6 @@ export class PyUpload extends BaseEvalElement {
             }
           };
 
-          reader.onprogress = (e) => {
-            console.log(e.total / e.loaded);
-          };
-
           reader.onerror = (error) => {
             reject (error);
           };
@@ -84,7 +79,7 @@ export class PyUpload extends BaseEvalElement {
       });
 
       const fileNames = await Promise.all(filePromises);
-      
+
       loaderElement.style.display = 'none';
 
       const uploadEvent = new CustomEvent('upload', { detail: fileNames });

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -11,6 +11,7 @@ import { PyWidget } from './components/base';
 import { PyLoader } from './components/pyloader';
 import { globalLoader } from './stores';
 import { PyConfig } from './components/pyconfig';
+import { PyUpload } from './components/pyupload';
 
 const xPyScript = customElements.define('py-script', PyScript);
 const xPyRepl = customElements.define('py-repl', PyRepl);
@@ -22,6 +23,7 @@ const xPyInputBox = customElements.define('py-inputbox', PyInputBox);
 const xPyWidget = customElements.define('py-register-widget', PyWidget);
 const xPyLoader = customElements.define('py-loader', PyLoader);
 const xPyConfig = customElements.define('py-config', PyConfig);
+const xPyUpload = customElements.define('py-upload', PyUpload);
 
 // As first thing, loop for application configs
 const config: PyConfig = document.querySelector('py-config');


### PR DESCRIPTION
Hey,

this is a draft PR for a basic `py-upload` component, as I think it could be useful for pyscript.
I am unsure if this would be accepted by users, as it has some restrictions. But I guess it could be a starting point.

This solution uses pyodide for writing and reading the files via MEMFS. There are pure JS alternatives if that is preferred.

How `py-upload` works (demo below):
- uses default HTML input with type file (using js)
- creates a file URL via `FileReader.readAsDataURL()` (using js)
- fetches the file(s) from the created file URL (using pyodide)
- writes the file(s) to the MEMFS (using pyodide)
- calls `pys-onUpload` with a CustomEvent('upload'), which passes the file name(s) (using js)
- in the callback, we can read those file(s) from the MEMFS with the passed file name(s) (using pyodide)

Restrictions:
- **blocking input/thread** - this may be a reason to trash the idea (could be because of writing to the MEMFS?)
  - tested with a 10MB file (takes ~5-6 seconds for me)
  - tested with a 100MB file (takes ~50 seconds for me)
- impossible to add a progress bar as of now, as `pyfetch` does not allow for streaming, at least not to my knowledge

There would still be a lot of work, even if those restrictions won't make it useless. I have some written down, but before implementing them I want to discuss if this is an option.

Kind regards
Mariano

![PYUPLOAD](https://user-images.githubusercontent.com/26199423/170298906-a6b6553d-c45a-421c-8f11-13c92133a068.gif)