### PR TITLE
Fix banner width

### DIFF
--- a/pyscriptjs/src/styles/pyscript_base.css
+++ b/pyscriptjs/src/styles/pyscript_base.css
@@ -111,8 +111,7 @@ color: #0f172a;
 /* Pop-up second layer end */
 .alert-banner {
     position: relative;
-    width: 99%;
-    padding: .5rem;
+    padding: .5rem 1.5rem .5rem .5rem;
     margin: 5px 0;
 }
 


### PR DESCRIPTION
@JeffersGlass  noticed that the border of the banner cut off on the right side. I've tested this and seems like setting width was causing some odd behaviour. 

This PR removes the `width` rule in the banner and sets a larger padding on the right hand side so on mobile the text won't appear under the x button