### PR TITLE
Remove overwriting properties

### DIFF
--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -2,9 +2,6 @@ import { BaseEvalElement } from './base';
 import { addClasses, htmlDecode } from '../utils';
 
 export class PyButton extends BaseEvalElement {
-    shadow: ShadowRoot;
-    wrapper: HTMLElement;
-    theme: string;
     widths: Array<string>;
     label: string;
     class: Array<string>;

--- a/pyscriptjs/src/components/pyconfig.ts
+++ b/pyscriptjs/src/components/pyconfig.ts
@@ -16,15 +16,11 @@ const DEFAULT_RUNTIME: Runtime = new PyodideRuntime();
  */
 
 export class PyConfig extends BaseEvalElement {
-    shadow: ShadowRoot;
-    wrapper: HTMLElement;
-    theme: string;
     widths: Array<string>;
     label: string;
     mount_name: string;
     details: HTMLElement;
     operation: HTMLElement;
-    code: string;
     values: AppConfig;
     constructor() {
         super();

--- a/pyscriptjs/src/components/pyinputbox.ts
+++ b/pyscriptjs/src/components/pyinputbox.ts
@@ -2,9 +2,6 @@ import { BaseEvalElement } from './base';
 import { addClasses, htmlDecode } from '../utils';
 
 export class PyInputBox extends BaseEvalElement {
-    shadow: ShadowRoot;
-    wrapper: HTMLElement;
-    theme: string;
     widths: Array<string>;
     label: string;
     mount_name: string;

--- a/pyscriptjs/src/components/pyloader.ts
+++ b/pyscriptjs/src/components/pyloader.ts
@@ -1,9 +1,6 @@
 import { BaseEvalElement } from './base';
 
 export class PyLoader extends BaseEvalElement {
-    shadow: ShadowRoot;
-    wrapper: HTMLElement;
-    theme: string;
     widths: Array<string>;
     label: string;
     mount_name: string;

--- a/pyscriptjs/src/components/pytitle.ts
+++ b/pyscriptjs/src/components/pytitle.ts
@@ -2,9 +2,6 @@ import { BaseEvalElement } from './base';
 import { addClasses, htmlDecode } from '../utils';
 
 export class PyTitle extends BaseEvalElement {
-    shadow: ShadowRoot;
-    wrapper: HTMLElement;
-    theme: string;
     widths: Array<string>;
     label: string;
     mount_name: string;


### PR DESCRIPTION
Hi,

This PR removes overwriting properties to resolve the following TS compile errors:

```console
$ npx tsc --noEmit
src/components/pybutton.ts:5:5 - error TS2612: Property 'shadow' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

5     shadow: ShadowRoot;
      ~~~~~~

src/components/pybutton.ts:6:5 - error TS2612: Property 'wrapper' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

6     wrapper: HTMLElement;
      ~~~~~~~

src/components/pybutton.ts:7:5 - error TS2612: Property 'theme' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

7     theme: string;
      ~~~~~

src/components/pyconfig.ts:19:5 - error TS2612: Property 'shadow' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

19     shadow: ShadowRoot;
       ~~~~~~

src/components/pyconfig.ts:20:5 - error TS2612: Property 'wrapper' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

20     wrapper: HTMLElement;
       ~~~~~~~

src/components/pyconfig.ts:21:5 - error TS2612: Property 'theme' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

21     theme: string;
       ~~~~~

src/components/pyconfig.ts:27:5 - error TS2612: Property 'code' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

27     code: string;
       ~~~~

src/components/pyinputbox.ts:5:5 - error TS2612: Property 'shadow' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

5     shadow: ShadowRoot;
      ~~~~~~

src/components/pyinputbox.ts:6:5 - error TS2612: Property 'wrapper' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

6     wrapper: HTMLElement;
      ~~~~~~~

src/components/pyinputbox.ts:7:5 - error TS2612: Property 'theme' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

7     theme: string;
      ~~~~~

src/components/pyloader.ts:4:5 - error TS2612: Property 'shadow' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

4     shadow: ShadowRoot;
      ~~~~~~

src/components/pyloader.ts:5:5 - error TS2612: Property 'wrapper' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

5     wrapper: HTMLElement;
      ~~~~~~~

src/components/pyloader.ts:6:5 - error TS2612: Property 'theme' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

6     theme: string;
      ~~~~~

src/components/pytitle.ts:5:5 - error TS2612: Property 'shadow' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

5     shadow: ShadowRoot;
      ~~~~~~

src/components/pytitle.ts:6:5 - error TS2612: Property 'wrapper' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

6     wrapper: HTMLElement;
      ~~~~~~~

src/components/pytitle.ts:7:5 - error TS2612: Property 'theme' will overwrite the base property in 'BaseEvalElement'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

7     theme: string;
      ~~~~~


Found 16 errors in 5 files.

Errors  Files
     3  src/components/pybutton.ts:5
     4  src/components/pyconfig.ts:19
     3  src/components/pyinputbox.ts:5
     3  src/components/pyloader.ts:4
     3  src/components/pytitle.ts:5
```