### PR TITLE
Don't create custom elements in main and fix various small issues on tests

### DIFF
--- a/pyscriptjs/src/components/elements.ts
+++ b/pyscriptjs/src/components/elements.ts
@@ -1,0 +1,35 @@
+import { PyRepl } from './pyrepl';
+import { PyBox } from './pybox';
+import { PyButton } from './pybutton';
+import { PyTitle } from './pytitle';
+import { PyInputBox } from './pyinputbox';
+import { PyWidget } from './base';
+
+/*
+These were taken from main.js because some of our components call
+runAfterRuntimeInitialized immediately when we are creating the custom
+element, this was causing tests to fail since runAfterRuntimeInitialized
+expects the runtime to have been loaded before being called.
+
+This function is now called from within the `runtime.initialize`. Once
+the runtime finished initializing, then we will create the custom elements
+so they are rendered in the page and we will always have a runtime available.
+
+Ideally, this would live under utils.js, but importing all the components in
+the utils.js file was causing jest to fail with weird errors such as:
+"ReferenceError: Cannot access 'BaseEvalElement' before initialization" coming
+from the PyScript class.
+
+*/
+function createCustomElements() {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const xPyRepl = customElements.define('py-repl', PyRepl);
+    const xPyBox = customElements.define('py-box', PyBox);
+    const xPyTitle = customElements.define('py-title', PyTitle);
+    const xPyWidget = customElements.define('py-register-widget', PyWidget);
+    const xPyInputBox = customElements.define('py-inputbox', PyInputBox);
+    const xPyButton = customElements.define('py-button', PyButton);
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+}
+
+export { createCustomElements };

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -14,6 +14,7 @@ const xPyScript = customElements.define('py-script', PyScript);
 const xPyLoader = customElements.define('py-loader', PyLoader);
 const xPyConfig = customElements.define('py-config', PyConfig);
 const xPyEnv = customElements.define('py-env', PyEnv);
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 // As first thing, loop for application configs
 logger.info('checking for py-confing');

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -1,32 +1,19 @@
 import './styles/pyscript_base.css';
 
 import { PyScript } from './components/pyscript';
-import { PyRepl } from './components/pyrepl';
 import { PyEnv } from './components/pyenv';
-import { PyBox } from './components/pybox';
-import { PyButton } from './components/pybutton';
-import { PyTitle } from './components/pytitle';
-import { PyInputBox } from './components/pyinputbox';
-import { PyWidget } from './components/base';
 import { PyLoader } from './components/pyloader';
-import { globalLoader } from './stores';
 import { PyConfig } from './components/pyconfig';
 import { getLogger } from './logger';
+import { globalLoader } from './stores';
 
 const logger = getLogger('pyscript/main');
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+// /* eslint-disable @typescript-eslint/no-unused-vars */
 const xPyScript = customElements.define('py-script', PyScript);
-const xPyRepl = customElements.define('py-repl', PyRepl);
-const xPyEnv = customElements.define('py-env', PyEnv);
-const xPyBox = customElements.define('py-box', PyBox);
-const xPyButton = customElements.define('py-button', PyButton);
-const xPyTitle = customElements.define('py-title', PyTitle);
-const xPyInputBox = customElements.define('py-inputbox', PyInputBox);
-const xPyWidget = customElements.define('py-register-widget', PyWidget);
 const xPyLoader = customElements.define('py-loader', PyLoader);
 const xPyConfig = customElements.define('py-config', PyConfig);
-/* eslint-enable @typescript-eslint/no-unused-vars */
+const xPyEnv = customElements.define('py-env', PyEnv);
 
 // As first thing, loop for application configs
 logger.info('checking for py-confing');

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -9,7 +9,7 @@ import { globalLoader } from './stores';
 
 const logger = getLogger('pyscript/main');
 
-// /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 const xPyScript = customElements.define('py-script', PyScript);
 const xPyLoader = customElements.define('py-loader', PyLoader);
 const xPyConfig = customElements.define('py-config', PyConfig);

--- a/pyscriptjs/src/runtime.ts
+++ b/pyscriptjs/src/runtime.ts
@@ -168,11 +168,12 @@ export abstract class Runtime extends Object {
         // now we call all post initializers AFTER we actually executed all page scripts
         loader?.log('Running post initializers...');
 
+        // Finally create the custom elements for pyscript such as pybutton
+        createCustomElements();
+
         if (appConfig_ && appConfig_.autoclose_loader) {
             loader?.close();
         }
-
-        createCustomElements();
 
         for (const initializer of postInitializers_) {
             await initializer();

--- a/pyscriptjs/src/runtime.ts
+++ b/pyscriptjs/src/runtime.ts
@@ -8,8 +8,9 @@ import {
     postInitializers,
     Initializer,
     scriptsQueue,
-    appConfig
-} from './stores'
+    appConfig,
+} from './stores';
+import { createCustomElements } from './components/elements';
 import type { PyScript } from './components/pyscript';
 import { getLogger } from './logger';
 
@@ -169,6 +170,7 @@ export abstract class Runtime extends Object {
 
         if (appConfig_ && appConfig_.autoclose_loader) {
             loader?.close();
+            createCustomElements();
         }
 
         for (const initializer of postInitializers_) {

--- a/pyscriptjs/src/runtime.ts
+++ b/pyscriptjs/src/runtime.ts
@@ -170,8 +170,9 @@ export abstract class Runtime extends Object {
 
         if (appConfig_ && appConfig_.autoclose_loader) {
             loader?.close();
-            createCustomElements();
         }
+
+        createCustomElements();
 
         for (const initializer of postInitializers_) {
             await initializer();

--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -191,6 +191,10 @@ class PyScriptTest:
             timeout=timeout,
             check_errors=check_errors,
         )
+        # We need this very small wait time for pyscript to append
+        # the script to the page, otherwise clicks and other actions
+        # won't be registered in the test.
+        self.page.wait_for_timeout(100)
 
     def pyscript_run(self, snippet, *, extra_head=""):
         """

--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -191,9 +191,8 @@ class PyScriptTest:
             timeout=timeout,
             check_errors=check_errors,
         )
-        # We need this very small wait time for pyscript to append
-        # the script to the page, otherwise clicks and other actions
-        # won't be registered in the test.
+        # We still don't know why this wait is necessary, but without it
+        # events aren't being triggered in the tests.
         self.page.wait_for_timeout(100)
 
     def pyscript_run(self, snippet, *, extra_head=""):

--- a/pyscriptjs/tests/integration/test_py_button.py
+++ b/pyscriptjs/tests/integration/test_py_button.py
@@ -1,24 +1,8 @@
-import pytest
-
 from .support import PyScriptTest
 
 
 class TestPyButton(PyScriptTest):
-    @pytest.mark.xfail
     def test_on_click(self):
-        """
-        currently this test fails for a bad reason which is unrelated to
-        py-button. During the page loading, the following JS exception occur,
-        in base.ts:BaseEvalElement.evaluate
-
-        [JS exception   ] TypeError: Cannot use 'in' operator to search for 'runPythonAsync' in undefined
-            at http://127.0.0.1:8080/build/pyscript.js:305:38
-            at Object.subscribe (http://127.0.0.1:8080/build/pyscript.js:46:13)
-            at PyButton.runAfterRuntimeInitialized (http://127.0.0.1:8080/build/pyscript.js:304:27)
-            at PyButton.connectedCallback (http://127.0.0.1:8080/build/pyscript.js:26856:18)
-            at http://127.0.0.1:8080/build/pyscript.js:27075:20
-            at http://127.0.0.1:8080/build/pyscript.js:27093:3
-        """  # noqa: E501
         self.pyscript_run(
             """
             <py-button label="my button">

--- a/pyscriptjs/tests/integration/test_py_inputbox.py
+++ b/pyscriptjs/tests/integration/test_py_inputbox.py
@@ -1,25 +1,8 @@
-import time
-
-import pytest
-
 from .support import PyScriptTest
 
 
 class TestPyInputBox(PyScriptTest):
-    @pytest.mark.xfail
     def test_input_box_typing(self):
-        """
-        This test fails in a similar fashion as the pybutton
-        test so it's xfailed for now.
-
-        [JS exception   ] TypeError: Cannot use 'in' operator to search for 'runPythonAsync' in undefined
-            at http://127.0.0.1:8080/build/pyscript.js:305:38
-            at Object.subscribe (http://127.0.0.1:8080/build/pyscript.js:46:13)
-            at PyButton.runAfterRuntimeInitialized (http://127.0.0.1:8080/build/pyscript.js:304:27)
-            at PyButton.connectedCallback (http://127.0.0.1:8080/build/pyscript.js:26856:18)
-            at http://127.0.0.1:8080/build/pyscript.js:27075:20
-            at http://127.0.0.1:8080/build/pyscript.js:27093:3
-        """  # noqa: E501
         self.pyscript_run(
             """
             <py-inputbox label="my input">
@@ -32,10 +15,7 @@ class TestPyInputBox(PyScriptTest):
         )
         assert self.console.log.lines == [self.PY_COMPLETE]
         input = self.page.locator("input")
-        # We need to wait some time before we can type any text
-        # otherwise it won't be registered. This was the smallest
-        # amount that seems to work.
-        time.sleep(0.1)
+
         input.type("Hello")
         input.press("Enter")
 

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -1,5 +1,3 @@
-import pytest
-
 from .support import PyScriptTest
 
 
@@ -15,22 +13,7 @@ class TestPyRepl(PyScriptTest):
         assert py_repl
         assert "Python" in py_repl.inner_text()
 
-    @pytest.mark.xfail
     def test_repl_runs_on_button_press(self):
-        """
-        Current this test fails due to an exception when we iterate over
-        'importmaps'
-
-        [  2.28 JS exception   ] TypeError: importmaps is not iterable
-            at PyRepl._register_esm (http://127.0.0.1:8080/build/pyscript.js:227:37)
-            at PyRepl.evaluate (http://127.0.0.1:8080/build/pyscript.js:252:22)
-            at http://127.0.0.1:8080/build/pyscript.js:23678:21
-            at runFor (http://127.0.0.1:8080/build/pyscript.js:11780:25)
-            at runHandlers (http://127.0.0.1:8080/build/pyscript.js:11789:17)
-            at Object.keydown (http://127.0.0.1:8080/build/pyscript.js:11691:20)
-            at InputState.runCustomHandlers (http://127.0.0.1:8080/build/pyscript.js:8194:37)
-            at HTMLDivElement.<anonymous> (http://127.0.0.1:8080/build/pyscript.js:8156:30)
-        """
         self.pyscript_run(
             """
             <py-repl id="my-repl" auto-generate="true"> </py-repl>
@@ -47,22 +30,7 @@ class TestPyRepl(PyScriptTest):
 
         assert repl_result.inner_text() == "4"
 
-    @pytest.mark.xfail
     def test_repl_runs_with_shift_enter(self):
-        """
-        Current this test fails due to an exception when we iterate over
-        'importmaps'
-
-        [  2.28 JS exception   ] TypeError: importmaps is not iterable
-            at PyRepl._register_esm (http://127.0.0.1:8080/build/pyscript.js:227:37)
-            at PyRepl.evaluate (http://127.0.0.1:8080/build/pyscript.js:252:22)
-            at http://127.0.0.1:8080/build/pyscript.js:23678:21
-            at runFor (http://127.0.0.1:8080/build/pyscript.js:11780:25)
-            at runHandlers (http://127.0.0.1:8080/build/pyscript.js:11789:17)
-            at Object.keydown (http://127.0.0.1:8080/build/pyscript.js:11691:20)
-            at InputState.runCustomHandlers (http://127.0.0.1:8080/build/pyscript.js:8194:37)
-            at HTMLDivElement.<anonymous> (http://127.0.0.1:8080/build/pyscript.js:8156:30)
-        """
         self.pyscript_run(
             """
             <py-repl id="my-repl" auto-generate="true"> </py-repl>

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -26,7 +26,7 @@ class TestPyRepl(PyScriptTest):
         self.page.locator("button").click()
 
         # The result gets the id of the repl + n
-        repl_result = self.page.locator("#my-repl-1")
+        repl_result = self.page.wait_for_selector("#my-repl-1", state="attached")
 
         assert repl_result.inner_text() == "4"
 
@@ -40,6 +40,6 @@ class TestPyRepl(PyScriptTest):
 
         # Confirm that we get a result by using the keys shortcut
         self.page.keyboard.press("Shift+Enter")
-        repl_result = self.page.locator("#my-repl-1")
+        repl_result = self.page.wait_for_selector("#my-repl-1", state="attached")
 
         assert repl_result.text_content() == "4"

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -161,7 +161,6 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "Pyscript/Panel KMeans Demo"
         wait_for_render(self.page, "*", "<div.*?class=['\"]bk-root['\"].*?>")
 
-    @pytest.mark.xfail(reason="JsError: issue #677")
     def test_panel_stream(self):
         # XXX improve this test
         self.goto("examples/panel_stream.html")
@@ -169,9 +168,6 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "PyScript/Panel Streaming Demo"
         wait_for_render(self.page, "*", "<div.*?class=['\"]bk-root['\"].*?>")
 
-    @pytest.mark.xfail(
-        reason="Test seems flaky, sometimes it doesn't return result from second repl"
-    )
     def test_repl(self):
         self.goto("examples/repl.html")
         self.wait_for_pyscript()
@@ -186,8 +182,12 @@ class TestExamples(PyScriptTest):
         # Confirm that using the second repl still works properly
         self.page.locator("#my-repl-2").type("2*2")
         self.page.keyboard.press("Shift+Enter")
-
-        assert self.page.locator("#my-repl-2-2").text_content() == "4"
+        # Make sure that the child of the second repl is attached properly
+        # before looking into the text_content
+        second_repl_result = self.page.wait_for_selector(
+            "#my-repl-2-2", state="attached"
+        )
+        assert second_repl_result.text_content() == "4"
 
     @pytest.mark.xfail(reason="Test seems flaky")
     def test_repl2(self):
@@ -198,6 +198,8 @@ class TestExamples(PyScriptTest):
         # confirm we can import utils and run one command
         self.page.locator("py-repl").type("import utils\nutils.now()")
         self.page.locator("button").click()
+        # Make sure the output is in the page
+        self.page.wait_for_selector("#output")
         # utils.now returns current date time
         content = self.page.content()
         pattern = "\\d+/\\d+/\\d+, \\d+:\\d+:\\d+"  # e.g. 08/09/2022 15:57:32
@@ -230,7 +232,6 @@ class TestExamples(PyScriptTest):
             in first_task.inner_html()
         )
 
-    @pytest.mark.xfail(reason="JsError, issue #673")
     def test_todo_pylist(self):
         # XXX improve this test
         self.goto("examples/todo-pylist.html")

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -105,7 +105,7 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "Bokeh Example"
         wait_for_render(self.page, "*", '<div.*?class=\\"bk\\".*?>')
 
-    @pytest.mark.xfail("Reason: Flaky test(#759)")
+    @pytest.mark.xfail(reason="Flaky test #759")
     def test_d3(self):
         # XXX improve this test
         self.goto("examples/d3.html")

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -105,6 +105,7 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "Bokeh Example"
         wait_for_render(self.page, "*", '<div.*?class=\\"bk\\".*?>')
 
+    @pytest.mark.xfail("Reason: Flaky test(#759)")
     def test_d3(self):
         # XXX improve this test
         self.goto("examples/d3.html")


### PR DESCRIPTION
This PR fixes a few things:

- the 'in undefined' error that we have seen when running tests
- the flakiness of the reply tests
- the test_panel_stream tests (cannot read  properties of undefined)
- wait a short time to allow the loaded script to be inserted into head

Hopefully, you don't mind this wall of text, explaining the reasoning behind the decisions in the PR :smile:

## runAfterRuntimeInitialized running immediately on page load

After adding a bunch of `console.traces` I've noticed that `runAfterRuntimeInitialized` was being called from `main.js` which was a bit odd, following the code path, it seems that it was being run when we were creating the py-button custom element in `const xPyButton = customElements.define('py-button', PyButton);`  See the console output for a better visual.

<details>
<summary>Console output with traces </summary>

```
adding initializer 
async function mountElements()
stores.ts:22:12
added initializer 
async function mountElements()
stores.ts:24:12
adding post initializer 
async function initHandlers()
stores.ts:27:12
added post initializer 
async function initHandlers()
stores.ts:29:12
RUNTIME READY pyenv.ts:8:12
initializers set runtime.ts:9:12
post initializers set runtime.ts:14:12
scripts queue set 2 runtime.ts:19:12
connected pyscript.ts:56:16
console.trace() inside runAfterRuntime base.ts:170:16
    runAfterRuntimeInitialized base.ts:170
    connectedCallback pybutton.ts:57
    <anonymous> main.ts:18
    <anonymous> pyscript.js:27234
console.trace() pyconfig constructor pyconfig.ts:22:16
    PyConfig pyconfig.ts:22
    createElement hello_world.html:1
    <anonymous> main.ts:28
    <anonymous> pyscript.js:27234
console.trace() pyconfig connected callback pyconfig.ts:27:16
    connectedCallback pyconfig.ts:27
    <anonymous> main.ts:29
    <anonymous> pyscript.js:27234
Uncaught TypeError: right-hand side of 'in' should be an object, got undefined
    runAfterRuntimeInitialized base.ts:172
    subscribe index.mjs:50
    runAfterRuntimeInitialized base.ts:171
    connectedCallback pybutton.ts:57
    <anonymous> main.ts:18
    <anonymous> pyscript.js:27234
base.ts:172:16
config set! runtime.ts:27:16
config set 
Object { autoclose_loader: true, runtimes: (1) […] }
pyconfig.ts:41:16
Initializing runtimes... pyconfig.ts:53:16
console.trace() pyodide.ts:40:16
    loadInterpreter pyodide.ts:40
    initialize runtime.ts:55
    loadRuntimes pyconfig.ts:59
    (Async: EventListener.handleEvent)
    loadRuntimes pyconfig.ts:58
    connectedCallback pyconfig.ts:42
    <anonymous> main.ts:29
    <anonymous> pyscript.js:27234
creating pyodide runtime pyodide.ts:41:16
Python initialization complete pyodide.asm.js:10:271183
loading micropip pyodide.ts:51:16
Loading micropip, pyparsing, packaging, distutils pyodide.asm.js:10:136383
Loaded micropip, packaging, pyparsing, distutils pyodide.asm.js:10:137532
loading pyscript... pyodide.ts:53:16
done setting up environment pyodide.ts:58:16
RUNTIME READY pyenv.ts:8:12
Collecting nodes to be mounted into python namespace... pyscript.ts:219:12
evaluate base.ts:100:16
console.trace() 
Object { src: "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js", name: "pyodide-default", lang: "python", interpreter: {…}, globals: Proxy }
base.ts:106:20
    evaluate base.ts:106
    initialize runtime.ts:77
    loadRuntimes pyconfig.ts:59
    (Async: EventListener.handleEvent)
    loadRuntimes pyconfig.ts:58
    connectedCallback pyconfig.ts:42
    <anonymous> main.ts:29
    <anonymous> pyscript.js:27234
----> changed out to py-493bc6ca-5a1b-d659-6e60-a158dafd047c true 2 pyodide.asm.js:10:198133
Element.write: 09/03/2022, 22:08:34 --> True pyodide.asm.js:10:198133
----> reverted 3 pyodide.asm.js:10:198133
scripts queue set runtime.ts:19:12
------ loader closed ------ runtime.ts:84:20
Collecting nodes... pyscript.ts:183:12
===PyScript page fully initialized=== runtime.ts:89:16
registered handlers pybutton.ts:60:20
Source map error: Error: request failed with status 404
Resource URL: https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js
Source Map URL: pyodide.js.map
```
</details>

Initially I wrapped the `customElements`  in a `setTimeout` and waited for 2.5s. This was sufficient most of the time, but there were some odd times that it wasn't. Increasing it to 3s made the button appear after the page loaded, which looked odd. 

The main.js file will only create elements for `PyScript`, `PyConfig`, `PyLoader` and `PyEnv`. and the rest of the elements will be created once the runtime loads successfully and we closed the loader. With this change, the elements were always rendered successfully on the page and the error ` Cannot use 'in' operator to search for 'run' in undefined` stopped.

Initially, the `createCustomElements` was in the `utils.ts` but that caused jest to fail with a strange behaviour, so this function was moved to its own file.

## Removing the time.sleep from tests

While working on the tests last week (or two?) I added a few `time.sleep` because events weren't being triggered correctly. After looking into the `py-button` integration test and noticing that the clicks weren't registered, I started looking into the `PyScriptTest` and the PyScript code.

The `PyScriptTest` will wait for `===PyScript page fully initialized===` to be printed in the console, once playwright sees the log, it starts the tests and in this case, the clicking. But the script hasn't been added to the head of the page yet, so no event is registered. Here's the relevant code:

https://github.com/pyscript/pyscript/blob/e31e03afde805f7ca46da425cd880b87a92d0f3e/pyscriptjs/src/components/pyconfig.ts#L68

Adding a small `page.wait_for_timeout` was enough for the tests to start passing :smile:  I'm wondering if perhaps we can make this timeout even smaller?

In a few tests, I've also added a `self.page.wait_for_selector` which seems to work nicely so playwright will wait until the element is loaded before trying to click or check the contents of the selector.


Please let me know if you would like me to change anything here (or if my assumptions/observations are incorrect :smile: )



Fixes: #673, #677,  #726