### PR TITLE
update makefile with all instruction

### DIFF
--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -64,7 +64,7 @@ test:
 	npm run build
 	$(conda_run) pytest -vv $(ARGS) tests/ --log-cli-level=warning
 
-all: 
+all:
 	make examples
 	npm install
 	npm run build

--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -64,11 +64,11 @@ test:
 	npm run build
 	$(conda_run) pytest -vv $(ARGS) tests/ --log-cli-level=warning
 
-all:
+all: 
 	make examples
 	npm install
 	npm run build
-	npm run start
+	npm run dev
 
 
 test-py:

--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -64,6 +64,13 @@ test:
 	npm run build
 	$(conda_run) pytest -vv $(ARGS) tests/ --log-cli-level=warning
 
+all:
+	make examples
+	npm install
+	npm run build
+	npm run start
+
+
 test-py:
 	@echo "Tests are coming :( this is a placeholder and it's meant to fail!"
 	$(conda_run) pytest -vv $(ARGS) tests/ --log-cli-level=warning


### PR DESCRIPTION
This change addresses #585 - the assumptions are made as follows:

* A conda environment is activated, either created from the environment.yml file or from the Makefile using the setup instruction.
* localhost:8080/examples/ is the default endpoint

I'm also working on an isolated Dockerfile in parallel. Please let me know if this is enough, or If we need to add the ability to create the conda environment from within the `all` instruction as well.

Cc: @marimeireles 