### PR TITLE
Add space before/after secrets value

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -92,7 +92,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
         -   name: Sync to S3

--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -47,7 +47,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
         -   name: Copy redirect file

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -44,7 +44,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
         -   name: Copy redirect file

--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -57,7 +57,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
         -   name: Copy redirect file

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -53,7 +53,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
         -   name: Sync to S3

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -22,7 +22,7 @@ jobs:
         -   name: Configure AWS credentials
             uses: aws-actions/configure-aws-credentials@v1.6.1
             with:
-                aws-region: ${{secrets.AWS_REGION}}
+                aws-region: ${{ secrets.AWS_REGION }}
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
         -   name: Sync to S3
             # Sync outdated or new files, delete ones no longer in source


### PR DESCRIPTION
Saw some actions failing on aws credential helper. The syntax was odd as it lacked space around the secret value.

`${{secrets.AWS_REGION}}` vs `${{ secrets.AWS_REGION }}`