### PR TITLE
Re-introduce xPyWidget update on CustomWidget's class

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -276,6 +276,7 @@ function createWidget(name: string, code: string, klass: string) {
             }
         }
     }
+    const xPyWidget = customElements.define(name, CustomWidget);
 }
 
 export class PyWidget extends HTMLElement {


### PR DESCRIPTION
We smh let this pass on dc84d7c1b5c6816f350cbfffbd6a019c03ad23a2
`xPyWidget` should be updated every time we create a custom widget :)