### PR TITLE
simplify OutputCtxManager logging

### DIFF
--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -386,7 +386,7 @@ class OutputCtxManager:
             Element(self._out).write(value, self._append)
 
         if self.output_to_console:
-            console.info( value )
+            console.info(value)
 
 
 class OutputManager:

--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -386,7 +386,7 @@ class OutputCtxManager:
             Element(self._out).write(value, self._append)
 
         if self.output_to_console:
-            console.info(f"[pyscript.py/OutputCtxManager] out={self._out}:", value)
+            console.info( value )
 
 
 class OutputManager:


### PR DESCRIPTION
This simplifies the logging output of OutputCtxManager with 1 console.info per message vs 2.

This is for release 2022.09.1 and we can reenable afterwards