### PR TITLE
Specify the array type

### DIFF
--- a/pyscriptjs/src/components/pybox.ts
+++ b/pyscriptjs/src/components/pybox.ts
@@ -51,7 +51,7 @@ export class PyBox extends HTMLElement {
                 else this.widths.push(w)
             }
         } else {
-            this.widths = Array(mainDiv.children.length).fill('1 1 0')
+            this.widths = Array<string>(mainDiv.children.length).fill('1 1 0');
         }
 
         this.widths.forEach((width, index) => {


### PR DESCRIPTION
Hi,

this PR adds a type annotation to resolve the following ESLint warning:

```console
$ npx eslint src/components/pybox.ts

/***/pyscript/pyscriptjs/src/components/pybox.ts
  54:13  warning  Unsafe assignment of type any[] to a variable of type string[]  @typescript-eslint/no-unsafe-assignment

✖ 1 problem (0 errors, 1 warning)
```