### PR TITLE
Remove fortawesome/free-solid-svg-icons

### DIFF
--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -14,7 +14,6 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/theme-one-dark": "^6.0.0",
         "@codemirror/view": "^6.3.0",
-        "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "codemirror": "^6.0.0",
         "sirv-cli": "^1.0.0",
         "svelte-fa": "^2.4.0",
@@ -721,27 +720,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
-      "integrity": "sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz",
-      "integrity": "sha512-UjCILHIQ4I8cN46EiQn0CZL/h8AwCGgR//1c4R96Q5viSRwuKVo0NdQEc4bm+69ZwC0dUvjbDqAHF1RR5FA3XA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -7225,19 +7203,6 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
-      "integrity": "sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg=="
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz",
-      "integrity": "sha512-UjCILHIQ4I8cN46EiQn0CZL/h8AwCGgR//1c4R96Q5viSRwuKVo0NdQEc4bm+69ZwC0dUvjbDqAHF1RR5FA3XA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
       }
     },
     "@humanwhocodes/config-array": {

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -53,7 +53,6 @@
     "@codemirror/state": "^6.0.0",
     "@codemirror/theme-one-dark": "^6.0.0",
     "@codemirror/view": "^6.3.0",
-    "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "codemirror": "^6.0.0",
     "sirv-cli": "^1.0.0",
     "svelte-fa": "^2.4.0",


### PR DESCRIPTION
Removes `@fortawesome/free-solid-svg-icons` from the dependencies - as far as I can tell, it isn't used anywhere.

From the reference to it in #1, I think this has been around from the beginning of this repo, and just went unused at some point.

There's no savings on the shipped-bundle size since we weren't using it, but still, no reason to install it if we don't need it.