### PR TITLE
Handle non-200 code when fetch py-script src

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -2,7 +2,7 @@ import { htmlDecode, ensureUniqueId } from '../utils';
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
-import { UserError, _createAlertBanner } from '../exceptions';
+import { FetchError, _createAlertBanner } from '../exceptions';
 
 const logger = getLogger('py-script');
 
@@ -25,7 +25,7 @@ export function make_PyScript(runtime: Runtime) {
                         `${response.status} ${response.statusText}`
                     );
                     _createAlertBanner(errorMessage)
-                    throw new UserError(errorMessage);
+                    throw new FetchError(errorMessage);
                 }
                 return await response.text();
             } else {

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -24,7 +24,8 @@ export function make_PyScript(runtime: Runtime) {
                         `Failed to fetch '${url}' - Reason: ` +
                         `${response.status} ${response.statusText}`
                     );
-                    _createAlertBanner(errorMessage)
+                    _createAlertBanner(errorMessage);
+                    this.innerHTML = '';
                     throw new FetchError(errorMessage);
                 }
                 return await response.text();

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -2,6 +2,7 @@ import { htmlDecode, ensureUniqueId } from '../utils';
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
+import { UserError, _createAlertBanner } from '../exceptions';
 
 const logger = getLogger('py-script');
 
@@ -16,11 +17,16 @@ export function make_PyScript(runtime: Runtime) {
 
         async getPySrc(): Promise<string> {
             if (this.hasAttribute('src')) {
-                // XXX: what happens if the fetch() fails?
-                // We should handle the case correctly, but in my defense
-                // this case was broken also before the refactoring. FIXME!
                 const url = this.getAttribute('src');
                 const response = await fetch(url);
+                if (response.status !== 200) {
+                    const errorMessage = (
+                        `Failed to fetch '${url}' - Reason: ` +
+                        `${response.status} ${response.statusText}`
+                    );
+                    _createAlertBanner(errorMessage)
+                    throw new UserError(errorMessage);
+                }
                 return await response.text();
             } else {
                 return htmlDecode(this.innerHTML);

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -144,3 +144,6 @@ class TestBasic(PyScriptTest):
 
         error_msg = str(exc.value)
         assert "Failed to fetch" in error_msg
+
+        pyscript_tag = self.page.locator("py-script")
+        assert pyscript_tag.inner_html() == ""

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -1,5 +1,6 @@
 import pytest
-from .support import PyScriptTest, JsErrors
+
+from .support import JsErrors, PyScriptTest
 
 
 class TestBasic(PyScriptTest):
@@ -127,7 +128,7 @@ class TestBasic(PyScriptTest):
             self.PY_COMPLETE,
             "hello from foo",
         ]
-    
+
     def test_py_script_src_not_found(self):
         self.pyscript_run(
             """
@@ -140,7 +141,6 @@ class TestBasic(PyScriptTest):
         assert "Failed to load resource" in self.console.error.lines[0]
         with pytest.raises(JsErrors) as exc:
             self.check_js_errors()
-        
+
         error_msg = str(exc.value)
         assert "Failed to fetch" in error_msg
-

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -1,4 +1,5 @@
-from .support import PyScriptTest
+import pytest
+from .support import PyScriptTest, JsErrors
 
 
 class TestBasic(PyScriptTest):
@@ -126,3 +127,20 @@ class TestBasic(PyScriptTest):
             self.PY_COMPLETE,
             "hello from foo",
         ]
+    
+    def test_py_script_src_not_found(self):
+        self.pyscript_run(
+            """
+            <py-script src="foo.py"></py-script>
+            """
+        )
+        assert self.console.log.lines == [
+            self.PY_COMPLETE,
+        ]
+        assert "Failed to load resource" in self.console.error.lines[0]
+        with pytest.raises(JsErrors) as exc:
+            self.check_js_errors()
+        
+        error_msg = str(exc.value)
+        assert "Failed to fetch" in error_msg
+


### PR DESCRIPTION
I noticed the comment about not handling errors when we fetch the src from py-script, this PR handles any non-200 status code, creates a banner and raises a FetchError