### PR TITLE
Remove line numbers from example

### DIFF
--- a/docs/concepts/what-is-pyscript.md
+++ b/docs/concepts/what-is-pyscript.md
@@ -19,7 +19,6 @@ To try it in your browser, copy the code below into an online HTML editor like W
 
 ```{literalinclude} ../_static/examples/what-is-pyscript.html
 ---
-linenos:
 ```
 
 :::


### PR DESCRIPTION
As per #565 the current best fix is to simply remove the line numbers from the output