### PR TITLE
fix: typos in play_mario, handtrack examples

### DIFF
--- a/examples/handtrack/say_hello.html
+++ b/examples/handtrack/say_hello.html
@@ -7,9 +7,9 @@
     <title>Svelte app</title>
 
     <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="../https://pyscript.net/alpha/pyscript.css" />
+    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
 
-    <script defer src="../https://pyscript.net/alpha/pyscript.js"></script>
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
   </head>
 
   <body>

--- a/examples/mario/play_mario.html
+++ b/examples/mario/play_mario.html
@@ -7,9 +7,9 @@
     <title>Svelte app</title>
 
     <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="../https://pyscript.net/alpha/pyscript.css" />
+    <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
 
-    <script defer src="../https://pyscript.net/alpha/pyscript.js"></script>
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
   </head>
 
   <body>
@@ -72,7 +72,7 @@ def toggle_video(evt):
 
 async def start_video():
   global isVideo
-  update_note.write("Inside sstart video")
+  update_note.write("Inside start video")
   status = await handTrack.startVideo(video.element)
   console.log("video started", status)
   if status:


### PR DESCRIPTION
typos in 
- play_mario.html: `../` in link href which causes error, `sstart` typo
- handtrack/say_hello.html: `../` in link href which causes error

![image](https://user-images.githubusercontent.com/60089135/176771553-cc6a3968-c275-43fb-8614-02a0281c7e97.png)
