### PR TITLE
Release automation

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,7 +50,6 @@ jobs:
             run: make test
 
         -   name: Prepare Release
-            if: startsWith(github.ref, 'refs/tags/')
             uses: softprops/action-gh-release@v1
             with:
                 tag_name: alpha # Remove for prod

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,59 @@
+name: '[CI] Build Alpha'
+
+on:
+    push:
+        tags:
+        -   '**'
+    workflow_dispatch: #Remove for prod
+
+env:
+    MINICONDA_PYTHON_VERSION: py38
+    MINICONDA_VERSION: 4.11.0
+
+defaults:
+    run:
+        working-directory: pyscriptjs
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+
+        -   name: Checkout
+            uses: actions/checkout@v3
+
+        -   name: Install node
+            uses: actions/setup-node@v3
+            with:
+                node-version: 18.x
+
+        -   name: Cache node modules
+            uses: actions/cache@v3
+            env:
+                cache-name: cache-node-modules
+            with:
+              # npm cache files are stored in `~/.npm` on Linux/macOS
+                path: ~/.npm
+                key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                restore-keys: |
+                    ${{ runner.os }}-build-${{ env.cache-name }}-
+                    ${{ runner.os }}-build-
+                    ${{ runner.os }}-
+
+        -   name: setup Miniconda
+            uses: conda-incubator/setup-miniconda@v2
+
+        -   name: Setup Environment
+            run: make setup
+
+        -   name: Build and Test
+            run: make test
+
+        - name: Prepare Release
+          if: startsWith(github.ref, 'refs/tags/')
+          uses: softprops/action-gh-release@v1
+          with:
+            tag_name: alpha # Remove for prod
+            draft: true
+            prerelease: true
+            generate_release_notes: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: '[CI] Build Alpha'
+name: '[CI] Build Release'
 
 on:
     push:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,6 @@ on:
     push:
         tags:
         -   '**'
-    workflow_dispatch: #Remove for prod
 
 env:
     MINICONDA_PYTHON_VERSION: py38
@@ -52,7 +51,6 @@ jobs:
         -   name: Prepare Release
             uses: softprops/action-gh-release@v1
             with:
-                tag_name: alpha # Remove for prod
                 draft: true
                 prerelease: true
                 generate_release_notes: true

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,15 +1,11 @@
 name: '[Docs] Build Release'
 
 on:
-  # Any time a tag or branch is created
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create
-    create:
-        paths:
-        -   docs/**
+    release:
+        types: [published]
 
 jobs:
     build:
-        if: startsWith(github.ref, 'refs/tags') # Only if tagged
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,10 @@
-name: '[CI] Build Alpha'
+
+name: '[CI] Publish Release'
 
 on:
-    push:
-        tags:
-        -   '**' # Currently any tag, need to slim down
-        paths:
-        -   pyscriptjs/**
+  release:
+    types: [published]
+  workflow_dispatch: # Remove for prod
 
 env:
     MINICONDA_PYTHON_VERSION: py38
@@ -22,7 +21,6 @@ jobs:
             contents: read
             id-token: write
         steps:
-
         -   name: Checkout
             uses: actions/checkout@v3
 
@@ -53,14 +51,15 @@ jobs:
         -   name: Build and Test
             run: make test
 
-        # Deploy to S3
+        # Upload to S3
         -   name: Configure AWS credentials
-            if: github.ref == 'refs/heads/main' # Only deploy on merge into main
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
                 aws-region: ${{secrets.AWS_REGION}}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-        -   name: Sync to S3
-            if: github.ref == 'refs/heads/main'
-            run: aws s3 sync --quiet ./examples/build/ s3://pyscript.net/alpha/
+#        -   name: Sync to S3
+#            run: | # Overwrite "latest" alpha + versioned subdirectory
+#              aws s3 sync --quiet ./examples/build/ s3://pyscript.net/alpha/${{ github.ref_name }}
+#              aws s3 sync --quiet ./examples/build/ s3://pyscript.net/alpha/
+

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,6 @@ name: '[CI] Publish Release'
 on:
     release:
         types: [published]
-    workflow_dispatch: # Remove for prod
 
 env:
     MINICONDA_PYTHON_VERSION: py38


### PR DESCRIPTION
This process for now will:

1. Test and build artifacts on a tag. Tags can be any commit, HEAD or cherry-picked.
2. Create a draft release with change notes and contributors generated from PR activity
3. At this point a maintainer can review the draft and add their own notes about features, breaking changes, etc.
4. Once the release is published, the artifacts will be built and tested again, and if tests pass pushed to S3 in two locations (one to maintain legacy file location).

Note: Building/testing before and after release publication is slightly redundant but since there's a manual break in the workflow, it will be required until we find a way to cache the artifact (if that's preferred). Since we're using the same ref/tag in any case, we should be able to trust that the builds are identical.

Note2: This will probably require follow-up PRs because I have to basically test in `main` to test reliably. I disabled the actual file sync to S3 until it's ready for prod, though.

See diagram below.

![pyscript-release drawio (1)](https://user-images.githubusercontent.com/34256109/174125660-4d45caeb-4a9f-4300-8a8b-02ba9895bd2d.png)

