### PR TITLE
Simplify tests with pytest-playwright

### DIFF
--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -12,3 +12,4 @@ dependencies:
 -   codespell
 -   pre-commit
 -   playwright
+-   pytest-playwright


### PR DESCRIPTION
The `pytest-playwright` package simplifies tests by providing a `page` fixture that launches the browser for you and also easily lets you configure playwright in the pytest command e.g. to switch to headed (rather than headless) mode and slow the test down and see what it's actually doing.