### PR TITLE
Namespaces Support

### DIFF
--- a/examples/namespaces.html
+++ b/examples/namespaces.html
@@ -14,7 +14,7 @@
   </head>
 
   <body>
-    <p>The following examples demonstrate using the 'pys-namespace' attribute to set which namespace Pyscript blocks execute within.</p>
+    <p>The following examples demonstrate using the 'namespace' attribute to set which namespace Pyscript blocks execute within.</p>
     <p>The first block of code should run without errors. <b>The second, third, and fourth code blocks with have errors.</b> This is intentional, to demonstrate the variables that are and aren't available within individual namespaces.</p>
     <div class="grid grid-cols-1 space-y-6">
         <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-blue-100 ">
@@ -41,7 +41,7 @@ print(f"{math.prod([x,y,z]) = }")
         </div>
 
         <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-yellow-100 ">
-            <pre>&lt;py-script pys-namespace = 'ns-one'&gt;
+            <pre>&lt;py-script namespace = 'ns-one'&gt;
 print(f"This is executing in a custom namespace called 'ns-one'")
 print("with python version" + str(sys.version.split(" ")[0]))
 
@@ -49,7 +49,7 @@ x, y = 4, 5
 #The math module has not be imported in this namespace, so we get a NameError
 print(f"{math.prod([x,y]) = }")
 &lt;/py-script&gt;</pre>
-          <py-script pys-namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
+          <py-script namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
         import traceback
         print(f"This is executing in a custom namespace called 'ns-one'")
         print("with python version" + str(sys.version.split(" ")[0]))
@@ -59,7 +59,7 @@ print(f"{math.prod([x,y]) = }")
           </py-script>
         </div>
         <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-green-100 ">
-            <pre>&lt;py-script pys-namespace = 'ns-two'&gt;
+            <pre>&lt;py-script namespace = 'ns-two'&gt;
 print("This is executing in a custom namespace called 'ns-two'")
 print(f"with python version {str(sys.version.split(" ")[0])}")
 
@@ -69,7 +69,7 @@ print(f"{x=}")
 # y is not defined in this namespace so we will get a nameerror
 print(f"{y=}")
 &lt;/py-script&gt;</pre>
-          <py-script pys-namespace="ns-two"class="p-2 bg-gray-200 border-4 border-gray-400">
+          <py-script namespace="ns-two"class="p-2 bg-gray-200 border-4 border-gray-400">
         import traceback
         print("This is executing in a custom namespace called 'ns-two'")
         print("with python version" + str(sys.version.split(" ")[0]))
@@ -80,7 +80,7 @@ print(f"{y=}")
                 </py-script>
                 </div>
           <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-yellow-100 ">
-              <pre>&lt;py-script pys-namespace = 'ns-one'&gt;
+              <pre>&lt;py-script namespace = 'ns-one'&gt;
 print(f"This is executing in a custom namespace called 'ns-one'")
 print("with python version" + str(sys.version.split(" ")[0]))
 
@@ -91,7 +91,7 @@ print(f"{y=}")
 # however, z is not defined in this namespace, so we get a nameerror
 print(f"{z=}")
 &lt;/py-script&gt;</pre>
-            <py-script pys-namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
+            <py-script namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
         print(f"This is executing in a custom namespace called 'ns-one'")
         print("with python version" + str(sys.version.split(" ")[0]))
         print(f"{x=}")

--- a/examples/namespaces.html
+++ b/examples/namespaces.html
@@ -99,6 +99,20 @@ print(f"{z=}")
         print(f"{z=}")
            </py-script>
           </div>
+          <div>
+            <h1 class="text-2xl font-semibold">REPLs</h1>
+            <p>These two REPLs are in separate namespaces, "repl-1" and "repl-2". They are in different namespaces than the above code examples. Try assigning and reading variables to see that their namespaces keep them separate.</p>
+            <p>All auto-generated REPLs inherit their namespace from the REPL that created them.</p>
+            <div class="grid grid-cols-2 gap-2 p-2 space-x-4 divide-x-2">
+              <div class="pb-2 bg-red-200">
+                <py-repl namespace="repl-1" auto-generate="true"></py-repl>
+              </div>
+              <div class="pb-2 bg-purple-200">
+                <py-repl namespace="repl-2" auto-generate="true"></py-repl>
+              </div>
+            </div>
+          </div>
+          <div>
         </div>
     </div>
   </body>

--- a/examples/namespaces.html
+++ b/examples/namespaces.html
@@ -13,7 +13,8 @@
     <style>pre {overflow-x: auto;}</style>
   </head>
 
-  <body>
+  <body class="ml-5">
+    <h1 class="text-2xl font-semibold">Custom Namespaces</h1>
     <p>The following examples demonstrate using the 'namespace' attribute to set which namespace Pyscript blocks execute within.</p>
     <p>The first block of code should run without errors. <b>The second, third, and fourth code blocks with have errors.</b> This is intentional, to demonstrate the variables that are and aren't available within individual namespaces.</p>
     <div class="grid grid-cols-1 space-y-6">
@@ -113,6 +114,51 @@ print(f"{z=}")
             </div>
           </div>
           <div>
+            <h1 class="text-2xl font-semibold">Other Components</h1>
+            <p>Py-buttons, py-inputbox, and other Pyscript tags can also make use of the 'namespace' attribute.</p>
+            <p>Both of the buttons below set the text in this box to the value of the variable <code>x</code>. However, <code>x</code> is different in each of their namespaces</p>
+            <div class="flex flex-row space-x-2">
+              <div class="w-16 h-6 border-2 border-gray-500"><label id="button-output" class=""></label></div>
+              <span class="italic"><code>&lt;label id="button-output&gt;</code></span>
+            </div>
+            <div class="grid grid-cols-2 gap-2 p-2 space-x-4 divide-x-2">
+              <div class="bg-yellow-400">
+                <pre class="mb-4">
+&lt;py-script namespace="button-1"&gt;
+x = 1
+&lt;/py-script&gt;
+&lt;py-button namespace="button-1 label="Set Label to 1"&gt;
+def on_click(event):
+  from js import document
+  document.getElementById("button-output").innerText = str(x)
+&lt;/py-button&gt;</pre>
+                <py-script namespace="button-1">x = 1</py-script>
+                <py-button namespace="button-1" label="Set Label to 1">
+                  def on_click(event):
+                    from js import document
+                    document.getElementById("button-output").innerText = str(x)
+                </py-button>
+              </div>
+              <div class="bg-gray-300">
+<pre class="mb-4">
+&lt;py-script namespace="button-2"&gt;
+x = 2
+&lt;/py-script&gt;
+&lt;py-button namespace="button-2" label="Set Label to 2"&gt;
+def on_click(event):
+  from js import document
+  document.getElementById("button-output").innerText = str(x)
+&lt;/py-button&gt;
+</pre>
+                <py-script namespace="button-2">x = 2</py-script>
+                <py-button namespace="button-2" label="Set Label to 2">
+                  def on_click(event):
+                    from js import document
+                    document.getElementById("button-output").innerText = str(x)
+                </py-button>
+              </div>
+            </div>
+          </div>
         </div>
     </div>
   </body>

--- a/examples/namespaces.html
+++ b/examples/namespaces.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <title>PyScript Namespaces Example</title>
+
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="stylesheet" href="/pyscriptjs/examples/build/pyscript.css" />
+
+    <script defer src="/pyscriptjs/examples/build/pyscript.js"></script>
+    <style>pre {overflow-x: auto;}</style>
+  </head>
+
+  <body>
+    <p>The following examples demonstrate using the 'pys-namespace' attribute to set which namespace Pyscript blocks execute within.</p>
+    <p>The first block of code should run without errors. <b>The second, third, and fourth code blocks with have errors.</b> This is intentional, to demonstrate the variables that are and aren't available within individual namespaces.</p>
+    <div class="grid grid-cols-1 space-y-6">
+        <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-blue-100 ">
+            <pre>&lt;py-script&gt;
+import math
+print(f"This is executing in the default scope")
+print("with python version" + str(sys.version.split(" ")[0]))
+x, y, z = 1, 2, 3
+print(f"{x=}")
+print(f"{y=}")
+print(f"{z=}")
+print(f"{math.prod([x,y,z]) = }")
+&lt;/py-script&gt;</pre>
+          <py-script class="p-2 bg-gray-200 border-4 border-gray-400">
+            import math
+            print(f"This is executing in the default scope")
+            print("with python version" + str(sys.version.split(" ")[0]))
+            x, y, z = 1, 2, 3
+            print(f"{x=}")
+            print(f"{y=}")
+            print(f"{z=}")
+            print(f"{math.prod([x,y,z]) = }")
+          </py-script>
+        </div>
+
+        <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-yellow-100 ">
+            <pre>&lt;py-script pys-namespace = 'ns-one'&gt;
+print(f"This is executing in a custom namespace called 'ns-one'")
+print("with python version" + str(sys.version.split(" ")[0]))
+
+x, y = 4, 5
+#The math module has not be imported in this namespace, so we get a NameError
+print(f"{math.prod([x,y]) = }")
+&lt;/py-script&gt;</pre>
+          <py-script pys-namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
+        import traceback
+        print(f"This is executing in a custom namespace called 'ns-one'")
+        print("with python version" + str(sys.version.split(" ")[0]))
+
+        x, y = 4, 5
+        print(f"{math.prod([x,y]) = }")
+          </py-script>
+        </div>
+        <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-green-100 ">
+            <pre>&lt;py-script pys-namespace = 'ns-two'&gt;
+print("This is executing in a custom namespace called 'ns-two'")
+print(f"with python version {str(sys.version.split(" ")[0])}")
+
+x = 6
+print(f"{x=}")
+
+# y is not defined in this namespace so we will get a nameerror
+print(f"{y=}")
+&lt;/py-script&gt;</pre>
+          <py-script pys-namespace="ns-two"class="p-2 bg-gray-200 border-4 border-gray-400">
+        import traceback
+        print("This is executing in a custom namespace called 'ns-two'")
+        print("with python version" + str(sys.version.split(" ")[0]))
+        
+        x = 6
+        print(f"{x=}")
+        print(f"{y=}")
+                </py-script>
+                </div>
+          <div class="grid grid-cols-2 gap-2 p-2 space-x-4 bg-yellow-100 ">
+              <pre>&lt;py-script pys-namespace = 'ns-one'&gt;
+print(f"This is executing in a custom namespace called 'ns-one'")
+print("with python version" + str(sys.version.split(" ")[0]))
+
+# x and y retain their values established in the earlier code block in this namespace
+print(f"{x=}")
+print(f"{y=}")
+
+# however, z is not defined in this namespace, so we get a nameerror
+print(f"{z=}")
+&lt;/py-script&gt;</pre>
+            <py-script pys-namespace = 'ns-one'class="p-2 bg-gray-200 border-4 border-gray-400">
+        print(f"This is executing in a custom namespace called 'ns-one'")
+        print("with python version" + str(sys.version.split(" ")[0]))
+        print(f"{x=}")
+        print(f"{y=}")
+        print(f"{z=}")
+           </py-script>
+          </div>
+        </div>
+    </div>
+  </body>
+</html>

--- a/examples/namespaces.html
+++ b/examples/namespaces.html
@@ -73,7 +73,7 @@ print(f"{y=}")
         import traceback
         print("This is executing in a custom namespace called 'ns-two'")
         print("with python version" + str(sys.version.split(" ")[0]))
-        
+
         x = 6
         print(f"{x=}")
         print(f"{y=}")

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -208,7 +208,7 @@ export class BaseEvalElement extends HTMLElement {
 
         if (this.hasAttribute('namespace')) this.namespace = this.getAttribute('namespace');
         else this.namespace = "DEFAULT_NAMESPACE";
-        
+
         const eval_namespace = getNamespace(this.namespace, runtime);
 
         try {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -129,6 +129,10 @@ export class BaseEvalElement extends HTMLElement {
         let source: string;
         let namespace;
         let output;
+
+        if (this.hasAttribute('namespace')) this.namespace = this.getAttribute('namespace');
+        else this.namespace = "DEFAULT_NAMESPACE";
+
         try {
             source = this.source ? await this.getSourceFromFile(this.source) : this.getSourceFromElement();
 
@@ -201,6 +205,10 @@ export class BaseEvalElement extends HTMLElement {
     async eval(source: string): Promise<void> {
         let output;
         const pyodide = runtime;
+
+        if (this.hasAttribute('namespace')) this.namespace = this.getAttribute('namespace');
+        else this.namespace = "DEFAULT_NAMESPACE";
+        
         const eval_namespace = getNamespace(this.namespace, runtime);
 
         try {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -245,8 +245,8 @@ function createWidget(name: string, code: string, klass: string) {
             this.wrapper = document.createElement('slot');
             this.shadow.appendChild(this.wrapper);
 
-            if (this.hasAttribute('pys-namespace')) {
-                this.namespace = this.getAttribute('pys-namespace');
+            if (this.hasAttribute('namespace')) {
+                this.namespace = this.getAttribute('namespace');
             } else {
                 this.namespace = 'DEFAULT_NAMESPACE';
             }
@@ -337,8 +337,8 @@ export class PyWidget extends HTMLElement {
             this.klass = this.getAttribute('klass');
         }
 
-        if (this.hasAttribute('pys-namespace')) {
-            this.namespace = this.getAttribute('pys-namespace');
+        if (this.hasAttribute('namespace')) {
+            this.namespace = this.getAttribute('namespace');
         } else {
             this.namespace = 'DEFAULT_NAMESPACE';
         }

--- a/pyscriptjs/src/components/pyconfig.ts
+++ b/pyscriptjs/src/components/pyconfig.ts
@@ -187,7 +187,7 @@ export class PyConfig extends BaseEvalElement {
         for (const runtime of this.values.runtimes) {
             const script = document.createElement('script'); // create a script DOM node
             const runtimeSpec = new PyodideRuntime(runtime.src);
-            script.src = runtime.src;  // set its src to the provided URL
+            script.src = runtime.src; // set its src to the provided URL
             script.addEventListener('load', () => {
                 void runtimeSpec.initialize();
             });

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -201,6 +201,10 @@ export class PyRepl extends BaseEvalElement {
                 newPyRepl.setAttribute('output-mode', this.getAttribute('output-mode'));
             }
 
+            if (this.hasAttribute('namespace')) {
+                newPyRepl.setAttribute('namespace', this.getAttribute('namespace'));
+            }
+
             const addReplAttribute = (attribute: string) => {
                 if (this.hasAttribute(attribute)) {
                     newPyRepl.setAttribute(attribute, this.getAttribute(attribute));

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -6,7 +6,7 @@ import { defaultKeymap } from '@codemirror/commands';
 import { oneDarkTheme } from '@codemirror/theme-one-dark';
 
 import { componentDetailsNavOpen, loadedEnvironments, mode, pyodideLoaded } from '../stores';
-import { addClasses } from '../utils';
+import { addClasses, htmlDecode } from '../utils';
 import { BaseEvalElement } from './base';
 
 // Premise used to connect to the first available pyodide interpreter
@@ -61,7 +61,7 @@ export class PyRepl extends BaseEvalElement {
 
     connectedCallback() {
         this.checkId();
-        this.code = this.innerHTML;
+        this.code = htmlDecode(this.innerHTML);
         this.innerHTML = '';
         const languageConf = new Compartment();
 

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -172,8 +172,8 @@ export class PyRepl extends BaseEvalElement {
     }
 
     preEvaluate(): void {
-        this.setOutputMode("replace");
-        if(!this.appendOutput) {
+        this.setOutputMode('replace');
+        if (!this.appendOutput) {
             this.outputElement.innerHTML = '';
         }
     }
@@ -192,12 +192,12 @@ export class PyRepl extends BaseEvalElement {
             newPyRepl.setAttribute('root', this.getAttribute('root'));
             newPyRepl.id = this.getAttribute('root') + '-' + nextExecId.toString();
 
-            if(this.hasAttribute('auto-generate')) {
+            if (this.hasAttribute('auto-generate')) {
                 newPyRepl.setAttribute('auto-generate', '');
                 this.removeAttribute('auto-generate');
             }
 
-            if(this.hasAttribute('output-mode')) {
+            if (this.hasAttribute('output-mode')) {
                 newPyRepl.setAttribute('output-mode', this.getAttribute('output-mode'));
             }
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -75,6 +75,12 @@ export class PyScript extends BaseEvalElement {
             } else {
                 this.errorElement = this.outputElement;
             }
+
+            if (this.hasAttribute('pys-namespace')) {
+                this.namespace = this.getAttribute('pys-namespace');
+            } else {
+                this.namespace = 'DEFAULT_NAMESPACE';
+            }
         }
 
         if (currentMode == 'edit') {
@@ -129,8 +135,8 @@ export class PyScript extends BaseEvalElement {
 
 /** Defines all possible pys-on* and their corresponding event types  */
 const pysAttributeToEvent: Map<string, string> = new Map<string, string>([
-        ["pys-onClick", "click"],
-        ["pys-onKeyDown", "keydown"]
+    ['pys-onClick', 'click'],
+    ['pys-onKeyDown', 'keydown'],
 ]);
 
 /** Initialize all elements with pys-on* handlers attributes  */
@@ -147,7 +153,9 @@ async function createElementsWithEventListeners(pyodide: any, pysAttribute: stri
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll(`[${pysAttribute}]`);
     for (const el of matches) {
         if (el.id.length === 0) {
-            throw new TypeError(`<${el.tagName.toLowerCase()}> must have an id attribute, when using the ${pysAttribute} attribute`)
+            throw new TypeError(
+                `<${el.tagName.toLowerCase()}> must have an id attribute, when using the ${pysAttribute} attribute`,
+            );
         }
         const handlerCode = el.getAttribute(pysAttribute);
         const event = pysAttributeToEvent.get(pysAttribute);
@@ -171,7 +179,6 @@ async function createElementsWithEventListeners(pyodide: any, pysAttribute: stri
         //   // pyodide.runPython(handlerCode);
         // }
     }
-
 }
 
 /** Mount all elements with attribute py-mount into the Python namespace */
@@ -187,5 +194,22 @@ async function mountElements() {
     }
     await pyodide.runPythonAsync(source);
 }
+
+async function initNamespaces() {
+    console.log('Copying global namespace to separate namespaces if necessary');
+    const pyodide = await pyodideReadyPromise;
+    const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[pys-namespace]');
+
+    for (const el of matches) {
+        const namespace_title = el.getAttribute('pys-namespace');
+
+        const my_new_namespace = pyodide.globals.get('dict')(pyodide.globals);
+        my_new_namespace.pop('pyscript_namespaces'); //remove any previously created namespaces from this copy
+        pyodide.globals.get('pyscript_namespaces').set(namespace_title, my_new_namespace);
+        console.log('Created new namespace ' + namespace_title);
+    }
+}
+
 addInitializer(mountElements);
+addInitializer(initNamespaces);
 addPostInitializer(initHandlers);

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -76,8 +76,8 @@ export class PyScript extends BaseEvalElement {
                 this.errorElement = this.outputElement;
             }
 
-            if (this.hasAttribute('pys-namespace')) {
-                this.namespace = this.getAttribute('pys-namespace');
+            if (this.hasAttribute('namespace')) {
+                this.namespace = this.getAttribute('namespace');
             } else {
                 this.namespace = 'DEFAULT_NAMESPACE';
             }
@@ -198,10 +198,10 @@ async function mountElements() {
 async function initNamespaces() {
     console.log('Copying global namespace to separate namespaces if necessary');
     const pyodide = await pyodideReadyPromise;
-    const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[pys-namespace]');
+    const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[namespace]');
 
     for (const el of matches) {
-        const namespace_title = el.getAttribute('pys-namespace');
+        const namespace_title = el.getAttribute('namespace');
 
         const my_new_namespace = pyodide.globals.get('dict')(pyodide.globals);
         my_new_namespace.pop('pyscript_namespaces'); //remove any previously created namespaces from this copy

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -196,17 +196,23 @@ async function mountElements() {
 }
 
 async function initNamespaces() {
-    console.log('Copying global namespace to separate namespaces if necessary');
     const pyodide = await pyodideReadyPromise;
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[namespace]');
+    let namespaceList = Array<string>();
 
     for (const el of matches) {
         const namespace_title = el.getAttribute('namespace');
+        if (!namespaceList.includes(namespace_title)){
+            namespaceList.push(namespace_title);
 
-        const my_new_namespace = pyodide.globals.get('dict')(pyodide.globals);
-        my_new_namespace.pop('pyscript_namespaces'); //remove any previously created namespaces from this copy
-        pyodide.globals.get('pyscript_namespaces').set(namespace_title, my_new_namespace);
-        console.log('Created new namespace ' + namespace_title);
+            const my_new_namespace = pyodide.globals.get('dict')(pyodide.globals);
+            my_new_namespace.pop('pyscript_namespaces'); //remove any previously created namespaces from this copy
+            pyodide.globals.get('pyscript_namespaces').set(namespace_title, my_new_namespace);
+        }
+    }
+
+    if (matches.length > 0){
+        console.log('Generated new namespaces based on "namespace" attributes: ' + namespaceList.join(", "));
     }
 }
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -40,7 +40,7 @@ export class PyScript extends BaseEvalElement {
 
     connectedCallback() {
         this.checkId();
-        this.code = this.innerHTML;
+        this.code = htmlDecode(this.innerHTML);
         this.innerHTML = '';
 
         const mainDiv = document.createElement('div');

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -24,12 +24,15 @@ const loadInterpreter = async function (indexUrl: string): Promise<any> {
     console.log('loading pyscript...');
     await pyodide.runPythonAsync(pyscript);
 
+    //create dict for non-default namespaces
+    pyodide.globals.set('pyscript_namespaces', pyodide.globals.get('dict')());
+
     console.log('done setting up environment');
     return pyodide;
 };
 
 const loadPackage = async function (package_name: string[] | string, runtime: any): Promise<any> {
-    if (package_name.length > 0){
+    if (package_name.length > 0) {
         const micropip = pyodide.globals.get('micropip');
         await micropip.install(package_name);
         micropip.destroy();

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -81,10 +81,9 @@ function handleFetchError(e: Error, singleFile: string) {
 
 function getNamespace(name: string, runtime: any) {
     if (name == 'DEFAULT_NAMESPACE') {
-        console.log('No namespace attribute found, using default(global) namespace');
         return runtime.globals;
     } else {
-        console.log('Found that namespace is ' + name);
+        console.log('Using namespace ' + name);
         return runtime.globals.get('pyscript_namespaces').get(name);
     }
 }

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -32,8 +32,7 @@ function ltrim(code: string): string {
 
     const k = Math.min(...lengths);
 
-    return k != 0 ? lines.map(line => line.substring(k)).join('\n')
-                  : code;
+    return k != 0 ? lines.map(line => line.substring(k)).join('\n') : code;
 }
 
 function guidGenerator(): string {
@@ -80,4 +79,24 @@ function handleFetchError(e: Error, singleFile: string) {
     showError(errorContent);
 }
 
-export { addClasses, removeClasses, getLastPath, ltrim, htmlDecode, guidGenerator, showError, handleFetchError };
+function getNamespace(name: string, runtime: any) {
+    if (name == 'DEFAULT_NAMESPACE') {
+        console.log('No pys-namespace attribute found, using default(global) namespace');
+        return runtime.globals;
+    } else {
+        console.log('Found that pys-namespace is ' + name);
+        return runtime.globals.get('pyscript_namespaces').get(name);
+    }
+}
+
+export {
+    addClasses,
+    removeClasses,
+    getLastPath,
+    ltrim,
+    htmlDecode,
+    guidGenerator,
+    showError,
+    handleFetchError,
+    getNamespace,
+};

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -81,10 +81,10 @@ function handleFetchError(e: Error, singleFile: string) {
 
 function getNamespace(name: string, runtime: any) {
     if (name == 'DEFAULT_NAMESPACE') {
-        console.log('No pys-namespace attribute found, using default(global) namespace');
+        console.log('No namespace attribute found, using default(global) namespace');
         return runtime.globals;
     } else {
-        console.log('Found that pys-namespace is ' + name);
+        console.log('Found that namespace is ' + name);
         return runtime.globals.get('pyscript_namespaces').get(name);
     }
 }


### PR DESCRIPTION
Addressing https://github.com/pyscript/pyscript/issues/166, this adds support for namespaces for any tag with an eval() or evaluate() method (py-script, py-repl, py-button, etc.) These tags can have a new attribute pys-namespace to specify which namespace they execute in. This replaces PR #407.

An very bare-bones example:

```
<py-script pys-namespace="my-first-namespace">
print(x := "First Namespace")
</py-script>

<py-script pys-namespace="my-second-namespace">
print(x := "Second Namespace")
</py-script>

<py-script pys-namespace="my-first-namespace">
print(x) #Should be 'First Namespace’
</py-script>
```
There is a new `namespaces.html` that demonstrates the basic namespace functionality.

Under the hood: After pyodide is initialized, the new `initNamespaces()` initializer makes a copy of `pyodide.globals` for every distinct value of pys-namespace found in the document. This is so the new namespaces will have access to the standard lib, PyScript, etc.

These copies are stored in a new dictionary in the pyodide.globals space called "pyscript_namespaces". Each element has a namespace attribute that stores the name of its namespace (as a string), which are the keys to the `pyscript_namespaces` dict.

When a pyscript element is `evaluate()`'d or `eval()`'d, that element uses its pys-namespace value as a key into the pyscript_namespaces dict and uses that as its `__globals__` namespace. If the element has no pys-namespace value, the usual pyodide.globals dict is used.

One thought for future improvement: right now, all the namespaces are created when pyodide is initialized. It might be nice if there were the option to initialize them on demand if they don't exist yet, so that pages could dynamically add new namespaces to elements. This is probably easiest if (2) is implemented, since the usual pyodide.globals namespace would only ever contain the standard pyodide startup modules, standard lib, and whatever PyScript initializes at init time.
