### PR TITLE
Add more unit tests for PyButton and BaseEvalElement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 .pyre/
 
 node_modules/
+
+coverage/

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -3,8 +3,7 @@ import re
 import time
 
 import pytest
-
-from .support import ROOT, PyScriptTest
+from tests.integration.support import ROOT, PyScriptTest
 
 MAX_TEST_TIME = 30  # Number of seconds allowed for checking a testing condition
 TEST_TIME_INCREMENT = 0.25  # 1/4 second, the length of each iteration
@@ -169,6 +168,9 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "PyScript/Panel Streaming Demo"
         wait_for_render(self.page, "*", "<div.*?class=['\"]bk-root['\"].*?>")
 
+    @pytest.mark.xfail(
+        reason="Test seems flaky, sometimes it doesn't return result from second repl"
+    )
     def test_repl(self):
         self.goto("examples/repl.html")
         self.wait_for_pyscript()

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -3,7 +3,8 @@ import re
 import time
 
 import pytest
-from tests.integration.support import ROOT, PyScriptTest
+
+from .support import ROOT, PyScriptTest
 
 MAX_TEST_TIME = 30  # Number of seconds allowed for checking a testing condition
 TEST_TIME_INCREMENT = 0.25  # 1/4 second, the length of each iteration

--- a/pyscriptjs/tests/unit/base.test.ts
+++ b/pyscriptjs/tests/unit/base.test.ts
@@ -1,0 +1,93 @@
+import 'jest';
+
+import { BaseEvalElement } from '../../src/components/base';
+import { pyodideLoaded } from '../../src/stores';
+
+customElements.define('py-base', BaseEvalElement);
+
+describe('BaseEvalElement', () => {
+    let instance: BaseEvalElement;
+
+    beforeEach(() => {
+        instance = new BaseEvalElement();
+    });
+
+    it('BaseEvalElement instantiates correctly', async () => {
+        expect(instance).toBeInstanceOf(BaseEvalElement);
+    });
+
+    // TODO: This test is a bit silly, but the idea is to keep it here until we fix this
+    // issue
+    it("should fail with: Cannot use 'in' operator to search for 'runPythonAsync' in undefined", async () => {
+        let thrownError;
+        let expectedTypeError = new TypeError("Cannot use 'in' operator to search for 'runPythonAsync' in undefined");
+        try {
+            instance.runAfterRuntimeInitialized(async () => {
+                return;
+            });
+        } catch (error) {
+            thrownError = error;
+        }
+        expect(thrownError).toEqual(expectedTypeError);
+    });
+
+    it('runAfterRuntimeInitialized calls pyodideLoaded.subscribe', async () => {
+        const mockedStore = jest.fn();
+        const mockedPyodideLoaded = jest.spyOn(pyodideLoaded, 'subscribe').mockImplementation(mockedStore);
+
+        instance.runAfterRuntimeInitialized(async () => {});
+
+        expect(mockedPyodideLoaded).toHaveBeenCalled();
+    });
+
+    it('addToOutput sets outputElements property correctly', async () => {
+        instance.outputElement = document.createElement('body');
+        instance.addToOutput('Hello, world!');
+
+        expect(instance.outputElement.innerHTML).toBe('<div>Hello, world!</div>');
+        expect(instance.outputElement.hidden).toBe(false);
+
+        instance.addToOutput('Have a good day!');
+        expect(instance.outputElement.innerHTML).toBe('<div>Hello, world!</div><div>Have a good day!</div>');
+    });
+
+    it('setOutputMode updates appendOutput property correctly', async () => {
+        // Confirm that the default mode is 'append'
+        expect(instance.appendOutput).toBe(true);
+
+        instance.setAttribute('output-mode', 'replace');
+        instance.setOutputMode();
+
+        expect(instance.appendOutput).toBe(false);
+
+        // Using a custom output-mode shouldn't update mode
+        instance.setAttribute('output-mode', 'custom');
+        instance.setOutputMode();
+        expect(instance.appendOutput).toBe(false);
+    });
+
+    it('preEvaluate returns null since subclasses should overwrite it', async () => {
+        const preEvaluateResult = instance.preEvaluate();
+        expect(preEvaluateResult).toBeNull();
+    });
+
+    it('postEvaluate returns null since subclasses should overwrite it', async () => {
+        const preEvaluateResult = instance.postEvaluate();
+        expect(preEvaluateResult).toBeNull();
+    });
+
+    it('checkId generates id if none exists', async () => {
+        // Test default value
+        expect(instance.id).toBe('');
+
+        instance.checkId();
+
+        // expect id is similar to py-78c3e696-a74f-df40-f82c-535f12c484ae
+        expect(instance.id).toMatch(/py-(\w+-){1,4}\w+/);
+    });
+
+    it('getSourceFromElement returns empty string', async () => {
+        const returnedGetSourceFromElement = instance.getSourceFromElement();
+        expect(returnedGetSourceFromElement).toBe('');
+    });
+});

--- a/pyscriptjs/tests/unit/base.test.ts
+++ b/pyscriptjs/tests/unit/base.test.ts
@@ -1,7 +1,7 @@
-import 'jest';
+import { jest } from '@jest/globals';
 
 import { BaseEvalElement } from '../../src/components/base';
-import { pyodideLoaded } from '../../src/stores';
+import { runtimeLoaded } from '../../src/stores';
 
 customElements.define('py-base', BaseEvalElement);
 
@@ -20,7 +20,7 @@ describe('BaseEvalElement', () => {
     // issue
     it("should fail with: Cannot use 'in' operator to search for 'runPythonAsync' in undefined", async () => {
         let thrownError;
-        let expectedTypeError = new TypeError("Cannot use 'in' operator to search for 'runPythonAsync' in undefined");
+        let expectedTypeError = new TypeError("Cannot use 'in' operator to search for 'run' in undefined");
         try {
             instance.runAfterRuntimeInitialized(async () => {
                 return;
@@ -31,13 +31,14 @@ describe('BaseEvalElement', () => {
         expect(thrownError).toEqual(expectedTypeError);
     });
 
-    it('runAfterRuntimeInitialized calls pyodideLoaded.subscribe', async () => {
+    it('runAfterRuntimeInitialized calls runtimeLoaded.subscribe', async () => {
         const mockedStore = jest.fn();
-        const mockedPyodideLoaded = jest.spyOn(pyodideLoaded, 'subscribe').mockImplementation(mockedStore);
+        // @ts-ignore: typescript causes the test to fail
+        const mockedruntimeLoaded = jest.spyOn(runtimeLoaded, 'subscribe').mockImplementation(mockedStore);
 
         instance.runAfterRuntimeInitialized(async () => {});
 
-        expect(mockedPyodideLoaded).toHaveBeenCalled();
+        expect(mockedruntimeLoaded).toHaveBeenCalled();
     });
 
     it('addToOutput sets outputElements property correctly', async () => {

--- a/pyscriptjs/tests/unit/pybutton.test.ts
+++ b/pyscriptjs/tests/unit/pybutton.test.ts
@@ -1,4 +1,4 @@
-import 'jest';
+import { jest } from '@jest/globals';
 import { PyButton } from '../../src/components/pybutton';
 
 customElements.define('py-button', PyButton);

--- a/pyscriptjs/tests/unit/pybutton.test.ts
+++ b/pyscriptjs/tests/unit/pybutton.test.ts
@@ -1,0 +1,75 @@
+import 'jest';
+import { PyButton } from '../../src/components/pybutton';
+
+customElements.define('py-button', PyButton);
+
+describe('PyButton', () => {
+    let instance: PyButton;
+    beforeEach(() => {
+        instance = new PyButton();
+        instance.runAfterRuntimeInitialized = jest.fn();
+    });
+
+    it('should get the Button to just instantiate', async () => {
+        expect(instance).toBeInstanceOf(PyButton);
+    });
+
+    it('confirm that  runAfterRuntimeInitialized is called', async () => {
+        const mockedRunAfterRuntimeInitialized = jest
+            .spyOn(instance, 'runAfterRuntimeInitialized')
+            .mockImplementation(jest.fn());
+
+        instance.connectedCallback();
+
+        expect(mockedRunAfterRuntimeInitialized).toHaveBeenCalled();
+    });
+
+    it('onCallback gets or sets a new id', async () => {
+        expect(instance.id).toBe('');
+
+        instance.connectedCallback();
+        const instanceId = instance.id;
+        // id should be similar to py-4850c8c3-d70d-d9e0-03c1-3cfeb0bcec0d-container
+        expect(instanceId).toMatch(/py-(\w+-){1,5}container/);
+
+        // calling checkId directly should return the same id
+        instance.checkId();
+        expect(instance.id).toEqual(instanceId);
+    });
+
+    it('onCallback updates on_click code and function name ', async () => {
+        expect(instance.code).toBe(undefined);
+        expect(instance.innerHTML).toBe('');
+
+        instance.innerHTML = '\ndef on_click(e):\n';
+
+        instance.connectedCallback();
+
+        expect(instance.code).toMatch(/def\son_click_py_(\w+)\(e\)/);
+        expect(instance.innerHTML).toContain('<button class="py-button"');
+    });
+
+    it('onCallback updates on_focus code and function name', async () => {
+        expect(instance.code).toBe(undefined);
+        expect(instance.innerHTML).toBe('');
+
+        instance.innerHTML = '\ndef on_focus(e):\n';
+
+        instance.connectedCallback();
+
+        expect(instance.code).toMatch(/def\son_focus_py_(\w+)\(e\)/);
+        expect(instance.innerHTML).toContain('<button class="py-button"');
+    });
+
+    it('onCallback sets mount_name based on id', async () => {
+        expect(instance.id).toBe('');
+        expect(instance.mount_name).toBe(undefined);
+
+        instance.connectedCallback();
+
+        const instanceId = instance.id;
+
+        expect(instanceId).toMatch(/py-(\w+-){1,5}container/);
+        expect(instance.mount_name).toBe(instanceId.replace('-container', '').split('-').join('_'));
+    });
+});


### PR DESCRIPTION
This PR is part of the effort to increase test coverage (#679). Two new test files were added:

- one for PyButton
- one for BaseEvalElement

I wonder if this is the right approach to testing each component and perhaps some internals. Many of these tests are just asserting default behaviours and checking that things changed as we expect when calling functions.

Please let me know if you would prefer to test these differently or if you think it's good then I'll keep writing tests for the other files 😄 