### PR TITLE
Add development section to our docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for wanting to contribute to the PyScript project!
     * [Reporting bugs](#reporting-bugs)
     * [Reporting security issues](#reporting-security-issues)
     * [Asking questions](#asking-questions)
-    * [Setting up your local environment](#setting-up-your-local-environment)
+    * [Setting up your local environment and developing](#setting-up-your-local-environment-and-developing)
     * [Places to start](#places-to-start)
     * [Submitting a change](#submitting-a-change)
 * [License terms for contributions](#license-terms-for-contributions)
@@ -41,149 +41,6 @@ If you aren't confident that it is appropriate to submit a security issue using 
 
 If you have questions about the project, using PyScript, or anything else, please ask in the [PyScript forum](https://community.anaconda.cloud/c/tech-topics/pyscript).
 
-## Setting up your local environment
-
-* Fork the repository - [quicklink](https://github.com/pyscript/pyscript/fork)
-
-* Clone your fork of the project
-
-```
-    git clone https://github.com/<your username>/pyscript
-```
-
-* Add the original project as your upstream (this will allow you to pull the latest changes)
-
-```
-    git remote add upstream git@github.com:pyscript/pyscript.git
-```
-
-* cd into the `pyscriptjs` folder using the line below in your terminal (if your terminal is already in pyscript then use **cd pyscriptjs** instead)
-```
-    cd pyscript/pyscriptjs
-```
-* Install the dependencies with the command below
-
-```
-    make setup
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: If `make setup` gives a node/npm version required  error then go to [troubleshooting](https://github.com/pyscript/pyscript/blob/main/TROUBLESHOOTING.md)
-
-* You can also run the examples locally by running the command below in your terminal
-```
-    make examples
-```
-* Run ***npm run dev*** to build and run the dev server. This will also watch for changes and rebuild when a file is saved.
-```
-    npm run dev
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: To access your local build paste `http://localhost:8080` into your browser
-
-
-Now that node and npm have both been updated `make setup` should work, and you can continue [setting up your local environment](#setting-up-your-local-environment) without problems (hopefully).
-
-### Developing
-
-* First, make sure you are using the latest version of the pyscript main branch
-
-```
-    git pull upstream main
-```
-
-* Update your fork with the latest changes
-
-```
-    git push origin main
-```
-
-* Activate the conda environment (this environment will contain all the necessary dependencies)
-
-```
-    conda activate pyscriptjs/env/
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: We are assuming you are in the root folder. If you are in the pyscriptjs you can run `conda activate env/` instead.
-
-* Install pre-commit (you only need to do this once)
-
-```
-    pre-commit install
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: On first run, pre-commit installs a bunch of hooks that will be run when you commit changes to your branch - this will make sure that your code is following our style (it will also lint your code automatically).
-
-* Create a branch for the issue that you want to work on
-
-```
-    git checkout -b <your branch name>
-```
-
-* Work on your change
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: If you are working on a python file, you may encounter linting issues when pre-commit runs. Pyscript uses [black](https://black.readthedocs.io/en/stable/) to fix any linting problems automatically. All you need to do is add the changes again and commit using your previous commit message (the previous one that failed didn't complete due to black formatting files).
-
-* Run tests before pushing the changes
-
-```
-    make tests
-```
-
-* When you make changes locally, double check that your contribution follows the PyScript formatting rules by running `npm run lint`. Note that in this case you're looking for the errors, <u>**NOT**</u> the warnings (Unless the warning is created by a local change). If an error is found by lint you should fix it <u>**before**</u> creating a pull request
-
-#### Rebasing changes
-
-Sometimes you might be asked to rebase main into your branch. You can do such by:
-
-* Checkout into your main branch and pull the upstream changes
-
-```
-    git checkout main
-    git pull upstream main
-```
-
-* Checkout your branch and rebase on main
-
-```
-    git rebase -i main
-```
-
-If you have conflicts, you must fix them by comparing yours and incoming changes. Your editor can probably help you with this, but do ask for help if you need it!
-
-* Once all conflicts have been fixed
-
-```
-    git rebase --continue
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: You may see more conflicts that you need to address until all are resolved.
-
-* Force push the fixed conflicts
-
-```
-    git push -f origin <your branch name>
-```
-
-
-### Building the docs
-
-To build the documentation locally first make sure you are in the `docs` directory.
-
-You'll need `make` and `conda` installed in your machine. The rest of the environment should be automatically download and created for you once you use the command:
-
-```
-make setup
-```
-
-Use `conda activate $environment_name` to activate your environment.
-
-To add new information to the documentation make sure you conform with PyScript's code of conduct and with the general principles of Diataxis. Don't worry about reading too much on it, just do your best to keep your contributions on the correct axis.
-
-Write your documentation files using [Markedly Structured Text](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html), which is very similar to vanilla Markdown but with some addons to create the documentation infrastructure.
-
-Once done, initialize a server to check your work:
-
-```
-make livehtml
-```
-
-Visible here: http:///127.0.0.1:8000
-
 ## Places to start
 
 If you would like to contribute to PyScript, but you aren't sure where to begin, here are some suggestions.
@@ -193,21 +50,15 @@ If you would like to contribute to PyScript, but you aren't sure where to begin,
 * **Look over the open pull requests.** Do you have comments or suggestions for the proposed changes? Add them.
 * **Check out the examples.** Is there a use case that would be good to have sample code for? Create an example for it.
 
-# Submitting a change
+## Setting up your local environment and developing
 
-All contributions must be licensed Apache 2.0, and all files must have a copy of the boilerplate license comment (can be copied from an existing file).
+If you would like to contribute to PyScript, you will need to set up a local development environment. The [following instructions](https://docs.pyscript.net/latest/development/setting-up-environment.html) will help you get started.
 
-To create a change for PyScript, you can follow the process described [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).
-
-* Follow the steps in [setting your local environment](#setting-up-your-local-environment) and [developing](#developing)
-* Make the changes you would like (don't forget to test them with `make test`)
-* Add tests relevant to the feature or bug you fixed
-* Open a pull request back to the PyScript project and address any comments/questions from the maintainers and other contributors.
+You can also read the [developing process](https://docs.pyscript.net/latest/development/developing.html) and how to rebase your branch with the latest changes.
 
 ## License terms for contributions
 
 This Project welcomes contributions, suggestions, and feedback. All contributions, suggestions, and feedback you submitted are accepted under the [Apache 2.0](./LICENSE) license. You represent that if you do not own copyright in the code that you have the authority to submit it under the [Apache 2.0](./LICENSE) license. All feedback, suggestions, or contributions are not confidential.
-
 
 ## Becoming a maintainer
 

--- a/docs/development/deprecation-cycle.md
+++ b/docs/development/deprecation-cycle.md
@@ -1,0 +1,30 @@
+# Deprecation Cycle
+
+Pyscript is under heavy development, which means that some things may change, and some features might need to be deprecated so you can use different alternative implementations.
+
+This page describes the deprecation cycle for pyscript.
+
+## Deprecation Steps
+
+1. Remove usage of deprecated features from all examples.
+2. Add warnings to all elements/features marked for deprecation.
+3. Release a new version of pyscript with the deprecation warnings.
+4. Next release, remove the deprecated features.
+
+## Deprecation Warnings
+
+Deprecation warnings are added to the codebase using the `showWarning` function from the `pyscriptjs.utils` module.
+
+This function creates a warning banner on the page if any of the deprecated features was used. You can use HTML to write the message; ideally, you should provide an alternative to the deprecated feature.
+
+### Example
+
+```js
+import {showWarning} from './utils'
+
+showWarning(`
+    <p>
+        The <code>py-deprecated</code> tag is deprecated. Please use the <code>py-actual</code> tag instead. Please refer to <a href="#">this documentation page</a> for more information.
+    </p>
+`)
+```

--- a/docs/development/developing.md
+++ b/docs/development/developing.md
@@ -1,0 +1,82 @@
+# Developing Process
+
+This document is intended to help you get started developing for pyscript, it assumes that you have [setup your development environment](setting-up-environment.md).
+
+* First, make sure you are using the latest version of the pyscript main branch
+
+```
+git pull upstream main
+```
+
+* Update your fork with the latest changes
+
+```
+git push origin main
+```
+
+* Activate the conda environment (this environment will contain all the necessary dependencies)
+
+```
+conda activate pyscriptjs/env/
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: We are assuming you are in the root folder. If you are in the pyscriptjs you can run `conda activate env/` instead.
+
+* Install pre-commit (you only need to do this once)
+
+```
+pre-commit install
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: On first run, pre-commit installs a bunch of hooks that will be run when you commit changes to your branch - this will make sure that your code is following our style (it will also lint your code automatically).
+
+* Create a branch for the issue that you want to work on
+
+```
+git checkout -b <your branch name>
+```
+
+* Work on your change
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: If you are working on a python file, you may encounter linting issues when pre-commit runs. Pyscript uses [black](https://black.readthedocs.io/en/stable/) to fix any linting problems automatically. All you need to do is add the changes again and commit using your previous commit message (the previous one that failed didn't complete due to black formatting files).
+
+* Run tests before pushing the changes
+
+```
+make tests
+```
+
+* When you make changes locally, double check that your contribution follows the PyScript formatting rules by running `npm run lint`. Note that in this case you're looking for the errors, <u>**NOT**</u> the warnings (Unless the warning is created by a local change). If an error is found by lint you should fix it <u>**before**</u> creating a pull request
+
+
+## Rebasing changes
+
+Sometimes you might be asked to rebase main into your branch. You can do such by:
+
+* Checkout into your main branch and pull the upstream changes
+
+```
+git checkout main
+git pull upstream main
+```
+
+* Checkout your branch and rebase on main
+
+```
+git rebase -i main
+```
+
+If you have conflicts, you must fix them by comparing yours and incoming changes. Your editor can probably help you with this, but do ask for help if you need it!
+
+* Once all conflicts have been fixed
+
+```
+git rebase --continue
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: You may see more conflicts that you need to address until all are resolved.
+
+* Force push the fixed conflicts
+
+```
+git push -f origin <your branch name>
+```
+
+If you need help with anything, feel free to reach out and ask for help!

--- a/docs/development/developing.md
+++ b/docs/development/developing.md
@@ -49,34 +49,6 @@ make tests
 
 ## Rebasing changes
 
-Sometimes you might be asked to rebase main into your branch. You can do such by:
-
-* Checkout into your main branch and pull the upstream changes
-
-```
-git checkout main
-git pull upstream main
-```
-
-* Checkout your branch and rebase on main
-
-```
-git rebase -i main
-```
-
-If you have conflicts, you must fix them by comparing yours and incoming changes. Your editor can probably help you with this, but do ask for help if you need it!
-
-* Once all conflicts have been fixed
-
-```
-git rebase --continue
-```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: You may see more conflicts that you need to address until all are resolved.
-
-* Force push the fixed conflicts
-
-```
-git push -f origin <your branch name>
-```
+Sometimes you might be asked to rebase main into your branch. Please refer to this [section on git rebase from GitHub docs](https://docs.github.com/en/get-started/using-git/about-git-rebase).
 
 If you need help with anything, feel free to reach out and ask for help!

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,12 @@
+# Development
+
+This section contains various topics related to pyscript development.
+
+```{toctree}
+---
+maxdepth: 1
+---
+setting-up-environment
+deprecation-cycle
+developing
+```

--- a/docs/development/setting-up-environment.md
+++ b/docs/development/setting-up-environment.md
@@ -1,0 +1,69 @@
+# Setting up your development environment
+
+* Fork the repository - [quicklink](https://github.com/pyscript/pyscript/fork)
+
+* Clone your fork of the project
+
+```
+git clone https://github.com/<your username>/pyscript
+```
+
+* Add the original project as your upstream (this will allow you to pull the latest changes)
+
+```sh
+git remote add upstream git@github.com:pyscript/pyscript.git
+```
+
+* cd into the `pyscriptjs` folder using the line below in your terminal (if your terminal is already in pyscript then use **cd pyscriptjs** instead)
+
+```
+cd pyscript/pyscriptjs
+```
+
+* Install the dependencies with the command below (you must have node >=16)
+
+```
+make setup
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: If `make setup` gives a node/npm version required  error then go to [troubleshooting](https://github.com/pyscript/pyscript/blob/main/TROUBLESHOOTING.md)
+
+* You can also run the examples locally by running the command below in your terminal
+
+```
+make examples
+```
+
+* Run ***npm run dev*** to build and run the dev server. This will also watch for changes and rebuild when a file is saved.
+
+```
+npm run dev
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NOTE**: To access your local build paste `http://localhost:8080` into your browser
+
+
+Now that node and npm have both been updated `make setup` should work, and you can continue [setting up your local environment](setting-up-environment.md) without problems (hopefully).
+
+
+## Setting up and building the docs
+
+To build the documentation locally first make sure you are in the `docs` directory.
+
+You'll need `make` and `conda` installed in your machine. The rest of the environment should be automatically download and created for you once you use the command:
+
+```
+make setup
+```
+
+Use `conda activate $environment_name` to activate your environment.
+
+To add new information to the documentation make sure you conform with PyScript's code of conduct and with the general principles of Diataxis. Don't worry about reading too much on it, just do your best to keep your contributions on the correct axis.
+
+Write your documentation files using [Markedly Structured Text](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html), which is very similar to vanilla Markdown but with some addons to create the documentation infrastructure.
+
+Once done, initialize a server to check your work:
+
+```
+make livehtml
+```
+
+Visible here: [http://127.0.0.1:8000](http://127.0.0.1:8000)

--- a/docs/reference/API/display.md
+++ b/docs/reference/API/display.md
@@ -4,19 +4,20 @@
 
 `*values` - the objects to be displayed. String objects are output as-written. For non-string objects, the default content to display is the the object's `repr()`. Objects may implement the following methods to indicate that they should be displayed as a different MIME type. MIME types with a * indicate that the content will be wrapped in the appropriate html tags and attributes before output:
 
-    | Method              | Inferred MIME type     |
-    |---------------------|------------------------|
-    | `__repr__`          | text/plain             |
-    | `_repr_html_`       | text/html              |
-    | `_repr_markdown_`   | text/markdown          |
-    | `_repr_svg_`        | image/svg+xml          |
-    | `_repr_png_`        | image/png*              |
-    | `_repr_pdf_`        | application/pdf        |
-    | `_repr_jpeg_`       | image/jpeg*             |
-    | `_repr_latex__`       | text/latex             |
-    | `_repr_json_`       | application/json       |
-    | `_repr_javascript_` | application/javascript* |
-    | `savefig`           | image/png              |
+| Method              | Inferred MIME type     |
+|---------------------|------------------------|
+| `__repr__`          | text/plain             |
+| `_repr_html_`       | text/html              |
+| `_repr_markdown_`   | text/markdown          |
+| `_repr_svg_`        | image/svg+xml          |
+| `_repr_png_`        | image/png*             |
+| `_repr_pdf_`        | application/pdf        |
+| `_repr_jpeg_`       | image/jpeg*            |
+| `_repr_latex__`     | text/latex             |
+| `_repr_json_`       | application/json       |
+| `_repr_javascript_` | application/javascript*|
+| `savefig`           | image/png              |
+|                     |                        |
 
 `target` - Element's ID. The default value for `target` is the current `py-script` tag ID, it's possible to specify different IDs for this parameter
 


### PR DESCRIPTION
This is the first pass at adding a `development` section for our docs, I've moved `setting up your env` and `developing` from contributing.md into two specific pages. The section in contributing was replaced by a shorter one that also points to these pages in the docs.

The development section is not included in the navbar, should it? I thought that this might be too specific and users might not care if they aren't creating PRs :thinking: 

Please let me know if you would like me to change anything :smile: 

Closes: #907
Fixes: #448