### PR TITLE
Add note on [[runtimes]] TOML table in docs

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -161,7 +161,7 @@ The `<py-config>` tag can be used as follows:
   lang = "python"
 </py-config>
 ```
-Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properites defined after it go into the runtimes object.
+Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properties defined after it go into the runtimes object.
 
 Alternatively, a JSON config can be passed using the `type` attribute.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -161,7 +161,7 @@ The `<py-config>` tag can be used as follows:
   lang = "python"
 </py-config>
 ```
-Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properties defined after it go into the runtimes object.
+Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properties defined after it goes into the runtimes object.
 
 Alternatively, a JSON config can be passed using the `type` attribute.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -161,6 +161,7 @@ The `<py-config>` tag can be used as follows:
   lang = "python"
 </py-config>
 ```
+Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properites defined after it go into the runtimes object.
 
 Alternatively, a JSON config can be passed using the `type` attribute.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -161,7 +161,7 @@ The `<py-config>` tag can be used as follows:
   lang = "python"
 </py-config>
 ```
-Note: `[[runtimes]]` is a TOML table. Make sure this is the last item within a py-config, as the properties created after it goes into the runtimes object.
+Note: `[[runtimes]]` is a TOML table. Make sure this is the last item within a py-config, as the properties created after it go into the runtimes object.
 
 Alternatively, a JSON config can be passed using the `type` attribute.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -161,7 +161,7 @@ The `<py-config>` tag can be used as follows:
   lang = "python"
 </py-config>
 ```
-Note: `[[runtimes]]` is a TOML table, make sure this is last in a py-config as the properties defined after it goes into the runtimes object.
+Note: `[[runtimes]]` is a TOML table. Make sure this is the last item within a py-config, as the properties created after it goes into the runtimes object.
 
 Alternatively, a JSON config can be passed using the `type` attribute.
 


### PR DESCRIPTION
Add note on [[runtimes]] TOML table in docs

"Note: [[runtimes]] is a TOML table, make sure this is last in a py-config as the properties defined after it goes into the runtimes object."

Fixes #859