### PR TITLE
Deprecate py-button, py-inputbox, py-box and py-title

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -417,10 +417,10 @@ The following tags can be used to add visual attributes to your HTML page.
 
 | Tag             | Description |
 | ---             | ----------- |
-| `<py-inputbox>` | Adds an input box that can be used to prompt users to enter input values. |
-| `<py-box>`      | Creates a container object that can be used to host one or more visual components that define how elements of `<py-box>` should align and show on the page. |
-| `<py-button>`   | Adds a button to which authors can add labels and event handlers for actions on the button, such as `on_focus` or `on_click`. |
-| `<py-title>`    | Adds a static text title component that styles the text inside the tag as a page title. |
+| `<py-inputbox>` | (Deprecated) Adds an input box that can be used to prompt users to enter input values. |
+| `<py-box>`      | (Deprecated) Creates a container object that can be used to host one or more visual components that define how elements of `<py-box>` should align and show on the page. |
+| `<py-button>`   | (Deprecated) Adds a button to which authors can add labels and event handlers for actions on the button, such as `on_focus` or `on_click`. |
+| `<py-title>`    | (Deprecated) Adds a static text title component that styles the text inside the tag as a page title. |
 
 ```{note}
 All the elements above are experimental and not implemented at their full functionality. Use them with the understanding that the APIs or full support might change or be removed until the visual components are more mature.

--- a/examples/repl2.html
+++ b/examples/repl2.html
@@ -24,9 +24,9 @@
         [[fetch]]
         files = ["./utils.py", "./antigravity.py"]
       </py-config>
-      <py-box widths="2/3;1/3">
+      <div>
         <py-repl id="my-repl" auto-generate="true"> </py-repl>
         <div id="output" class="p-4"></div>
-      </py-box>
+      </div>
   </body>
 </html>

--- a/examples/todo-pylist.html
+++ b/examples/todo-pylist.html
@@ -19,6 +19,7 @@
     <py-script>
       def add_task(*ags, **kws):
         # create a new dictionary representing the new task
+        new_task_content = Element("new-task-content")
         task = { "content": new_task_content.value,  "done": False, "created_at": dt.now() }
 
         # add a new task to the list and tell it to use the `content` key to show in the UI
@@ -28,22 +29,18 @@
         # clear the inputbox element used to create the new task
         new_task_content.clear()
 
+      def on_click(evt):
+        add_task()
+
     </py-script>
   </head>
 
   <body>
-      <py-title>To Do List</py-title>
-      <py-box widths="4/5;1/5">
-        <py-inputbox id="new-task-content">
-          def on_keypress(e):
-            if (e.code == "Enter"):
-              add_task()
-        </py-inputbox>
-        <py-button id="new-task-btn" label="Add Task!">
-          def on_click(evt):
-            add_task()
-        </py-button>
-      </py-box>
+      <h1>To Do List</h1>
+      <div class="py-box">
+        <input id="new-task-content" />
+        <button py-click="add_task()" id="new-task-btn" class="py-button">Add Task!</button>
+      </div>
 
       <py-list id="myList"></py-list>
       <py-repl id="my-repl" auto-generate="true"> </py-repl>

--- a/pyscriptjs/src/components/pybox.ts
+++ b/pyscriptjs/src/components/pybox.ts
@@ -1,4 +1,4 @@
-import { getAttribute, addClasses } from '../utils';
+import { getAttribute, addClasses, showWarning } from '../utils';
 import { getLogger } from '../logger';
 
 const logger = getLogger('py-box');
@@ -20,6 +20,11 @@ export class PyBox extends HTMLElement {
     }
 
     connectedCallback() {
+        const deprecationMessage = (
+            '<p>The element &lt;py-box&gt; is deprecated, you should create a ' +
+            'div with "py-box" class name instead. For example: &lt;div class="py-box"&gt; '
+        )
+        showWarning(deprecationMessage)
         const mainDiv = document.createElement('div');
         addClasses(mainDiv, ['py-box']);
 

--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -44,7 +44,7 @@ export function make_PyButton(runtime: Runtime) {
         async connectedCallback() {
             const deprecationMessage = (
                 '<p>The element &lt;py-button&gt; is deprecated, create a function with your ' +
-                'inline code and use &lt;button py-click="function()" class="py-button" &gt; instead.</p>'
+                'inline code and use &lt;button py-click="function()" class="py-button"&gt; instead.</p>'
             )
             showWarning(deprecationMessage)
             ensureUniqueId(this);

--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -44,7 +44,7 @@ export function make_PyButton(runtime: Runtime) {
         async connectedCallback() {
             const deprecationMessage = (
                 '<p>The element &lt;py-button&gt; is deprecated, create a function with your ' +
-                'inline code and use &lt;button py-click="function()"&gt; instead.</p>'
+                'inline code and use &lt;button py-click="function()" class="py-button" &gt; instead.</p>'
             )
             showWarning(deprecationMessage)
             ensureUniqueId(this);

--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -1,4 +1,4 @@
-import { getAttribute, addClasses, htmlDecode, ensureUniqueId } from '../utils';
+import { getAttribute, addClasses, htmlDecode, ensureUniqueId, showWarning } from '../utils';
 import { getLogger } from '../logger';
 import type { Runtime } from '../runtime';
 
@@ -42,6 +42,11 @@ export function make_PyButton(runtime: Runtime) {
         }
 
         async connectedCallback() {
+            const deprecationMessage = (
+                '<p>The element &lt;py-button&gt; is deprecated, create a function with your ' +
+                'inline code and use &lt;button py-click="function()"&gt; instead.</p>'
+            )
+            showWarning(deprecationMessage)
             ensureUniqueId(this);
             this.code = htmlDecode(this.innerHTML) || '';
             this.mount_name = this.id.split('-').join('_');

--- a/pyscriptjs/src/components/pyinputbox.ts
+++ b/pyscriptjs/src/components/pyinputbox.ts
@@ -1,4 +1,4 @@
-import { getAttribute, addClasses, htmlDecode, ensureUniqueId } from '../utils';
+import { getAttribute, addClasses, htmlDecode, ensureUniqueId, showWarning } from '../utils';
 import { getLogger } from '../logger';
 import type { Runtime } from '../runtime';
 
@@ -21,6 +21,11 @@ export function make_PyInputBox(runtime: Runtime) {
         }
 
         async connectedCallback() {
+            const deprecationMessage = (
+                '<p>The element &lt;py-input&gt; is deprecated, create a function with your ' +
+                'inline code and use &lt;input py-input="function()"&gt; instead.</p>'
+            )
+            showWarning(deprecationMessage)
             ensureUniqueId(this);
             this.code = htmlDecode(this.innerHTML);
             this.mount_name = this.id.split('-').join('_');

--- a/pyscriptjs/src/components/pyinputbox.ts
+++ b/pyscriptjs/src/components/pyinputbox.ts
@@ -22,8 +22,8 @@ export function make_PyInputBox(runtime: Runtime) {
 
         async connectedCallback() {
             const deprecationMessage = (
-                '<p>The element &lt;py-input&gt; is deprecated, create a function with your ' +
-                'inline code and use &lt;input py-input="function()"&gt; instead.</p>'
+                '<p>The element &lt;py-input&gt; is deprecated, ' +
+                'use &lt;input class="py-input"&gt; instead.</p>'
             )
             showWarning(deprecationMessage)
             ensureUniqueId(this);

--- a/pyscriptjs/src/components/pytitle.ts
+++ b/pyscriptjs/src/components/pytitle.ts
@@ -1,4 +1,4 @@
-import { addClasses, htmlDecode } from '../utils';
+import { addClasses, htmlDecode, showWarning } from '../utils';
 
 export class PyTitle extends HTMLElement {
     widths: string[];
@@ -9,6 +9,10 @@ export class PyTitle extends HTMLElement {
     }
 
     connectedCallback() {
+        const deprecationMessage = (
+            '<p>The element &lt;py-title&gt; is deprecated, please use an  &lt;h1&gt; tag instead.</p>'
+        )
+        showWarning(deprecationMessage)
         this.label = htmlDecode(this.innerHTML);
         this.mount_name = this.id.split('-').join('_');
         this.innerHTML = '';

--- a/pyscriptjs/src/styles/pyscript_base.css
+++ b/pyscriptjs/src/styles/pyscript_base.css
@@ -293,6 +293,7 @@ input {
     border-color: rgba(37, 99, 235, var(--tw-border-opacity));
     border-width: 1px;
     border-radius: 0.25rem;
+    cursor: pointer;
 }
 
 .py-li-element p {

--- a/pyscriptjs/tests/integration/test_py_box.py
+++ b/pyscriptjs/tests/integration/test_py_box.py
@@ -16,3 +16,19 @@ class TestPyButton(PyScriptTest):
 
         assert len(pybox_element) == 2
         assert pybox_element[1].get_attribute("class") == "py-box-child"
+
+    def test_deprecated_element(self):
+        self.pyscript_run(
+            """
+            <py-box>
+            </py-box>
+        """
+        )
+        banner = self.page.locator(".py-warning")
+        banner_content = banner.inner_text()
+        expected = (
+            "The element <py-box> is deprecated, you should create a div "
+            'with "py-box" class name instead. For example: <div class="py-box">'
+        )
+
+        assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_py_button.py
+++ b/pyscriptjs/tests/integration/test_py_button.py
@@ -31,7 +31,7 @@ class TestPyButton(PyScriptTest):
         banner_content = banner.inner_text()
         expected = (
             "The element <py-button> is deprecated, create a function with your "
-            'inline code and use <button py-click="function()"> instead.'
+            'inline code and use <button py-click="function()" class="py-button"> instead.'
         )
 
         assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_py_button.py
+++ b/pyscriptjs/tests/integration/test_py_button.py
@@ -16,3 +16,22 @@ class TestPyButton(PyScriptTest):
         self.page.locator("text=my button").click()
         self.page.locator("text=my button").click()
         assert self.console.log.lines == [self.PY_COMPLETE, "clicked!", "clicked!"]
+
+    def test_deprecated_element(self):
+        self.pyscript_run(
+            """
+            <py-button label="my button">
+                import js
+                def on_click(evt):
+                    js.console.log('clicked!')
+            </py-button>
+        """
+        )
+        banner = self.page.locator(".py-warning")
+        banner_content = banner.inner_text()
+        expected = (
+            "The element <py-button> is deprecated, create a function with your "
+            'inline code and use <button py-click="function()"> instead.'
+        )
+
+        assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_py_inputbox.py
+++ b/pyscriptjs/tests/integration/test_py_inputbox.py
@@ -35,8 +35,8 @@ class TestPyInputBox(PyScriptTest):
         banner = self.page.locator(".py-warning")
         banner_content = banner.inner_text()
         expected = (
-            "The element <py-input> is deprecated, create a function with your "
-            'inline code and use <input py-input="function()"> instead.'
+            "The element <py-input> is deprecated, "
+            'use <input class="py-input"> instead.'
         )
 
         assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_py_inputbox.py
+++ b/pyscriptjs/tests/integration/test_py_inputbox.py
@@ -20,3 +20,23 @@ class TestPyInputBox(PyScriptTest):
         input.press("Enter")
 
         assert self.console.log.lines == [self.PY_COMPLETE, "Hello"]
+
+    def test_deprecated_element(self):
+        self.pyscript_run(
+            """
+            <py-inputbox label="my input">
+                import js
+                def on_keypress(evt):
+                    if evt.key == "Enter":
+                        js.console.log(evt.target.value)
+            </py-inputbox>
+            """
+        )
+        banner = self.page.locator(".py-warning")
+        banner_content = banner.inner_text()
+        expected = (
+            "The element <py-input> is deprecated, create a function with your "
+            'inline code and use <input py-input="function()"> instead.'
+        )
+
+        assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_py_title.py
+++ b/pyscriptjs/tests/integration/test_py_title.py
@@ -14,3 +14,17 @@ class TestPyTitle(PyScriptTest):
         # py_title will be none
         assert py_title
         assert py_title.text_content() == "Hello, World!"
+
+    def test_deprecated_element(self):
+        self.pyscript_run(
+            """
+            <py-title>Hello, world!</py-title>
+        """
+        )
+        banner = self.page.locator(".py-warning")
+        banner_content = banner.inner_text()
+        expected = (
+            "The element <py-title> is deprecated, please use an <h1> tag instead."
+        )
+
+        assert banner_content == expected

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -282,7 +282,7 @@ class TestExamples(PyScriptTest):
         self.page.locator("py-repl").type("import utils\ndisplay(utils.now())")
         self.page.locator("button").click()
         # Make sure the output is in the page
-        self.page.wait_for_selector("#output")
+        self.page.wait_for_selector("#my-repl-1-1")
         # utils.now returns current date time
         content = self.page.content()
         pattern = "\\d+/\\d+/\\d+, \\d+:\\d+:\\d+"  # e.g. 08/09/2022 15:57:32


### PR DESCRIPTION
This PR adds a deprecated banner to any of these elements, updates the examples and docs.

For one of the examples we were using `py-inputbox` to handle Enter press, I've tried to use `py-keydown` or `py-keypress` but couldn't get it to work because the event wasn't being sent to the function. What am I missing? 🤔 

For the docs I added a `(Deprecated)` before the explanation of each element mostly because this is a small section in the docs. Should we expand on what users should use?

Fixes: #897