### PR TITLE
Fix the CSS of the todo-pylist example

### DIFF
--- a/pyscriptjs/src/styles/pyscript_base.css
+++ b/pyscriptjs/src/styles/pyscript_base.css
@@ -238,3 +238,7 @@ button, input, optgroup, select, textarea {
     line-height: 1.15;
     margin: 0;
 }
+
+.line-through {
+    text-decoration: line-through;
+}


### PR DESCRIPTION
PyItemTemplate.strike() uses the CSS class line-through, which was part of Tailwind. Reintroduce it in our custom CSS. This fixes the todo-pylist example