### PR TITLE
Introduce/improve check_js_errors and improve test_no_implicit_target

### DIFF
--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -159,7 +159,7 @@ class PyScriptTest:
         self.clear_js_errors()
 
         if expected_messages:
-            raise JsErrorsDidNotRaise(expected_messages, [])
+            raise JsErrorsDidNotRaise(expected_messages, js_errors)
 
         if js_errors:
             raise JsErrors(js_errors)
@@ -309,11 +309,11 @@ class JsErrorsDidNotRaise(Exception):
         lines = ["The following JS errors were expected but could not be found:"]
         for msg in expected_messages:
             lines.append("    - " + msg)
-        ## if errors:
-        ##     lines.append("---")
-        ##     lines.append("The following JS errors were raised but not expected:")
-        ##     for err in errors:
-        ##         lines.append(JsErrors.format_playwright_error(err))
+        if errors:
+            lines.append("---")
+            lines.append("The following JS errors were raised but not expected:")
+            for err in errors:
+                lines.append(JsErrors.format_playwright_error(err))
         msg = "\n".join(lines)
         super().__init__(msg)
         self.expected_messages = expected_messages

--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -143,25 +143,24 @@ class PyScriptTest:
         check_js_errors will not raise, unless NEW JS errors have been reported
         in the meantime.
         """
-        ## expected_messages = list(expected_messages)
+        expected_messages = list(expected_messages)
         js_errors = self._js_errors[:]
 
         for i, msg in enumerate(expected_messages):
-            for _, error in enumerate(js_errors):
+            for j, error in enumerate(js_errors):
                 if msg is not None and error is not None and msg in error.message:
                     # we matched one expected message with an error, remove both
-                    # expected_messages[i] = None
-                    js_errors[i] = None
+                    expected_messages[i] = None
+                    js_errors[j] = None
 
-        ## # now expected_messages and js_errors should contain only Nones
-        ## expected_messages = [msg for msg in expected_messages if msg is not None]
+        # now expected_messages and js_errors should contain only Nones
+        expected_messages = [msg for msg in expected_messages if msg is not None]
         js_errors = [err for err in js_errors if err is not None]
-
-        ## if expected_messages:
-        ##     # some of the expected messages were not found
-        ##     xxx
-
         self.clear_js_errors()
+
+        if expected_messages:
+            raise JsErrorsDidNotRaise(expected_messages, [])
+
         if js_errors:
             raise JsErrors(js_errors)
 
@@ -309,12 +308,12 @@ class JsErrorsDidNotRaise(Exception):
     def __init__(self, expected_messages, errors):
         lines = ["The following JS errors were expected but could not be found:"]
         for msg in expected_messages:
-            lines.append("    " + msg)
-        lines.append("---")
-        if errors:
-            lines.append("The following JS errors were raised but not expected:")
-            for err in errors:
-                lines.append(JsErrors.format_playwright_error(err))
+            lines.append("    - " + msg)
+        ## if errors:
+        ##     lines.append("---")
+        ##     lines.append("The following JS errors were raised but not expected:")
+        ##     for err in errors:
+        ##         lines.append(JsErrors.format_playwright_error(err))
         msg = "\n".join(lines)
         super().__init__(msg)
         self.expected_messages = expected_messages

--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -146,16 +146,16 @@ class PyScriptTest:
         ## expected_messages = list(expected_messages)
         js_errors = self._js_errors[:]
 
-        ## for i, msg in enumerate(expected_messages):
-        ##     for j, error in enumerate(js_errors):
-        ##         if msg is not None and error is not None and msg in error.message:
-        ##             # we matched one expected message with an error, remove both
-        ##             expected_messages[i] = None
-        ##             js_errors[i] = None
+        for i, msg in enumerate(expected_messages):
+            for _, error in enumerate(js_errors):
+                if msg is not None and error is not None and msg in error.message:
+                    # we matched one expected message with an error, remove both
+                    # expected_messages[i] = None
+                    js_errors[i] = None
 
         ## # now expected_messages and js_errors should contain only Nones
         ## expected_messages = [msg for msg in expected_messages if msg is not None]
-        ## js_errors = [err for err in js_errors if err is not None]
+        js_errors = [err for err in js_errors if err is not None]
 
         ## if expected_messages:
         ##     # some of the expected messages were not found

--- a/pyscriptjs/tests/integration/test_00_support.py
+++ b/pyscriptjs/tests/integration/test_00_support.py
@@ -75,7 +75,7 @@ class TestSupport(PyScriptTest):
         assert self.console.log.lines == ["my log 1", "my log 2"]
         assert self.console.debug.lines == ["my debug"]
 
-    def test_check_errors(self):
+    def test_check_js_errors(self):
         doc = """
         <html>
           <body>
@@ -86,17 +86,17 @@ class TestSupport(PyScriptTest):
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
         with pytest.raises(JsError) as exc:
-            self.check_errors()
+            self.check_js_errors()
         # check that the exception message contains the error message and the
         # stack trace
         msg = str(exc.value)
         assert "Error: this is an error" in msg
         assert f"at {self.fake_server}/mytest.html" in msg
         #
-        # after a call to check_errors, the errors are cleared
-        self.check_errors()
+        # after a call to check_js_errors, the errors are cleared
+        self.check_js_errors()
 
-    def test_check_errors_multiple(self):
+    def test_check_js_errors_multiple(self):
         doc = """
         <html>
           <body>
@@ -108,14 +108,14 @@ class TestSupport(PyScriptTest):
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
         with pytest.raises(JsMultipleErrors) as exc:
-            self.check_errors()
+            self.check_js_errors()
         assert "error 1" in str(exc.value)
         assert "error 2" in str(exc.value)
         #
         # check that errors are cleared
-        self.check_errors()
+        self.check_js_errors()
 
-    def test_clear_errors(self):
+    def test_clear_js_errors(self):
         doc = """
         <html>
           <body>
@@ -125,10 +125,10 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        self.clear_errors()
-        # self.check_errors does not raise, because the errors have been
+        self.clear_js_errors()
+        # self.check_js_errors does not raise, because the errors have been
         # cleared
-        self.check_errors()
+        self.check_js_errors()
 
     def test_wait_for_console(self):
         """
@@ -182,14 +182,14 @@ class TestSupport(PyScriptTest):
         assert "this is an error" in str(exc.value)
         assert isinstance(exc.value.__context__, sync_api.TimeoutError)
         #
-        # if we use check_errors=False, the error are ignored, but we get the
+        # if we use check_js_errors=False, the error are ignored, but we get the
         # Timeout anyway
         self.goto("mytest.html")
         with pytest.raises(sync_api.TimeoutError):
-            self.wait_for_console("Page loaded!", timeout=200, check_errors=False)
+            self.wait_for_console("Page loaded!", timeout=200, check_js_errors=False)
         # we still got a JsError, so we need to manually clear it, else the
         # test fails at teardown
-        self.clear_errors()
+        self.clear_js_errors()
 
     def test_wait_for_console_exception_2(self):
         """
@@ -214,9 +214,9 @@ class TestSupport(PyScriptTest):
             self.wait_for_console("Page loaded!", timeout=200)
         assert "this is an error" in str(exc.value)
         #
-        # with check_errors=False, the Error is ignored and the
+        # with check_js_errors=False, the Error is ignored and the
         # wait_for_console succeeds
         self.goto("mytest.html")
-        self.wait_for_console("Page loaded!", timeout=200, check_errors=False)
+        self.wait_for_console("Page loaded!", timeout=200, check_js_errors=False)
         # clear the errors, else the test fails at teardown
-        self.clear_errors()
+        self.clear_js_errors()

--- a/pyscriptjs/tests/integration/test_00_support.py
+++ b/pyscriptjs/tests/integration/test_00_support.py
@@ -201,6 +201,35 @@ class TestSupport(PyScriptTest):
         ).strip()
         assert re.search(expected, msg)
 
+    def test_check_js_errors_expected_not_found_but_other_errors(self):
+        doc = """
+        <html>
+          <body>
+            <script>throw new Error('error 1');</script>
+            <script>throw new Error('error 2');</script>
+          </body>
+        </html>
+        """
+        self.writefile("mytest.html", doc)
+        self.goto("mytest.html")
+        with pytest.raises(JsErrorsDidNotRaise) as exc:
+            self.check_js_errors("this is not going to be found")
+        #
+        msg = str(exc.value)
+        expected = textwrap.dedent(
+            """
+            The following JS errors were expected but could not be found:
+                - this is not going to be found
+            ---
+            The following JS errors were raised but not expected:
+            Error: error 1
+                at http://fake_server/mytest.html:.*
+            Error: error 2
+                at http://fake_server/mytest.html:.*
+            """
+        ).strip()
+        assert re.search(expected, msg)
+
     def test_clear_js_errors(self):
         doc = """
         <html>

--- a/pyscriptjs/tests/integration/test_00_support.py
+++ b/pyscriptjs/tests/integration/test_00_support.py
@@ -103,6 +103,18 @@ class TestSupport(PyScriptTest):
         # after a call to check_js_errors, the errors are cleared
         self.check_js_errors()
 
+    def test_check_js_errors_expected(self):
+        doc = """
+        <html>
+          <body>
+            <script>throw new Error('this is an error');</script>
+          </body>
+        </html>
+        """
+        self.writefile("mytest.html", doc)
+        self.goto("mytest.html")
+        self.check_js_errors("this is an error")
+
     def test_check_js_errors_multiple(self):
         doc = """
         <html>

--- a/pyscriptjs/tests/integration/test_02_output.py
+++ b/pyscriptjs/tests/integration/test_02_output.py
@@ -67,17 +67,9 @@ class TestOutuput(PyScriptTest):
         self.page.locator("text=Click me").click()
         text = self.page.text_content("body")
         assert "hello" not in text
-
-        # currently the test infrastructure doesn't allow to easily assert that
-        # js exceptions were raised this is a workaround but we need a better fix.
-        # Antonio promised to write it
-        assert len(self._page_errors) == 1
-        console_text = self._page_errors
-        assert (
+        self.check_js_errors(
             "Implicit target not allowed here. Please use display(..., target=...)"
-            in console_text[0].message
         )
-        self._page_errors = []
 
     def test_explicit_target_pyscript_tag(self):
         self.pyscript_run(


### PR DESCRIPTION
Until now, we didn't have a nice way to check that we expect a specific JS error in the web page.
This PR improves `check_js_errors()` so that now you can pass a list of error messages that you expect.
It is tricky because we need to handle (and test!) all various combinations of cases:
  - errors expected and found / expected but not found
  - unexpected errors found / not found

Finally, use the new logic to improve `test_no_implicit_target`.

Requesting review from @marimeireles since I discussed it with her.

