### PR TITLE
Remove an unused import

### DIFF
--- a/pyscriptjs/tests/integration/test_03_style.py
+++ b/pyscriptjs/tests/integration/test_03_style.py
@@ -1,5 +1,3 @@
-import re
-
 from playwright.sync_api import expect
 
 from .support import PyScriptTest


### PR DESCRIPTION
Hi,

This PR removes an unused import to resolve the following pre-commit error:

```console
$ pre-commit run flake8 --all-files
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

pyscriptjs/tests/integration/test_03_style.py:1:1: F401 're' imported but unused
import re
^
1     F401 're' imported but unused
```