### PR TITLE
Enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
 -   name: Question
     url: https://community.anaconda.cloud/c/tech-topics/pyscript


### PR DESCRIPTION
The current issue templates are very useful to guide external contributors to submit complete and detailed bug reports, but they are annoying for "internal tasks". As an example, https://github.com/pyscript/pyscript/issues/610 contains a lot of unnecessary sections.

With this change, we are allowed again to open blank issues when needed by using the the small "open blank issue" link at the bottom:
![image](https://user-images.githubusercontent.com/344507/179993538-fcced3be-0223-46d2-965f-030a81aa75bf.png)

Ideally, it would be nice to allow blank issues only for people with the `write` permission to the repo but I didn't find a way to do that, so it will be available for everyone. Hopefully, external users will not abuse this freedom, and if we see that it happens, we can always revert back to the current behavior.