### PR TITLE
Enable "Publish Snapshot" by removing --dryrun setting

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,4 +23,4 @@ jobs:
                 role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
         -   name: Sync to S3
             run: >
-                aws s3 sync --dryrun s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/
+                aws s3 sync s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/


### PR DESCRIPTION
Testing the `--dryrun` version produced this output and looks to be accurate. This PR removes `--dryrun` to enable the workflow.

Output with `--dryrun` testing on path `2022.09.1.RC1`
<img width="972" alt="Screen Shot 2022-09-25 at 12 38 21 PM" src="https://user-images.githubusercontent.com/35942272/192157408-56fa3452-59b2-4bfa-a77b-a2582129fc83.png">
