### PR TITLE
Fix URL source reference in examples/simple_clock.html

### DIFF
--- a/examples/simple_clock.html
+++ b/examples/simple_clock.html
@@ -7,9 +7,9 @@
     <title>Simple Clock Demo</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="./build/pyscript.css" />
+    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
 
-    <script defer src="./build/pyscript.js"></script>
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
     <py-env>
     - paths:
       - ./utils.py


### PR DESCRIPTION
The old version of the simple_clock.html example erroneously referenced "./build/" instead of "https://pyscript.net/alpha/" in its reference to PyScript CSS and JavaScript resources. Fixes: #495.