### PR TITLE
Add tsc as an optional build step with --noEmit

### DIFF
--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -5,6 +5,7 @@
     "build-min": "NODE_ENV=production rollup -c",
     "build": "rollup -c",
     "dev": "rollup -c -w",
+    "tsc":"tsc --noEmit",
     "start": "sirv public --no-clear --port 8080",
     "validate": "svelte-check",
     "format:check": "prettier --check './src/**/*.{js,html,ts}'",


### PR DESCRIPTION
This allows us to run the TypeScript compiler directly. Rollup runs this same command within `rollup -c` but we are not seeing the real warnings through `rollup`. Just a pair of 👓 for the codebase. 

Run tsc: `npm run tsc`