### PR TITLE
Snapshot releases

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,4 +1,4 @@
-# SNAPSHOT PUBLISHING
+name: '[CI] Publish Snapshot'
 # Copy /unstable/ to /snapshots/2022.09.1.RC1/
 
 on:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,5 +1,5 @@
 # SNAPSHOT PUBLISHING
-# Copy /unstable/ to shapshots/2022.09.1.RC1/
+# Copy /unstable/ to /snapshots/2022.09.1.RC1/
 
 on:
     workflow_dispatch:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,25 +2,25 @@
 # Copy /unstable/ to shapshots/2022.09.1.RC1/
 
 on:
-  workflow_dispatch:
-    inputs:
-      snapshot_version:
-        description: 'The calver version of this snapshot: 2022.09.1 or 2022.09.1.RC1'
-        type: string
-        required: true
+    workflow_dispatch:
+        inputs:
+            snapshot_version:
+                description: 'The calver version of this snapshot: 2022.09.1 or 2022.09.1.RC1'
+                type: string
+                required: true
 
 jobs:
-  snapshot:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.6.1
-        with:
-          aws-region: '${{ secrets.AWS_REGION }}'
-          role-to-assume: '${{ secrets.AWS_OIDC_RUNNER_ROLE }}'
-      - name: Sync to S3
-        run: > # write to s3
-          aws s3 sync --dryrun s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/
+    snapshot:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+        -   name: Configure AWS credentials
+            uses: aws-actions/configure-aws-credentials@v1.6.1
+            with:
+                aws-region: ${{ secrets.AWS_REGION }}
+                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+        -   name: Sync to S3
+            run: >
+                aws s3 sync --dryrun s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,26 @@
+# SNAPSHOT PUBLISHING
+# Copy /unstable/ to shapshots/2022.09.1.RC1/
+
+on:
+  workflow_dispatch:
+    inputs:
+      snapshot_version:
+        description: 'The calver version of this snapshot: 2022.09.1 or 2022.09.1.RC1'
+        type: string
+        required: true
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: '${{ secrets.AWS_REGION }}'
+          role-to-assume: '${{ secrets.AWS_OIDC_RUNNER_ROLE }}'
+      - name: Sync to S3
+        run: > # write to s3
+          aws s3 sync --dryrun s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/


### PR DESCRIPTION
A Github Actions workflow that publishes a snapshot release of `/unstable/` into `/snapshots/{name}/`. 

This is a manual workflow and is executed within the github account.

This version will test the output using AWS CLI `--dryrun` setting.
We will remov the `--dryrun` setting once we see correct behavior