### PR TITLE
WIP: Fix Typescript errors in strict and eslint warnings

### DIFF
--- a/pyscriptjs/.eslintrc.js
+++ b/pyscriptjs/.eslintrc.js
@@ -29,5 +29,6 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'warn',
         '@typescript-eslint/restrict-plus-operands': 'warn',
         '@typescript-eslint/no-empty-function': 'warn',
+        '@typescript-eslint/no-unnecessary-type-assertion': "off"
     },
 };

--- a/pyscriptjs/src/components/pybox.ts
+++ b/pyscriptjs/src/components/pybox.ts
@@ -27,7 +27,7 @@ export class PyBox extends HTMLElement {
         // meaning that we end up with 2 editors, if there's a <py-repl> inside the <py-box>
         // so, if we have more than 2 children with the cm-editor class, we remove one of them
         while (this.childNodes.length > 0) {
-            if (this.firstChild.nodeName == 'PY-REPL') {
+            if (this.firstChild && this.firstChild?.nodeName == 'PY-REPL') {
                 // in this case we need to remove the child and create a new one from scratch
                 const replDiv = document.createElement('div');
                 // we need to put the new repl inside a div so that if the repl has auto-generate true
@@ -36,10 +36,10 @@ export class PyBox extends HTMLElement {
                 mainDiv.appendChild(replDiv);
                 this.firstChild.remove();
             } else {
-                if (this.firstChild.nodeName != '#text') {
-                    mainDiv.appendChild(this.firstChild);
+                if (this.firstChild?.nodeName != '#text') {
+                    mainDiv.appendChild(this.firstChild as Node);
                 } else {
-                    this.firstChild.remove();
+                    this.firstChild?.remove();
                 }
             }
         }

--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -43,12 +43,14 @@ export function make_PyButton(runtime: Runtime) {
 
         async connectedCallback() {
             ensureUniqueId(this);
-            this.code = htmlDecode(this.innerHTML) || '';
+            this.code = htmlDecode(this.innerHTML);
             this.mount_name = this.id.split('-').join('_');
             this.innerHTML = '';
 
             const mainDiv = document.createElement('button');
-            mainDiv.innerHTML = this.label;
+            if (this.label) {
+                mainDiv.innerHTML = this.label;
+            }
             addClasses(mainDiv, this.class);
 
             mainDiv.id = this.id;

--- a/pyscriptjs/src/components/pyloader.ts
+++ b/pyscriptjs/src/components/pyloader.ts
@@ -23,8 +23,8 @@ export class PyLoader extends HTMLElement {
         </div>
       </div>`;
         this.mount_name = this.id.split('-').join('_');
-        this.operation = document.getElementById('pyscript-operation');
-        this.details = document.getElementById('pyscript-operation-details');
+        this.operation = document.getElementById('pyscript-operation') as HTMLElement;
+        this.details = document.getElementById('pyscript-operation-details') as HTMLElement;
     }
 
     log(msg: string) {

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -66,9 +66,14 @@ export function make_PyRepl(runtime: Runtime) {
                 basicSetup,
                 languageConf.of(python()),
                 keymap.of([
+                    /* eslint-disable @typescript-eslint/ban-ts-comment */
+                    // @ts-ignore: spread-operator makes ts unhappy
                     ...defaultKeymap,
+                    // @ts-ignore: run expects Command type
                     { key: 'Ctrl-Enter', run: this.execute.bind(this) },
+                    // @ts-ignore: run expects Command type
                     { key: 'Shift-Enter', run: this.execute.bind(this) },
+                    /* eslint-enable @typescript-eslint/ban-ts-comment */
                 ]),
             ];
 

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -47,8 +47,9 @@ export function make_PyRepl(runtime: Runtime) {
             if (!this.hasAttribute('root')) {
                 this.setAttribute('root', this.id);
             }
-
-            const pySrc = htmlDecode(this.innerHTML).trim();
+            // eslint-disable-line  @typescript-eslint/no-unnecessary-type-assertion
+            const decodedInnerHTML = htmlDecode(this.innerHTML) as string
+            const pySrc = decodedInnerHTML.trim();
             this.innerHTML = '';
             this.editor = this.makeEditor(pySrc);
             const boxDiv = this.makeBoxDiv();
@@ -186,7 +187,7 @@ export function make_PyRepl(runtime: Runtime) {
             return this.editor.state.doc.toString();
         }
 
-        getOutputElement(): HTMLElement {
+        getOutputElement(): HTMLElement | undefined {
             const outputID = getAttribute(this, 'output');
             if (outputID !== null) {
                 const el = document.getElementById(outputID);

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -135,7 +135,7 @@ export function make_PyRepl(runtime: Runtime) {
             // XXX I'm sure there is a better way to embed svn into typescript
             runButton.innerHTML =
                 '<svg id="" style="height:20px;width:20px;vertical-align:-.125em;transform-origin:center;overflow:visible;color:green" viewBox="0 0 384 512" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg"><g transform="translate(192 256)" transform-origin="96 0"><g transform="translate(0,0) scale(1,1)"><path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" fill="currentColor" transform="translate(-192 -256)"></path></g></g></svg>';
-            runButton.addEventListener('click', this.execute.bind(this));
+            runButton.addEventListener('click', void this.execute.bind(this));
             return runButton;
         }
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -158,7 +158,7 @@ async function createElementsWithEventListeners(runtime: Runtime, pyAttribute: s
         } else {
             el.addEventListener(event, (): void => {
                 (async () => {
-                    await runtime.run(handlerCode);
+                    await runtime.run(handlerCode as string);
                 });
             });
         }

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -156,25 +156,12 @@ async function createElementsWithEventListeners(runtime: Runtime, pyAttribute: s
             `;
             await runtime.run(source);
         } else {
-            el.addEventListener(event, () => {
+            el.addEventListener(event, (): void => {
                 (async () => {
                     await runtime.run(handlerCode);
-                })();
+                });
             });
         }
-        // TODO: Should we actually map handlers in JS instead of Python?
-        // el.onclick = (evt: any) => {
-        //   console.log("click");
-        //   new Promise((resolve, reject) => {
-        //     setTimeout(() => {
-        //       console.log('Inside')
-        //     }, 300);
-        //   }).then(() => {
-        //     console.log("resolved")
-        //   });
-        //   // let handlerCode = el.getAttribute('py-onClick');
-        //   // pyodide.runPython(handlerCode);
-        // }
     }
 }
 

--- a/pyscriptjs/src/components/pytitle.ts
+++ b/pyscriptjs/src/components/pytitle.ts
@@ -9,7 +9,7 @@ export class PyTitle extends HTMLElement {
     }
 
     connectedCallback() {
-        this.label = htmlDecode(this.innerHTML);
+        this.label = htmlDecode(this.innerHTML) || "";
         this.mount_name = this.id.split('-').join('_');
         this.innerHTML = '';
 

--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -1,5 +1,5 @@
 import type { Runtime } from '../runtime';
-import type { PyProxy } from 'pyodide';
+import type { PyProxy } from '../types';
 import { getLogger } from '../logger';
 
 const logger = getLogger('py-register-widget');
@@ -13,7 +13,7 @@ function createWidget(runtime: Runtime, name: string, code: string, klass: strin
         klass: string = klass;
         code: string = code;
         proxy: PyProxy;
-        proxyClass: any;
+        proxyClass: PyProxy;
 
         constructor() {
             super();
@@ -27,8 +27,10 @@ function createWidget(runtime: Runtime, name: string, code: string, klass: strin
 
         async connectedCallback() {
             await runtime.runButDontRaise(this.code);
+            /* eslint-disable @typescript-eslint/no-unsafe-assignment */
             this.proxyClass = runtime.globals.get(this.klass);
             this.proxy = this.proxyClass(this);
+            /* eslint-enable @typescript-eslint/no-unsafe-assignment */
             this.proxy.connect();
             this.registerWidget();
         }

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -42,7 +42,7 @@ export function _createAlertBanner(message: string, level: "error" | "warning" =
 * the user what went wrong. Note that the error will still stop execution,
 * any other errors we will simply throw them and no banner will be shown.
 */
-export function withUserErrorHandler(fn) {
+export function withUserErrorHandler(fn: () => void) {
   try {
     return fn();
   } catch (error: unknown) {

--- a/pyscriptjs/src/logger.ts
+++ b/pyscriptjs/src/logger.ts
@@ -45,11 +45,13 @@ function _makeLogger(prefix: string): Logger {
     prefix = '[' + prefix + '] ';
 
     function make(level: string) {
+        /* eslint-disable */
         const out_fn = console[level].bind(console);
         function fn(fmt: string, ...args: unknown[]) {
             out_fn(prefix + fmt, ...args);
         }
         return fn;
+        /* eslint-enable */
     }
 
     // 'log' is intentionally omitted

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -3,7 +3,8 @@ import './styles/pyscript_base.css';
 import { loadConfigFromElement } from './pyconfig';
 import type { AppConfig } from './pyconfig';
 import type { Runtime } from './runtime';
-import { type Plugin, PluginManager } from './plugin';
+import type { PyScript } from "./types"
+import { PluginManager } from './plugin';
 import { make_PyScript, initHandlers, mountElements } from './components/pyscript';
 import { PyLoader } from './components/pyloader';
 import { PyodideRuntime } from './pyodide';
@@ -62,7 +63,7 @@ export class PyScriptApp {
     config: AppConfig;
     loader: PyLoader;
     runtime: Runtime;
-    PyScript: any; // XXX would be nice to have a more precise type for the class itself
+    PyScript: PyScript;
     plugins: PluginManager;
     _stdioMultiplexer: StdioMultiplexer;
 

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -106,7 +106,7 @@ export class PyScriptApp {
                 'going to be parsed, all the others will be ignored',
             );
         }
-        this.config = loadConfigFromElement(el);
+        this.config = loadConfigFromElement(el as Element);
         logger.info('config loaded:\n' + JSON.stringify(this.config, null, 2));
     }
 
@@ -122,7 +122,7 @@ export class PyScriptApp {
     // lifecycle (4)
     loadRuntime() {
         logger.info('Initializing runtime');
-        if (this.config.runtimes.length == 0) {
+        if (this.config.runtimes?.length === 0 || !this.config.runtimes) {
             throw new UserError('Fatal error: config.runtimes is empty');
         }
 
@@ -244,12 +244,15 @@ export class PyScriptApp {
         // inside py-script. It's also unclear whether we want to wait or not
         // (or maybe only wait only if we do an actual 'import'?)
         for (const node of document.querySelectorAll("script[type='importmap']")) {
-            const importmap: ImportMapType = (() => {
-                try {
-                    return JSON.parse(node.textContent) as ImportMapType;
-                } catch {
-                    return null;
+            const importmap: ImportMapType | null = (() => {
+                if (node.textContent) {
+                    try {
+                        return JSON.parse(node.textContent) as ImportMapType;
+                    } catch {
+                        return null;
+                    }
                 }
+                return null;
             })();
 
             if (importmap?.imports == null) continue;

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -3,7 +3,6 @@ import './styles/pyscript_base.css';
 import { loadConfigFromElement } from './pyconfig';
 import type { AppConfig } from './pyconfig';
 import type { Runtime } from './runtime';
-import type { PyScript } from "./types"
 import { PluginManager } from './plugin';
 import { make_PyScript, initHandlers, mountElements } from './components/pyscript';
 import { PyLoader } from './components/pyloader';
@@ -63,7 +62,7 @@ export class PyScriptApp {
     config: AppConfig;
     loader: PyLoader;
     runtime: Runtime;
-    PyScript: PyScript;
+    PyScript: any;
     plugins: PluginManager;
     _stdioMultiplexer: StdioMultiplexer;
 
@@ -222,7 +221,7 @@ export class PyScriptApp {
     executeScripts(runtime: Runtime) {
         void this.register_importmap(runtime);
         this.PyScript = make_PyScript(runtime);
-        customElements.define('py-script', this.PyScript);
+        customElements.define('py-script', this.PyScript as CustomElementConstructor);
     }
 
     // ================= registraton API ====================

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -1,7 +1,7 @@
-import type { PyScriptApp } from './main';
 import type { AppConfig } from './pyconfig';
 import type { Runtime } from './runtime';
 
+/* eslint-disable */
 export class Plugin {
 
     /** Validate the configuration of the plugin and handle default values.
@@ -40,7 +40,7 @@ export class Plugin {
     afterSetup(runtime: Runtime) {
     }
 }
-
+/* eslint-disable */
 
 export class PluginManager {
     _plugins: Plugin[];

--- a/pyscriptjs/src/plugins/fetch.ts
+++ b/pyscriptjs/src/plugins/fetch.ts
@@ -28,7 +28,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
         {
             fetchPaths.push(from);
             const filename = to_file || from.split('/').pop();
-            if (filename === '') {
+            if (!filename || filename === '') {
                 throw new UserError(`Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`);
             }
             else {

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -6,7 +6,7 @@ import { UserError } from "./exceptions"
 
 const logger = getLogger('py-config');
 
-export interface AppConfig extends Record<string, any> {
+export interface AppConfig extends Record<string, any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     name?: string;
     description?: string;
     version?: string;
@@ -21,6 +21,7 @@ export interface AppConfig extends Record<string, any> {
     fetch?: FetchConfig[];
     plugins?: string[];
     pyscript?: PyScriptMetadata;
+    terminal?: string | boolean;
 }
 
 export type FetchConfig = {

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -95,9 +95,12 @@ function extractFromSrc(el: Element, configType: string) {
 }
 
 function extractFromInline(el: Element, configType: string) {
-    if (el.innerHTML !== '') {
+    if (el.innerHTML && el.innerHTML !== '') {
         logger.info('loading <py-config> content');
-        return validateConfig(htmlDecode(el.innerHTML), configType);
+        const decodedInnerHTML = htmlDecode(el.innerHTML)
+        if (decodedInnerHTML) {
+            return validateConfig(decodedInnerHTML, configType);
+        }
     }
     return {};
 }
@@ -153,14 +156,14 @@ function parseConfig(configText: string, configType = 'toml') {
             }
             config = toml.parse(configText);
         } catch (err) {
-            const errMessage: string = err.toString();
+            const errMessage: string = (err as Error).toString();
             throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`);
         }
     } else if (configType === 'json') {
         try {
             config = JSON.parse(configText);
         } catch (err) {
-            const errMessage: string = err.toString();
+            const errMessage: string = (err as Error).toString();
             throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`);
         }
     } else {
@@ -195,7 +198,7 @@ function validateConfig(configText: string, configType = 'toml') {
                     finalConfig[item] = [];
                     const fetchList = config[item] as FetchConfig[];
                     fetchList.forEach(function (eachFetch: FetchConfig) {
-                        const eachFetchConfig: FetchConfig = {};
+                        const eachFetchConfig = {} as FetchConfig;
                         for (const eachFetchConfigParam in eachFetch) {
                             const targetType = eachFetchConfigParam === 'files' ? 'array' : 'string';
                             if (validateParamInConfig(eachFetchConfigParam, targetType, eachFetch)) {

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -113,9 +113,13 @@ export class PyodideRuntime extends Runtime {
         const response = await fetch(fetch_path);
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);
-        pathArr.push(filename);
-        const stream = this.interpreter.FS.open(pathArr.join('/'), 'w');
-        this.interpreter.FS.write(stream, data, 0, data.length, 0);
-        this.interpreter.FS.close(stream);
+        if (filename) {
+            pathArr.push(filename);
+            const stream = this.interpreter.FS.open(pathArr.join('/'), 'w');
+            this.interpreter.FS.write(stream, data, 0, data.length, 0);
+            this.interpreter.FS.close(stream);
+        } else {
+            throw new Error(`Filename is undefined but shouldn't be. Path passed: ${path}`)
+        }
     }
 }

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -1,6 +1,7 @@
 import { Runtime } from './runtime';
 import { getLogger } from './logger';
-import type { loadPyodide as loadPyodideDeclaration, PyodideInterface, PyProxy } from 'pyodide';
+import type { loadPyodide as loadPyodideDeclaration, PyodideInterface } from 'pyodide';
+import type { PyProxy } from "./types"
 // eslint-disable-next-line
 // @ts-ignore
 import pyscript from './python/pyscript.py';

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -1,7 +1,7 @@
 import { Runtime } from './runtime';
 import { getLogger } from './logger';
-import type { loadPyodide as loadPyodideDeclaration, PyodideInterface } from 'pyodide';
-import type { PyProxy } from "./types"
+import type { loadPyodide as loadPyodideDeclaration } from 'pyodide';
+import type { PyProxy, PyodideInterface } from "./types"
 // eslint-disable-next-line
 // @ts-ignore
 import pyscript from './python/pyscript.py';
@@ -64,7 +64,7 @@ export class PyodideRuntime extends Runtime {
             fullStdLib: false,
         });
 
-        this.globals = this.interpreter.globals;
+        this.globals = this.interpreter.globals as PyProxy;
 
         // XXX: ideally, we should load micropip only if we actually need it
         await this.loadPackage('micropip');

--- a/pyscriptjs/src/runtime.ts
+++ b/pyscriptjs/src/runtime.ts
@@ -1,5 +1,6 @@
 import type { AppConfig } from './pyconfig';
-import type { PyodideInterface, PyProxy } from 'pyodide';
+import type { PyodideInterface } from 'pyodide';
+import type { PyProxy } from "./types"
 import { getLogger } from './logger';
 
 const logger = getLogger('pyscript/runtime');

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -9,11 +9,6 @@ export declare interface PyProxy extends PyProxy  {
   set(id: string, proxy: PyProxyClass): void;
 }
 
-
-export declare interface PyScript extends HTMLElement {
-  getPySrc(): Promise<string>
-}
-
 export declare type Display = {
   (obj: any): void;
   callKwargs(obj: any, kwargs: object): void;

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -15,7 +15,7 @@ export declare type Display = {
 }
 
 export declare type CurrentDisplayTarget = {
-  (targetId: string): void;
+  (targetId?: string): void;
 }
 
 type Path = {

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -1,13 +1,23 @@
 import type { PyProxy, PyProxyClass } from "pyodide"
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 export declare type PyProxy = PyProxy & {
   connect(): void;
-  get(value: string): PyProxyClass;
+  get(value: string): function | object;
   set(id: string, proxy: PyProxyClass): void;
 }
 
 
 export declare interface PyScript extends HTMLElement {
-  getPySrc(): Promise<strin>
+  getPySrc(): Promise<string>
+}
+
+export declare type Display = {
+  (obj: any): void;
+  callKwargs(obj: any, kwargs: object): void;
+}
+
+export declare type CurrentDisplayTarget = {
+  (targetId: string): void;
 }

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -6,3 +6,8 @@ export declare type PyProxy = PyProxy & {
   get(value: string): PyProxyClass;
   set(id: string, proxy: PyProxyClass): void;
 }
+
+
+export declare interface PyScript extends HTMLElement {
+  getPySrc(): Promise<strin>
+}

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -1,0 +1,8 @@
+import type { PyProxy, PyProxyClass } from "pyodide"
+
+
+export declare type PyProxy = PyProxy & {
+  connect(): void;
+  get(value: string): PyProxyClass;
+  set(id: string, proxy: PyProxyClass): void;
+}

--- a/pyscriptjs/src/types.d.ts
+++ b/pyscriptjs/src/types.d.ts
@@ -1,8 +1,9 @@
-import type { PyProxy, PyProxyClass } from "pyodide"
+import type { PyProxy, PyProxyClass, PyodideInterface } from "pyodide"
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export declare type PyProxy = PyProxy & {
+export declare interface PyProxy extends PyProxy  {
+  (...args: any[]): any;
   connect(): void;
   get(value: string): function | object;
   set(id: string, proxy: PyProxyClass): void;
@@ -20,4 +21,22 @@ export declare type Display = {
 
 export declare type CurrentDisplayTarget = {
   (targetId: string): void;
+}
+
+type Path = {
+  exists: boolean;
+  parentExists: boolean
+}
+
+export declare type FileSystem = {
+  (path: string): Promise<string>;
+  analyzePath(path: string): Path;
+  mkdir(path: string): void;
+  write(stream: object, buffer: Uint8Array, offset: number, length: number,  position: number): void;
+  close(stream: any): void;
+  open(path: string, mode: string): object;
+}
+
+export declare interface PyodideInterface extends PyodideInterface {
+  FS: FileSystem
 }

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -23,17 +23,17 @@ export function htmlDecode(input: string): string | null {
 
 export function ltrim(code: string): string {
     const lines = code.split('\n');
-    if (lines.length == 0) return code;
+    if (lines.length === 0) return code;
 
     const lengths = lines
         .filter(line => line.trim().length != 0)
         .map(line => {
             return line.match(/^\s*/)?.pop()?.length;
-        });
+        }) as number[];
 
     const k = Math.min(...lengths);
 
-    return k != 0 ? lines.map(line => line.substring(k)).join('\n') : code;
+    return k !== 0 ? lines.map(line => line.substring(k)).join('\n') : code;
 }
 
 let _uniqueIdCounter = 0;

--- a/pyscriptjs/tsconfig.json
+++ b/pyscriptjs/tsconfig.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strictBindCallApply": true,
+    "strictPropertyInitialization" : false,
     "lib": [
       "es2017",
       "dom",

--- a/pyscriptjs/tsconfig.json
+++ b/pyscriptjs/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "strictBindCallApply": true,
     "lib": [
       "es2017",
       "dom",


### PR DESCRIPTION
I'm opening this as a WIP since we will chat as a team about typing. This PR contains the work so far on addressing eslint warnings and TypeScript errors in `--strict` mode. 

With this PR we are down to 27 typescript errors in strict and 15 eslint warnings. You will probably notice some funky things happening in the PR and I also dislike the usage of `as blah` but for some reason, typescript isn't getting the type properly otherwise.

A lot of the typescript errors come from when we do things like `getAttribute`, `getElementById` etc since these can always return a thing or null. In a lot of cases we can just assume that the element is there, for others we might need to guard against null before setting it to a variable.

I touched some of the code but then decided not to before we have the chat 😄 