### PR TITLE
Add tests verifying correct example behavior

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,13 @@ repos:
     hooks:
     -   id: bandit
         args:
-        -   --skip=B201
+        -   --skip=B101,B201
 
 -   repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
     -   id: black
+
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.1.0


### PR DESCRIPTION
In this PR I'll start adding tests that don't just check whether examples are rendering but actually verifies correct behavior.

Note: I disabled bandit 101 checks (`Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.`) because checking for asserts is pretty silly in general (imo) but since pytest is entirely based around the use of asserts it makes no sense to enforce.

Tests added:

- [x] simple_clock.html