### PR TITLE
fix: < and > are parsed with HTML escape symbols

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -6,7 +6,7 @@ import { defaultKeymap } from '@codemirror/commands';
 import { oneDarkTheme } from '@codemirror/theme-one-dark';
 
 import { componentDetailsNavOpen, loadedEnvironments, mode, pyodideLoaded } from '../stores';
-import { addClasses } from '../utils';
+import { addClasses, htmlDecode } from '../utils';
 import { BaseEvalElement } from './base';
 
 // Premise used to connect to the first available pyodide interpreter
@@ -61,7 +61,7 @@ export class PyRepl extends BaseEvalElement {
 
     connectedCallback() {
         this.checkId();
-        this.code = this.innerHTML;
+        this.code = htmlDecode(this.innerHTML);
         this.innerHTML = '';
         const languageConf = new Compartment();
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -40,7 +40,7 @@ export class PyScript extends BaseEvalElement {
 
     connectedCallback() {
         this.checkId();
-        this.code = this.innerHTML;
+        this.code = htmlDecode(this.innerHTML);
         this.innerHTML = '';
 
         const mainDiv = document.createElement('div');


### PR DESCRIPTION
Reads in code for `<py-repl>` and `<py-script>` and replaces `&lt;` and `&gt;` by `<` and `>`.

Fix bug #480