### PR TITLE
Raise error if we get a non 200 status from fetch

### DIFF
--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -6,6 +6,13 @@ export class UserError extends Error {
   }
 }
 
+export class FetchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "FetchError"
+  }
+}
+
 export function _createAlertBanner(message: string, level: "error" | "warning" = "error", logMessage = true) {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   switch (`log-${level}-${logMessage}`) {

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -210,7 +210,9 @@ export class PyScriptApp {
             } catch (e) {
                 // Remove the loader so users can see the banner better
                 this.loader.remove()
-                if (e.name === "FetchError") {
+                // The 'TypeError' here happens when running pytest
+                // I'm not particularly happy with this solution.
+                if (e.name === "FetchError" || e.name === "TypeError") {
                     handleFetchError(<Error>e, fetchPaths[i]);
                 } else {
                     throw e

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -210,8 +210,11 @@ export class PyScriptApp {
             } catch (e) {
                 // Remove the loader so users can see the banner better
                 this.loader.remove()
-                //Should we still export full error contents to console?
-                handleFetchError(<Error>e, fetchPaths[i]);
+                if (e.name === "FetchError") {
+                    handleFetchError(<Error>e, fetchPaths[i]);
+                } else {
+                    throw e
+                }
             }
         }
         logger.info('All paths fetched');

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -110,6 +110,9 @@ export class PyodideRuntime extends Runtime {
             }
         }
         const response = await fetch(fetch_path);
+        if (response.status !== 200) {
+            throw new Error(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`);
+        }
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);
         pathArr.push(filename);

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -1,5 +1,6 @@
 import { Runtime } from './runtime';
 import { getLogger } from './logger';
+import { FetchError } from './exceptions'
 import type { loadPyodide as loadPyodideDeclaration, PyodideInterface, PyProxy } from 'pyodide';
 // eslint-disable-next-line
 // @ts-ignore
@@ -111,7 +112,7 @@ export class PyodideRuntime extends Runtime {
         }
         const response = await fetch(fetch_path);
         if (response.status !== 200) {
-            throw new Error(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`);
+            throw new FetchError(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`);
         }
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);

--- a/pyscriptjs/tests/integration/test_py_config.py
+++ b/pyscriptjs/tests/integration/test_py_config.py
@@ -244,22 +244,31 @@ class TestConfig(PyScriptTest):
             """,
             wait_for_pyscript=False,
         )
-        errorContent = """PyScript: Access to local files
+
+        # This is expected if running pytest with --dev flag
+        localErrorContent = """PyScript: Access to local files
         (using "Paths:" in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files."""
 
+        # This is expected if running a live server
+        serverErrorContent = (
+        "Loading from file <u>./f.py</u> failed with error 404 (File not Found). "
+        "Are your filename and path are correct?"
+        )
+
         inner_html = self.page.locator(".py-error").inner_html()
-        assert errorContent in inner_html
-        assert "Failed to load resource: net::ERR_FAILED" in self.console.error.lines
+        assert localErrorContent in inner_html or serverErrorContent in inner_html
+        assert "Failed to load resource" in self.console.error.lines[0]
         assert (
-            "Caught an error in fetchPaths:\r\n TypeError: Failed to fetch"
-            in self.console.warning.lines
+            "Caught an error in fetchPaths"
+            in self.console.warning.lines[0]
         )
         with pytest.raises(JsErrors) as exc:
             self.check_js_errors()
 
-        assert errorContent in str(exc.value)
+        received_error_msg = str(exc.value)
+        assert localErrorContent in received_error_msg or serverErrorContent in received_error_msg
 
     def test_paths_from_packages(self):
         self.writefile("utils/__init__.py", "")

--- a/pyscriptjs/tests/integration/test_py_config.py
+++ b/pyscriptjs/tests/integration/test_py_config.py
@@ -253,22 +253,22 @@ class TestConfig(PyScriptTest):
 
         # This is expected if running a live server
         serverErrorContent = (
-        "Loading from file <u>./f.py</u> failed with error 404 (File not Found). "
-        "Are your filename and path are correct?"
+            "Loading from file <u>./f.py</u> failed with error 404 (File not Found). "
+            "Are your filename and path are correct?"
         )
 
         inner_html = self.page.locator(".py-error").inner_html()
         assert localErrorContent in inner_html or serverErrorContent in inner_html
         assert "Failed to load resource" in self.console.error.lines[0]
-        assert (
-            "Caught an error in fetchPaths"
-            in self.console.warning.lines[0]
-        )
+        assert "Caught an error in fetchPaths" in self.console.warning.lines[0]
         with pytest.raises(JsErrors) as exc:
             self.check_js_errors()
 
         received_error_msg = str(exc.value)
-        assert localErrorContent in received_error_msg or serverErrorContent in received_error_msg
+        assert (
+            localErrorContent in received_error_msg
+            or serverErrorContent in received_error_msg
+        )
 
     def test_paths_from_packages(self):
         self.writefile("utils/__init__.py", "")


### PR DESCRIPTION
This PR adds a check to the status code of `fetch` and if we get any non 200 then we throw an error.

This was a bit of a quick hack, but now I am wondering if perhaps we should handle only any 300+ errors? 🤔  If we are getting something is likely that we will always get a 200 right? 

Fixes: #934