### PR TITLE
Fixed Makefile to always clean and recopy the examples build folder (located under examples)

### DIFF
--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -66,7 +66,9 @@ examples:
 	find ./examples/webgl -type f -name '*.html' -exec sed $(SED_I_ARG) s+https://pyscript.net/latest/+../../../build/+g {} \;
 	find ./examples -type f -name '*.html' -exec sed $(SED_I_ARG) s+https://pyscript.net/latest/+../build/+g {} \;
 	npm run build
-	cp -R ./build/ ./examples/build
+	rm -rf ./examples/build
+	mkdir -p ./examples/build
+	cp -R ./build/* ./examples/build
 	@echo "To serve examples run: $(conda_run) python -m http.server 8080 --directory examples"
 
 # run prerequisites and serve pyscript examples at http://localhost:8000/examples/


### PR DESCRIPTION
Fixed Makefile to always clean and recopy the examples build folder (located under examples). Fixes #688 