### PR TITLE
Evaluate dynamically added <py-script> tag

### DIFF
--- a/pyscriptjs/src/stores.ts
+++ b/pyscriptjs/src/stores.ts
@@ -25,7 +25,7 @@ export const componentDetailsNavOpen = writable(false);
 export const mainDiv = writable(null);
 export const currentComponentDetails = writable([]);
 export const scriptsQueue = writable<PyScript[]>([]);
-export const scriptsQueueEvaluated = writable(false); 
+export const scriptsQueueEvaluated = writable(false);
 let scriptsQueueEvaluated_=false;
 scriptsQueueEvaluated.subscribe((value)=>scriptsQueueEvaluated_=value);
 export const initializers = writable<Initializer[]>([]);

--- a/pyscriptjs/src/stores.ts
+++ b/pyscriptjs/src/stores.ts
@@ -25,13 +25,20 @@ export const componentDetailsNavOpen = writable(false);
 export const mainDiv = writable(null);
 export const currentComponentDetails = writable([]);
 export const scriptsQueue = writable<PyScript[]>([]);
+export const scriptsQueueEvaluated = writable(false); 
+let scriptsQueueEvaluated_=false;
+scriptsQueueEvaluated.subscribe((value)=>scriptsQueueEvaluated_=value);
 export const initializers = writable<Initializer[]>([]);
 export const postInitializers = writable<Initializer[]>([]);
 export const globalLoader = writable<PyLoader | undefined>();
 export const appConfig = writable();
 
 export const addToScriptsQueue = (script: PyScript) => {
-    scriptsQueue.update(scriptsQueue => [...scriptsQueue, script]);
+    if (scriptsQueueEvaluated_) {
+        script.evaluate();
+    } else {
+        scriptsQueue.update(scriptsQueue => [...scriptsQueue, script]);
+    }
 };
 
 export const addInitializer = (initializer: Initializer) => {


### PR DESCRIPTION
In original version, the element created by document.createElement("py-script") after pyodide runtime initialization does not evaluate script content.

Here is an example (run in browser console):
```
       let pys=document.createElement("py-script");
       pys.setAttribute("output", "graph"); // <div id="graph"> should be present.
       let tx=document.createTextNode("print(5+10)");
       pys.appendChild(tx);
       document.body.appendChild(pys);
```

This is because tags in scriptsQueue( added on creation of the <py-script> tags) runs only on runtime initialization.

This commit changes addToScriptsQueue so that evaluate the script instantly instead of adding to the queue when it is called after runtime initialization. The example shown above produces output 15.
