### PR TITLE
Add directly listing for releases (fix error)

### DIFF
--- a/pyscriptjs/public/index.html
+++ b/pyscriptjs/public/index.html
@@ -15,11 +15,11 @@
     <main>
         <h1>&lt;py-script&gt;</h1>
         <ul>
-            <li><a href="pyscript.min.js.map">pyscript.min.js.map</a></li>
-            <li><a href="pyscript.min.js">pyscript.min.js</a></li>
-            <li><a href="pyscript.js.map">pyscript.js.map</a></li>
             <li><a href="pyscript.js">pyscript.js</a></li>
+            <li><a href="pyscript.min.js">pyscript.min.js</a></li>
             <li><a href="pyscript.css">pyscript.css</a></li>
+            <li><a href="pyscript.min.js.map">pyscript.min.js.map</a></li>
+            <li><a href="pyscript.js.map">pyscript.js.map</a></li>
         </ul>
         <div id="out"></div>
         <py-script std-out="out">

--- a/pyscriptjs/public/index.html
+++ b/pyscriptjs/public/index.html
@@ -27,7 +27,7 @@
             print(sys.version)
         </py-script>
 
-        <h2>Hello World Example</h2>
+        <h2>Example</h2>
         <pre style="padding:1em;border:1px solid #000000;">&lt;!DOCTYPE html&gt;
 &lt;html lang=&quot;en&quot;&gt;
     &lt;head&gt;

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -53,7 +53,7 @@ export default {
     }),
     copy({
       targets: [
-        { src: 'public/index.html', dest: 'build/' },
+        { src: 'public/index.html', dest: 'build' },
       ]
     }),
     !production && serve(),

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -13,13 +13,13 @@ const production = !process.env.ROLLUP_WATCH || (process.env.NODE_ENV === "produ
 
 export default {
   input: "src/main.ts",
-  output:[
+  output: [
     {
-    sourcemap: true,
-    format: "iife",
-    inlineDynamicImports: true,
-    name: "app",
-    file: "build/pyscript.js",
+      sourcemap: true,
+      format: "iife",
+      inlineDynamicImports: true,
+      name: "app",
+      file: "build/pyscript.js",
     },
     {
       file: "build/pyscript.min.js",
@@ -47,18 +47,23 @@ export default {
     }),
     // This will make sure that examples will always get the latest build folder
     !production && copy({
-        targets: [
-          { src: 'build/*', dest: 'examples/build' },
-          { src: 'public/index.html', dest: 'build/' },
-        ]
-      }),
+      targets: [
+        { src: 'build/*', dest: 'examples/build' },
+      ]
+    }),
+    copy({
+      targets: [
+        { src: 'public/index.html', dest: 'build/' },
+      ]
+    }),
     !production && serve(),
     !production && livereload("public"),
     // production && terser(),
     !production && serve({
       port: 8080,
-      contentBase: 'examples'}
-      )
+      contentBase: 'examples'
+    }
+    )
   ],
   watch: {
     clearScreen: false,

--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -62,8 +62,7 @@ export default {
     !production && serve({
       port: 8080,
       contentBase: 'examples'
-    }
-    )
+    })
   ],
   watch: {
     clearScreen: false,


### PR DESCRIPTION
The rollup configuration was not set to allow copy during production build.
 - copy index.html to build directory ever build