### PR TITLE
Fix deprecated message and tests

### DIFF
--- a/pyscriptjs/src/components/pybox.ts
+++ b/pyscriptjs/src/components/pybox.ts
@@ -21,8 +21,8 @@ export class PyBox extends HTMLElement {
 
     connectedCallback() {
         const deprecationMessage = (
-            '<p>The element &lt;py-box&gt; is deprecated, you should create a ' +
-            'div with "py-box" class name instead. For example: &lt;div class="py-box"&gt; '
+            'The element <py-box> is deprecated, you should create a ' +
+            'div with "py-box" class name instead. For example: <div class="py-box">'
         )
         createDeprecationWarning(deprecationMessage, "py-box")
         const mainDiv = document.createElement('div');

--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -43,8 +43,8 @@ export function make_PyButton(runtime: Runtime) {
 
         async connectedCallback() {
             const deprecationMessage = (
-                '<p>The element &lt;py-button&gt; is deprecated, create a function with your ' +
-                'inline code and use &lt;button py-click="function()" class="py-button"&gt; instead.</p>'
+                'The element <py-button> is deprecated, create a function with your ' +
+                'inline code and use <button py-click="function()" class="py-button"> instead.'
             )
             createDeprecationWarning(deprecationMessage, "py-button")
 

--- a/pyscriptjs/src/components/pyinputbox.ts
+++ b/pyscriptjs/src/components/pyinputbox.ts
@@ -22,8 +22,8 @@ export function make_PyInputBox(runtime: Runtime) {
 
         async connectedCallback() {
             const deprecationMessage = (
-                '<p>The element &lt;py-input&gt; is deprecated, ' +
-                'use &lt;input class="py-input"&gt; instead.</p>'
+                'The element <py-input> is deprecated, ' +
+                'use <input class="py-input"> instead.'
             )
             createDeprecationWarning(deprecationMessage, "py-input")
             ensureUniqueId(this);

--- a/pyscriptjs/src/components/pytitle.ts
+++ b/pyscriptjs/src/components/pytitle.ts
@@ -10,7 +10,7 @@ export class PyTitle extends HTMLElement {
 
     connectedCallback() {
         const deprecationMessage = (
-            '<p>The element &lt;py-title&gt; is deprecated, please use an  &lt;h1&gt; tag instead.</p>'
+            'The element <py-title> is deprecated, please use an <h1> tag instead.'
         )
         createDeprecationWarning(deprecationMessage, "py-title")
         this.label = htmlDecode(this.innerHTML);


### PR DESCRIPTION
When working on #924  I forgot to change the deprecated message, since we are sending text by default, the escaped characters were added as is and that broke CI.

This PR fixes the deprecation message

cc @madhur-tandon 