### PR TITLE
Specify the type of store value

### DIFF
--- a/pyscriptjs/src/stores.ts
+++ b/pyscriptjs/src/stores.ts
@@ -11,7 +11,7 @@ export type Environment = {
     state: string;
 };
 
-export const pyodideLoaded = writable();
+export const pyodideLoaded = writable<PyodideInterface>();
 
 export const loadedEnvironments = writable<Record<Environment['id'], Environment>>({});
 export const DEFAULT_MODE = 'play';


### PR DESCRIPTION
Hi,

This PR adds a type annotation to resolve the following compile error:

```console
$ npx tsc --noEmit
src/components/base.ts:9:5 - error TS2740: Type '{}' is missing the following properties from type 'PyodideInterface': globals, FS, pyodide_py, version, and 16 more.

9     runtime = value;
      ~~~~~~~

src/components/base.ts:193:37 - error TS2361: The right-hand side of an 'in' expression must not be a primitive.

193             if ('runPythonAsync' in value) {
                                        ~~~~~

src/components/base.ts:237:41 - error TS2361: The right-hand side of an 'in' expression must not be a primitive.

237                 if ('runPythonAsync' in value) {
                                            ~~~~~

src/components/base.ts:238:21 - error TS2322: Type 'unknown' is not assignable to type 'PyodideInterface'.

238                     runtime = value;
                        ~~~~~~~

src/components/pyenv.ts:12:5 - error TS2322: Type 'unknown' is not assignable to type 'PyodideInterface'.

12     runtime = value;
       ~~~~~~~


Found 5 errors in 2 files.

Errors  Files
     4  src/components/base.ts:9
     1  src/components/pyenv.ts:12
```