### PR TITLE
Ensure that angle brackets in pyscript tag are escaped before parsing

### DIFF
--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -14,8 +14,12 @@ function getLastPath(str: string): string {
     return str.split('\\').pop().split('/').pop();
 }
 
+function escape(str: string): string {
+    return str.replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
 function htmlDecode(input: string): string {
-    const doc = new DOMParser().parseFromString(ltrim(input), 'text/html');
+    const doc = new DOMParser().parseFromString(ltrim(escape(input)), 'text/html');
     return doc.documentElement.textContent;
 }
 

--- a/pyscriptjs/tests/test_01_basic.py
+++ b/pyscriptjs/tests/test_01_basic.py
@@ -36,3 +36,18 @@ class TestBasic(PyScriptTest):
         """
         )
         assert self.console.info.lines == ["one", "two", "three", "four"]
+
+    def test_escaping_of_angle_brackets(self):
+        """
+        Check that they py-script tags escape angle brackets
+        """
+        # NOTE: this test relies on the fact that pyscript does not write
+        # anything to console.info. If we start writing to info in the future,
+        # we will probably need to tweak this test.
+        self.pyscript_run(
+            """
+            <py-script>import js; js.console.info(1>2)</py-script>
+            <py-script>import js; js.console.info(1<2)</py-script>
+        """
+        )
+        assert self.console.info.lines == ["false", "true"]

--- a/pyscriptjs/tests/test_01_basic.py
+++ b/pyscriptjs/tests/test_01_basic.py
@@ -39,7 +39,7 @@ class TestBasic(PyScriptTest):
 
     def test_escaping_of_angle_brackets(self):
         """
-        Check that they py-script tags escape angle brackets
+        Check that py-script tags escape angle brackets
         """
         # NOTE: this test relies on the fact that pyscript does not write
         # anything to console.info. If we start writing to info in the future,

--- a/pyscriptjs/tests/test_01_basic.py
+++ b/pyscriptjs/tests/test_01_basic.py
@@ -46,8 +46,8 @@ class TestBasic(PyScriptTest):
         # we will probably need to tweak this test.
         self.pyscript_run(
             """
-            <py-script>import js; js.console.info(1>2)</py-script>
-            <py-script>import js; js.console.info(1<2)</py-script>
+            <py-script>import js; js.console.info(1<2, 1>2)</py-script>
+            <py-script>js.console.info("<div></div>")</py-script>
         """
         )
-        assert self.console.info.lines == ["false", "true"]
+        assert self.console.info.lines == ["true false", "<div></div>"]


### PR DESCRIPTION
Without escaping angle brackets (`<` and `>`) the DOMParser will strip out anything that looks like an HTML tag.

- [x] Add test