### PR TITLE
Migrate the Jest config

### DIFF
--- a/pyscriptjs/jest.config.js
+++ b/pyscriptjs/jest.config.js
@@ -3,11 +3,14 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'jest-environment-jsdom',
     extensionsToTreatAsEsm: ['.ts'],
-    globals: {
-      'ts-jest': {
-          tsconfig: 'tsconfig.json',
-          useESM: true
-      }
+    transform: {
+        '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+                tsconfig: 'tsconfig.json',
+                useESM: true,
+            },
+        ],
     },
     verbose: true,
     testEnvironmentOptions: {

--- a/pyscriptjs/jest.config.js
+++ b/pyscriptjs/jest.config.js
@@ -14,9 +14,9 @@ module.exports = {
     },
     verbose: true,
     testEnvironmentOptions: {
-        url: "http://localhost"
+        url: 'http://localhost',
     },
     moduleNameMapper: {
-      "^[./a-zA-Z0-9$_-]+\\.py$": "<rootDir>/__mocks__/fileMock.js",
-    }
-  };
+        '^[./a-zA-Z0-9$_-]+\\.py$': '<rootDir>/__mocks__/fileMock.js',
+    },
+};


### PR DESCRIPTION
Hi,

This PR migrates the Jest config to resolve the following warning:

```console
$ npm run test

> pyscript@0.0.1 test
> cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage

ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
...
```

Ref: https://kulshekhar.github.io/ts-jest/docs/getting-started/options