### PR TITLE
Add div id to target in the  display so examples get displayed in the right tag

### DIFF
--- a/examples/altair.html
+++ b/examples/altair.html
@@ -15,7 +15,7 @@
           "vega_datasets"
         ]
       </py-config>
-      <py-script output="altair">
+      <py-script>
 import altair as alt
 from vega_datasets import data
 

--- a/examples/altair.html
+++ b/examples/altair.html
@@ -56,7 +56,7 @@ display(alt.vconcat(
 ).resolve_legend(
     color="independent",
     size="independent"
-))
+), target="altair")
       </py-script>
     </body>
 </html>

--- a/examples/folium.html
+++ b/examples/folium.html
@@ -16,7 +16,7 @@
         ]
       </py-config>
 
-      <py-script output="folium">
+      <py-script>
 import folium
 import json
 import pandas as pd

--- a/examples/folium.html
+++ b/examples/folium.html
@@ -47,7 +47,7 @@ folium.Choropleth(
 
 folium.LayerControl().add_to(m)
 
-display(m)
+display(m, target="folium")
       </py-script>
     </body>
 </html>

--- a/examples/matplotlib.html
+++ b/examples/matplotlib.html
@@ -48,7 +48,7 @@ tpc = ax1.tripcolor(triang, z, shading='flat')
 fig1.colorbar(tpc)
 ax1.set_title('tripcolor of Delaunay triangulation, flat shading')
 
-display(fig1)
+display(fig1, target="mpl")
       </py-script>
     </body>
 </html>

--- a/examples/matplotlib.html
+++ b/examples/matplotlib.html
@@ -15,7 +15,7 @@
         ]
       </py-config>
 
-      <py-script output="mpl">
+      <py-script>
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 import numpy as np


### PR DESCRIPTION
Some examples had a div with an id and we were rendering things onto this div, in some cases (like Altair) this div had a style of `width: 100%; height:100%` which made the example render way below the viewport.

This small PR adds `target=` to the display function so they get displayed in the top level div (we could also remove them, but maybe it's a good example of how to use display? 🤔 )