### PR TITLE
use pip (latest) to install playwright

### DIFF
--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -32,7 +32,7 @@ setup:
 	npm install
 	$(CONDA_EXE) env $(shell [ -d $(env) ] && echo update || echo create) -p $(env) --file environment.yml
 	$(conda_run) playwright install
-	$(CONDA_EXE) install -c anaconda pytest
+	$(CONDA_EXE) install -c anaconda pytest -y
 
 clean:
 	find . -name \*.py[cod] -delete

--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -4,14 +4,14 @@ channels:
 -   microsoft
 dependencies:
 -   python=3.9
--   pip=20.2.2
+-   pip
 -   pytest=7
 -   nodejs=16
 -   black
 -   isort
 -   codespell
 -   pre-commit
--   playwright
 
 -   pip:
+    -   playwright
     -   pytest-playwright


### PR DESCRIPTION
This helps us with installation issues on an M1 mac on running `make setup`