### PR TITLE
Added Internet Requirement For Getting Started.

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -11,6 +11,8 @@ If you're using [VSCode](https://code.visualstudio.com/), the
 [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
 can be used to reload the page as you edit the HTML file.
 
+You will also need constant internet connection to access the other packages which are hosted online that pyscript depend on.
+
 ## Installation
 
 There is no installation required. In this document, we'll use


### PR DESCRIPTION
I updated the getting started to show help beginners ensure that they have a constant internet connection to access dependencies like [pyodide] (https://pyodide.org/en/stable/index.html) that are hosted online.