### PR TITLE
Improve Detection of Scripts that Require Top-Level Await

### DIFF
--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -128,8 +128,9 @@ export class BaseEvalElement extends HTMLElement {
                 def is_async(source: str) -> bool:
                     console.warn("PARSING!")
                     node = ast.parse(source)
+                    async_statement_node_types = (ast.Await, ast.AsyncFor, ast.AsyncWith)
                     for n in ast.walk(node):
-                        if n.__class__ in [ast.Await, ast.AsyncFor, ast.AsyncWith]: return True
+                        if n.__class__ in async_statement_node_types: return True
                     return False
                 is_async
             `);

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -119,23 +119,8 @@ export class BaseEvalElement extends HTMLElement {
         try {
             source = this.source ? await this.getSourceFromFile(this.source)
                                  : this.getSourceFromElement();
-            //const is_async = source.includes('asyncio')
 
-
-            const async_detector = runtime.runPython(`
-                import ast
-
-                def is_async(source: str) -> bool:
-                    console.warn("PARSING!")
-                    node = ast.parse(source)
-                    async_statement_node_types = (ast.Await, ast.AsyncFor, ast.AsyncWith)
-                    for n in ast.walk(node):
-                        if n.__class__ in async_statement_node_types: return True
-                    return False
-                is_async
-            `);
-
-            const is_async = async_detector(source)
+            const is_async = runtime.globals.get('is_async')(source);
 
             this._register_esm(runtime);
             if (is_async) {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -120,7 +120,7 @@ export class BaseEvalElement extends HTMLElement {
             source = this.source ? await this.getSourceFromFile(this.source)
                                  : this.getSourceFromElement();
 
-            const is_async = source.includes('asyncio') || runtime.globals.get('is_async')(source);
+            const is_async = runtime.globals.get('is_async')(source);
 
             this._register_esm(runtime);
             if (is_async) {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -84,7 +84,7 @@ export class BaseEvalElement extends HTMLElement {
         nodes.forEach( node =>
             {
                 let importmap;
-                    try {
+                try {
                     importmap = JSON.parse(node.textContent);
                     if (importmap?.imports == null) return;
                     importmaps.push(importmap);
@@ -120,7 +120,7 @@ export class BaseEvalElement extends HTMLElement {
             source = this.source ? await this.getSourceFromFile(this.source)
                                  : this.getSourceFromElement();
 
-            const is_async = runtime.globals.get('is_async')(source);
+            const is_async = source.includes('asyncio') || runtime.globals.get('is_async')(source);
 
             this._register_esm(runtime);
             if (is_async) {

--- a/pyscriptjs/src/components/base.ts
+++ b/pyscriptjs/src/components/base.ts
@@ -84,7 +84,7 @@ export class BaseEvalElement extends HTMLElement {
         nodes.forEach( node =>
             {
                 let importmap;
-                try {
+                    try {
                     importmap = JSON.parse(node.textContent);
                     if (importmap?.imports == null) return;
                     importmaps.push(importmap);
@@ -119,7 +119,22 @@ export class BaseEvalElement extends HTMLElement {
         try {
             source = this.source ? await this.getSourceFromFile(this.source)
                                  : this.getSourceFromElement();
-            const is_async = source.includes('asyncio')
+            //const is_async = source.includes('asyncio')
+
+
+            const async_detector = runtime.runPython(`
+                import ast
+
+                def is_async(source: str) -> bool:
+                    console.warn("PARSING!")
+                    node = ast.parse(source)
+                    for n in ast.walk(node):
+                        if n.__class__ in [ast.Await, ast.AsyncFor, ast.AsyncWith]: return True
+                    return False
+                is_async
+            `);
+
+            const is_async = async_detector(source)
 
             this._register_esm(runtime);
             if (is_async) {

--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import base64
 import io
@@ -435,3 +436,12 @@ class OutputManager:
 
 pyscript = PyScript()
 output_manager = OutputManager()
+
+
+def is_async(source: str) -> bool:
+    node = ast.parse(source)
+    async_statement_node_types = (ast.Await, ast.AsyncFor, ast.AsyncWith)
+    for n in ast.walk(node):
+        if n.__class__ in async_statement_node_types:
+            return True
+    return False


### PR DESCRIPTION
# Issue
As noted in #714, testing whether a script needs to run with top-level-await enabled by looking for 'asyncio' in the source code misses some cases where top-level-await is necessary.

# Solution
This PR changes the detection method. Instead of looking for the string 'asyncio' in the source, we use `ast.Parse()` to parse the source file, then walk the syntax tree to determine if any `await`, `await for`, or `await with` statements are used outside of `async def` functions. (This is precisely the situation that requires code to be compiled with the `PyCF_ALLOW_TOP_LEVEL_AWAIT` flag, which is what runPythonAsync() achieves.)

## Testing
I've created [a separate repository](https://github.com/JeffersGlass/top-level-await-detection) for the tests for the included code (`TopLevelAsyncFinder` and the `is_async` function). These tests demonstrate that `is_async` correctly differentiates between the three top-level-await statements inside and outside of async def statements. I'd be happy to include that code in this codebase somewhere, but I wasn't sure how it would fit into the testing regimen.

## Timing
Of course, parsing and walking the AST is slowing than just looking for a string in the source, so I did some benchmarking. The gist is: it's slower, yes, but compared to the full pyodide/pyscript loading time, it's negligible. Running on the examples in this repo, the longest time to parse and walk the AST is roughly 6.5 milliseconds for the WebGL example, compared to 2.5 seconds from page-load to first-PyScript-execution in the same circumstances. (Testing for 'asyncio' in the source text takes <10 microseconds.)

I've compiled the [test data for all the examples](https://github.com/JeffersGlass/top-level-await-detection/blob/main/pyscript-examples-timing.md), for the curious.

## Efficiency
The AST walking isn't as efficient as it could be - we always walk the entire tree instead of returning as soon as a top-level-await statement is found. This is a possible improvement for down the road.