### PR TITLE
Fix: ObjectConstructor missing 'entries' property error

### DIFF
--- a/pyscriptjs/tsconfig.json
+++ b/pyscriptjs/tsconfig.json
@@ -27,7 +27,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "lib": [
-      "es2016",
+      "es2017",
       "dom",
       "DOM.Iterable"
     ]


### PR DESCRIPTION
While looking at the code I've noticed that we are setting `es2016` in the tsconfig. Updating it to use `es2017` seems to have "fixed" the warning.

Fixes: #703