### PR TITLE
Use `globalThis`

### DIFF
--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -97,9 +97,7 @@ export function globalExport(name: string, obj: object) {
     // attach the given object to the global object, so that it is globally
     // visible everywhere. Should be used very sparingly!
 
-    // `window` in the browser, `global` in node
-    const _global = window || global;
-    _global[name] = obj;
+    globalThis[name] = obj;
 }
 
 export function getAttribute(el: Element, attr: string): string | null {


### PR DESCRIPTION
Hi,

This PR changes `window` and `global` to `globalThis` to simplify an implementation.

Ref: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis