### PR TITLE
Fix URLs for pyscript.css, pyscript.js

### DIFF
--- a/examples/mario/play_mario.html
+++ b/examples/mario/play_mario.html
@@ -7,9 +7,9 @@
     <title>Svelte app</title>
 
     <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="../https://pyscript.net/alpha/pyscript.css" />
+    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
 
-    <script defer src="../https://pyscript.net/alpha/pyscript.js"></script>
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
There was an extraneous "../" before https://pyscript.net/alpha/pyscript.css and https://pyscript.net/alpha/pyscript.js. This simply fixes that, so the PyScript files actually load.