### PR TITLE
Try new method to keep CI from running on forks

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -18,8 +18,7 @@ concurrency:
 
 jobs:
     build:
-        if: >-
-            !github.event.repository.fork
+        if: github.repository_owner == 'pyscript'
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
Previous if: statement didn't appear to work. This will check that the repo owner is pyscript, which will naturally exclude any forks.

See here for forked runs still happening:

https://github.com/pyscript/pyscript/actions/workflows/docs-review.yml