### PR TITLE
Add Github Stale to PyScript repo

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -6,8 +6,9 @@ daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
--   pinned
--   security
+-   backlog
+-   needs-triage
+-   needs-work
 
 # Label to use when marking an issue as stale
 staleLabel: stale

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -6,19 +6,19 @@ daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - security
+-   pinned
+-   security
 
 # Label to use when marking an issue as stale
 staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-  
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed because it has not had
-  recent activity. Thank you for your contributions.
+    This issue has been automatically closed because it has not had
+    recent activity. Thank you for your contributions.

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+  
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because it has not had
+  recent activity. Thank you for your contributions.


### PR DESCRIPTION
This adds ["Github Stale"](https://github.com/marketplace/stale) support to `pyscript/pyscript` repo with a base configuration within this PR.

A staler proactively labels and expires issues/prs/branches where no activity exists.

## Configuration

 - Number of days of inactivity before an issue becomes stale: 60
 - Number of days of inactivity before a stale issue is closed: 7
 - Issues with these labels will never be considered stale: [ 'pinned', 'security' ]
 - Label to use when marking an issue as stale: stale
 - Comment to post when marking an issue as stale. 
```text
This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
```
- Comment to post when closing a stale issue. 
```text
This issue has been automatically closed because it has not had recent activity. Thank you for your contributions.
```