### PR TITLE
Zip the build folder and add it to release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -45,11 +45,8 @@ jobs:
         -   name: Setup Environment
             run: make setup
 
-        -   name: Test
+        -   name: Build and Test
             run: make test
-
-        -   name: Build
-            run: make build
 
         -   name: Zip build folder
             run: zip -r -q ./build.zip ./build

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -45,8 +45,14 @@ jobs:
         -   name: Setup Environment
             run: make setup
 
-        -   name: Build and Test
+        -   name: Test
             run: make test
+
+        -   name: Build
+            run: make build
+
+        -   name: Zip build folder
+            run: zip -r -q ./build.zip ./build
 
         -   name: Prepare Release
             uses: softprops/action-gh-release@v1
@@ -54,3 +60,4 @@ jobs:
                 draft: true
                 prerelease: true
                 generate_release_notes: true
+                files: ./build.zip


### PR DESCRIPTION
I used `act` to check if this would run successfully (using dry-run) and got a green checkmark, hopefully it will work 😬 

With this PR the `prepare-release` action should zip the `build` folder and include it in the release. There's also an action to zip files/folders, but assuming that `zip` is included in the ubuntu instance, the command should work.

Fixes: #851