### PR TITLE
Update online doc for the py-config tag to align with current PyScript latest

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -256,9 +256,30 @@ The `<py-repl>` tag creates a REPL component that is rendered to the page as a c
 
 ## The py-config tag
 
-Use the `<py-config>` tag to set and configure general metadata about your PyScript application in YAML format. If you are unfamiliar with YAML, consider reading [Red Hat's YAML for beginners](https://www.redhat.com/sysadmin/yaml-beginners) guide for more information.
+Use the `<py-config>` tag to set and configure general metadata for your PyScript application. 
+The configuration has to be set in JSON format. If you are unfamiliar with JSON, consider reading [freecodecamp's JSON for beginners](https://www.freecodecamp.org/news/what-is-json-a-json-file-example/) guide for more information.
+
+The ideal place to use `<py-config>` is in between the `<head>...</head>` tags.
 
 The `<py-config>` tag can be used as follows:
+
+```html
+<py-config>
+  {
+    "autoclose_loader": true,
+    "runtimes": [{
+      "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
+      "name": "pyodide-0.21.2",
+      "lang": "python"
+    }]
+  }
+</py-config>
+```
+
+**Warning**: Please note that earlier versions of PyScript used YAML instead of JSON in the `<py-config>` tag to specify application's dependencies.
+Please see [Red Hat's YAML for beginners](https://www.redhat.com/sysadmin/yaml-beginners) for more information about YAML.
+
+Therefore, if you're using the **alpha** version of PyScript, the `<py-config>` tag should be defined as follows:
 
 ```html
 <py-config>
@@ -269,6 +290,8 @@ The `<py-config>` tag can be used as follows:
       lang: python
 </py-config>
 ```
+
+Support for all YAML-based specifications has been deprecated in PyScript, and they will not be further supported in future releases.
 
 The following optional values are supported by `<py-config>`:
 | Value | Type | Description |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -256,7 +256,7 @@ The `<py-repl>` tag creates a REPL component that is rendered to the page as a c
 
 ## The py-config tag
 
-Use the `<py-config>` tag to set and configure general metadata for your PyScript application. 
+Use the `<py-config>` tag to set and configure general metadata for your PyScript application.
 The configuration has to be set in JSON format. If you are unfamiliar with JSON, consider reading [freecodecamp's JSON for beginners](https://www.freecodecamp.org/news/what-is-json-a-json-file-example/) guide for more information.
 
 The ideal place to use `<py-config>` is in between the `<head>...</head>` tags.

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -17,7 +17,7 @@ const xPyEnv = customElements.define('py-env', PyEnv);
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // As first thing, loop for application configs
-logger.info('checking for py-confing');
+logger.info('checking for py-config');
 const config: PyConfig = document.querySelector('py-config');
 if (!config) {
     const loader = document.createElement('py-config');


### PR DESCRIPTION
This PR includes a quick fix to the `getting-started` tutorial to reflect what's currently supported in `latest` version of PyScript 
```html
<link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css"/>
<script defer src="https://pyscript.net/latest/pyscript.js"></script>
```
and the `<py-config>` tag for runtimes.

In particular, it appears that current `latest` only supports the `<py-config>` tag  using runtime configuration in JSON and **not** in YAML.

This PR also provides a quick documentation FIX to #515 (in particular: https://github.com/pyscript/pyscript/issues/515#issuecomment-1250408368).

The integration provided in this PR refers to the contribution @madhur-tandon already prepared in [#775 ](https://github.com/pyscript/pyscript/pull/775), but it also expands on upcoming YAML deprecation, as well as adding a note for those still using PyScript `alpha` version. 

On this note, I believe it's still quite important to keep reference to `alpha` version in doc for now as most of the docs and  and articles around are still referring to alpha and alpha-based examples, and don't use/know about the `latest` release. 

Hence my PR to keep the distinction crystal clear, potentially useful to anyone who will stumble across this - as I did :D 

HTH