### PR TITLE
Fix: Importmaps can be undefined

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -80,7 +80,7 @@ export class BaseEvalElement extends HTMLElement {
     protected async _register_esm(pyodide: PyodideInterface): Promise<void> {
         const imports: { [key: string]: unknown } = {};
         const nodes = document.querySelectorAll("script[type='importmap']");
-        let importmaps: Array<any>;
+        const importmaps: Array<any> = [];
         nodes.forEach( node =>
             {
                 let importmap;


### PR DESCRIPTION
This is just a small change to instantiate importmaps as an empty array so when we try to iterate over importmaps, if we didn't push any imports it will just skip the step

Also, just wanted to check, are we missing an `await` here since `_register_esm` is an async method?

https://github.com/pyscript/pyscript/blob/fa7a97ca3087d9f5c0a1fe2787a57201a33a6dce/pyscriptjs/src/components/base.ts#L124

Fixes: #707