### PR TITLE
Upgrade to Pyodide 0.21.3

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -156,8 +156,8 @@ The `<py-config>` tag can be used as follows:
   autoclose_loader = true
 
   [[runtimes]]
-  src = "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js"
-  name = "pyodide-0.21.2"
+  src = "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js"
+  name = "pyodide-0.21.3"
   lang = "python"
 </py-config>
 ```
@@ -170,8 +170,8 @@ Alternatively, a JSON config can be passed using the `type` attribute.
   {
     "autoclose_loader": true,
     "runtimes": [{
-      "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
-      "name": "pyodide-0.21.2",
+      "src": "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js",
+      "name": "pyodide-0.21.3",
       "lang": "python"
     }]
   }
@@ -189,8 +189,8 @@ where `custom.toml` contains
 ```
 autoclose_loader = true
 [[runtimes]]
-src = "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js"
-name = "pyodide-0.21.2"
+src = "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js"
+name = "pyodide-0.21.3"
 lang = "python"
 ```
 
@@ -206,8 +206,8 @@ where `custom.json` contains
 {
   "autoclose_loader": true,
   "runtimes": [{
-    "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
-    "name": "pyodide-0.21.2",
+    "src": "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js",
+    "name": "pyodide-0.21.3",
     "lang": "python"
   }]
 }

--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -31,7 +31,7 @@
         "jest": "29.1.2",
         "jest-environment-jsdom": "29.1.2",
         "prettier": "2.7.1",
-        "pyodide": "0.21.2",
+        "pyodide": "0.21.3",
         "rollup": "2.79.1",
         "rollup-plugin-copy": "3.4.0",
         "rollup-plugin-css-only": "3.1.0",
@@ -5144,9 +5144,9 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.2.tgz",
-      "integrity": "sha512-pU2VSihi8uGZAJwN6Jhz1JCPQubJR1wGdwH08iH9NyrapwqmFNjL4RGv74OzYo/ZreHEXBQ1GrTZ1Pm0FXX0/A==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.3.tgz",
+      "integrity": "sha512-5fu5P8ys8V8tKTsK9lag0HattbZQuFRdnNzv1LLOLCieM9A96OPs2cF29lPpcD9N+8GuUtfrGCWEMKiupTHUlA==",
       "dev": true,
       "dependencies": {
         "base-64": "^1.0.0",
@@ -10325,9 +10325,9 @@
       "dev": true
     },
     "pyodide": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.2.tgz",
-      "integrity": "sha512-pU2VSihi8uGZAJwN6Jhz1JCPQubJR1wGdwH08iH9NyrapwqmFNjL4RGv74OzYo/ZreHEXBQ1GrTZ1Pm0FXX0/A==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.3.tgz",
+      "integrity": "sha512-5fu5P8ys8V8tKTsK9lag0HattbZQuFRdnNzv1LLOLCieM9A96OPs2cF29lPpcD9N+8GuUtfrGCWEMKiupTHUlA==",
       "dev": true,
       "requires": {
         "base-64": "^1.0.0",

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -30,7 +30,7 @@
     "jest": "29.1.2",
     "jest-environment-jsdom": "29.1.2",
     "prettier": "2.7.1",
-    "pyodide": "0.21.2",
+    "pyodide": "0.21.3",
     "rollup": "2.79.1",
     "rollup-plugin-copy": "3.4.0",
     "rollup-plugin-css-only": "3.1.0",

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -45,8 +45,8 @@ export const defaultConfig: AppConfig = {
     "type": "app",
     "autoclose_loader": true,
     "runtimes": [{
-        "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
-        "name": "pyodide-0.21.2",
+        "src": "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js",
+        "name": "pyodide-0.21.3",
         "lang": "python"
     }],
     "packages":[],

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -20,7 +20,7 @@ export class PyodideRuntime extends Runtime {
 
     constructor(
         config: AppConfig,
-        src = 'https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js',
+        src = 'https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js',
         name = 'pyodide-default',
         lang = 'python',
     ) {

--- a/pyscriptjs/tests/integration/test_py_config.py
+++ b/pyscriptjs/tests/integration/test_py_config.py
@@ -66,7 +66,7 @@ class TestConfig(PyScriptTest):
         )
         assert self.console.log.lines[-1] == "config name: app with external config"
 
-    # The default pyodide version is 0.21.2 as of writing
+    # The default pyodide version is 0.21.3 as of writing
     # this test which is newer than the one we are loading below
     # (after downloading locally) -- which is 0.20.0
 
@@ -175,8 +175,8 @@ class TestConfig(PyScriptTest):
             {
                 "runtimes": [
                     {
-                        "src": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
-                        "name": "pyodide-0.21.2",
+                        "src": "https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js",
+                        "name": "pyodide-0.21.3",
                         "lang": "python"
                     },
                     {

--- a/pyscriptjs/tests/unit/runtime.test.ts
+++ b/pyscriptjs/tests/unit/runtime.test.ts
@@ -23,12 +23,12 @@ describe('PyodideRuntime', () => {
          * following lines - so as to dynamically import
          * and make it available in the global namespace
          * - are used.
-         * 
+         *
          * Pyodide uses a "really hacky" method to get the
          * URL/Path where packages/package data are stored;
          * it throws an error, catches it, and parses it. In
-         * Jest, this calculated path is different than in 
-         * the browser/Node, so files cannot be found and the 
+         * Jest, this calculated path is different than in
+         * the browser/Node, so files cannot be found and the
          * test fails. We set indexURL below the correct location
          * to fix this.
          * See https://github.com/pyodide/pyodide/blob/7dfee03a82c19069f714a09da386547aeefef242/src/js/pyodide.ts#L161-L179

--- a/pyscriptjs/tests/unit/runtime.test.ts
+++ b/pyscriptjs/tests/unit/runtime.test.ts
@@ -14,9 +14,8 @@ describe('PyodideRuntime', () => {
         /**
          * Since import { loadPyodide } from 'pyodide';
          * is not used inside `src/pyodide.ts`, the function
-         * `runtime.initialize();` below which calls
-         * `loadInterpreter` and thus `loadPyodide` results
-         * in an expected issue of:
+         * `runtime.loadInterpreter();` below which calls
+         * `loadPyodide()` results in an expected issue of:
          *   ReferenceError: loadPyodide is not defined
          *
          * To make jest happy, while also not importing
@@ -24,9 +23,18 @@ describe('PyodideRuntime', () => {
          * following lines - so as to dynamically import
          * and make it available in the global namespace
          * - are used.
+         * 
+         * Pyodide uses a "really hacky" method to get the
+         * URL/Path where packages/package data are stored;
+         * it throws an error, catches it, and parses it. In
+         * Jest, this calculated path is different than in 
+         * the browser/Node, so files cannot be found and the 
+         * test fails. We set indexURL below the correct location
+         * to fix this.
+         * See https://github.com/pyodide/pyodide/blob/7dfee03a82c19069f714a09da386547aeefef242/src/js/pyodide.ts#L161-L179
          */
         const pyodideSpec = await import('pyodide');
-        global.loadPyodide = pyodideSpec.loadPyodide;
+        global.loadPyodide = async (options) => pyodideSpec.loadPyodide(Object.assign({indexURL: '../pyscriptjs/node_modules/pyodide/'}, options));
         await runtime.loadInterpreter();
     });
 


### PR DESCRIPTION
Upgrade to Pyodide 0.21.3 as the default. The [changelog from 0.21.2 -> 0.21.3](https://pyodide.org/en/stable/project/changelog.html#version-0-21-3) is mostly bug fixes (including a couple regressions in 0.21.2) - the only breaking changes involves how the `soupsieve` package loads.

The rest of the fixes - including [loading packages in a more sensible order](https://github.com/pyodide/pyodide/pull/3020) and [being able to access the Pyodide version without having to use loadPyodide()](https://github.com/pyodide/pyodide/pull/3074) seem minor but potentially useful.