### PR TITLE
Fixed typo in getting-started.md

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -236,7 +236,7 @@ The following optional values are supported by `<py-config>`:
   * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
     * src (string, Required): URL to the runtime source.
     * name (string): Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
-    * lang (string): Programming language supported by the runtime. This field can be used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
+    * lang (string): Programming language supported by the runtime. This field can be used by the application author to provide clarification. It currently has no implications on how PyScript behaves.
 
 ## Visual component tags
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -236,7 +236,7 @@ The following optional values are supported by `<py-config>`:
   * runtimes (List of Runtimes): List of runtime configurations. Each Runtime expects the following fields:
     * src (string, Required): URL to the runtime source.
     * name (string): Name of the runtime. This field can be any string and is to be used by the application author for their own customization purposes.
-    * name (string): Programming language supported by the runtime. This field can be used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
+    * lang (string): Programming language supported by the runtime. This field can be used by the application author to provide clarify. It currently has no implications on how PyScript behaves.
 
 ## Visual component tags
 


### PR DESCRIPTION
Hi maintainers!

I went through the Getting Started doc and found a little typo there. In the  **py-config tag** section, the  **lang** field in the runtime value was listed as **name**. I found this as a typo and decided to send a PR to fix this. I hope it gets merged; thanks :) 
I would love the feedback of the maintainers on this; cheers!