### PR TITLE
Minimum viable py-config default schema

### DIFF
--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -16,7 +16,9 @@ const defaultConfig: AppConfig = {
         "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
         "name": "pyodide-0.21.2",
         "lang": "python"
-    }]
+    }],
+    "packages":[],
+    "paths":[]
 }
 
 function addClasses(element: HTMLElement, classes: Array<string>) {

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -9,25 +9,15 @@ const allKeys = {
 };
 
 const defaultConfig: AppConfig = {
-    "name": "pyscript",
-    "description": "default config",
-    "version": "0.1",
     "schema_version": 1,
     "type": "app",
-    "author_name": "anonymous coder",
-    "author_email": "foo@bar.com",
-    "license": "Apache",
     "autoclose_loader": true,
     "runtimes": [{
         "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
         "name": "pyodide-0.21.2",
         "lang": "python"
-    }],
-    "packages": [],
-    "paths": [],
-    "plugins": []
+    }]
 }
-
 
 function addClasses(element: HTMLElement, classes: Array<string>) {
     for (const entry of classes) {

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -18,7 +18,8 @@ const defaultConfig: AppConfig = {
         "lang": "python"
     }],
     "packages":[],
-    "paths":[]
+    "paths":[],
+    "plugins": []
 }
 
 function addClasses(element: HTMLElement, classes: Array<string>) {

--- a/pyscriptjs/tests/unit/pyconfig.test.ts
+++ b/pyscriptjs/tests/unit/pyconfig.test.ts
@@ -54,8 +54,6 @@ describe('PyConfig', () => {
 
     it('should load the default config', () => {
         instance.connectedCallback();
-        expect(instance.values.name).toBe('pyscript');
-        expect(instance.values.author_email).toBe('foo@bar.com');
         expect(instance.values.pyscript?.time).not.toBeNull();
         // @ts-ignore
         expect(instance.values.runtimes[0].lang).toBe('python');
@@ -68,8 +66,6 @@ describe('PyConfig', () => {
         // @ts-ignore
         expect(instance.values.runtimes[0].lang).toBe('covfefe');
         expect(instance.values.pyscript?.time).not.toBeNull();
-        // version wasn't present in `inline config` but is still set due to merging with default
-        expect(instance.values.version).toBe('0.1');
     });
 
     it('should load the JSON config from src attribute', () => {
@@ -81,8 +77,6 @@ describe('PyConfig', () => {
         expect(instance.values.pyscript?.time).not.toBeNull();
         // wonerful is an extra key supplied by the user and is unaffected by merging process
         expect(instance.values.wonerful).toBe('discgrace');
-        // version wasn't present in `config from src` but is still set due to merging with default
-        expect(instance.values.version).toBe('0.1');
     });
 
     it('should load the JSON config from both inline and src', () => {
@@ -109,8 +103,6 @@ describe('PyConfig', () => {
         // @ts-ignore
         expect(instance.values.runtimes[0].lang).toBe('covfefe');
         expect(instance.values.pyscript?.time).not.toBeNull();
-        // version wasn't present in `inline config` but is still set due to merging with default
-        expect(instance.values.version).toBe('0.1');
         expect(instance.values.wonerful).toBe('highjacked');
     });
 


### PR DESCRIPTION
The `<py-config>` default runtime schema should be minimal and not contain defaults that are not valid. All these default config properties are optional and can be overwritten by using `<py-config>`

PR process:

1. Change the default config within utils.ts to only what is necessary
2. Test all examples for correct behavior
3. Fix failing tests isolated where default values were being tested that are now undefined.
4. All tests are passing... units, ts, integration tests.

This looks and feels good to go.