### PR TITLE
Cleanup `runtime.run` awaits

### DIFF
--- a/pyscriptjs/src/components/pybutton.ts
+++ b/pyscriptjs/src/components/pybutton.ts
@@ -41,7 +41,7 @@ export function make_PyButton(runtime: Runtime) {
             }
         }
 
-        async connectedCallback() {
+        connectedCallback() {
             const deprecationMessage = (
                 'The element <py-button> is deprecated, create a function with your ' +
                 'inline code and use <button py-click="function()" class="py-button"> instead.'
@@ -76,8 +76,8 @@ export function make_PyButton(runtime: Runtime) {
 
             // now that we appended and the element is attached, lets connect with the event handlers
             // defined for this widget
-            await runtime.runButDontRaise(this.code);
-            await runtime.runButDontRaise(registrationCode);
+            runtime.runButDontRaise(this.code);
+            runtime.runButDontRaise(registrationCode);
             logger.debug('py-button connected');
         }
     }

--- a/pyscriptjs/src/components/pyinputbox.ts
+++ b/pyscriptjs/src/components/pyinputbox.ts
@@ -20,7 +20,7 @@ export function make_PyInputBox(runtime: Runtime) {
             }
         }
 
-        async connectedCallback() {
+        connectedCallback() {
             const deprecationMessage = (
                 'The element <py-input> is deprecated, ' +
                 'use <input class="py-input"> instead.'
@@ -50,8 +50,8 @@ export function make_PyInputBox(runtime: Runtime) {
                 registrationCode += `\n${this.mount_name}.element.addEventListener('keypress', create_proxy(on_keypress_${this.mount_name}))`;
             }
 
-            await runtime.runButDontRaise(this.code);
-            await runtime.runButDontRaise(registrationCode);
+            runtime.runButDontRaise(this.code);
+            runtime.runButDontRaise(registrationCode);
             logger.debug('py-inputbox connected');
         }
     }

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -134,15 +134,15 @@ const pyAttributeToEvent: Map<string, string> = new Map<string, string>([
 ]);
 
 /** Initialize all elements with py-* handlers attributes  */
-export async function initHandlers(runtime: Runtime) {
+export function initHandlers(runtime: Runtime) {
     logger.debug('Initializing py-* event handlers...');
     for (const pyAttribute of pyAttributeToEvent.keys()) {
-        await createElementsWithEventListeners(runtime, pyAttribute);
+        createElementsWithEventListeners(runtime, pyAttribute);
     }
 }
 
 /** Initializes an element with the given py-on* attribute and its handler */
-async function createElementsWithEventListeners(runtime: Runtime, pyAttribute: string): Promise<void> {
+function createElementsWithEventListeners(runtime: Runtime, pyAttribute: string) {
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll(`[${pyAttribute}]`);
     for (const el of matches) {
         if (el.id.length === 0) {
@@ -161,12 +161,10 @@ async function createElementsWithEventListeners(runtime: Runtime, pyAttribute: s
             from pyodide.ffi import create_proxy
             Element("${el.id}").element.addEventListener("${event}",  create_proxy(${handlerCode}))
             `;
-            await runtime.run(source);
+            runtime.run(source);
         } else {
             el.addEventListener(event, () => {
-                (async () => {
-                    await runtime.run(handlerCode);
-                })();
+                runtime.run(handlerCode);
             });
         }
         // TODO: Should we actually map handlers in JS instead of Python?
@@ -186,7 +184,7 @@ async function createElementsWithEventListeners(runtime: Runtime, pyAttribute: s
 }
 
 /** Mount all elements with attribute py-mount into the Python namespace */
-export async function mountElements(runtime: Runtime) {
+export function mountElements(runtime: Runtime) {
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[py-mount]');
     logger.info(`py-mount: found ${matches.length} elements`);
 
@@ -195,5 +193,5 @@ export async function mountElements(runtime: Runtime) {
         const mountName = el.getAttribute('py-mount') || el.id.split('-').join('_');
         source += `\n${mountName} = Element("${el.id}")`;
     }
-    await runtime.run(source);
+    runtime.run(source);
 }

--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -25,8 +25,8 @@ function createWidget(runtime: Runtime, name: string, code: string, klass: strin
             this.shadow.appendChild(this.wrapper);
         }
 
-        async connectedCallback() {
-            await runtime.runButDontRaise(this.code);
+        connectedCallback() {
+            runtime.runButDontRaise(this.code);
             this.proxyClass = runtime.globals.get(this.klass);
             this.proxy = this.proxyClass(this);
             this.proxy.connect();

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -176,7 +176,7 @@ export class PyScriptApp {
 
         this.logStatus('Setting up virtual environment...');
         await this.setupVirtualEnv(runtime);
-        await mountElements(runtime);
+        mountElements(runtime);
 
         // lifecycle (6.5)
         this.plugins.afterSetup(runtime);
@@ -188,7 +188,7 @@ export class PyScriptApp {
         // lifecycle (8)
         createCustomElements(runtime);
 
-        await initHandlers(runtime);
+        initHandlers(runtime);
 
         // NOTE: runtime message is used by integration tests to know that
         // pyscript initialization has complete. If you change it, you need to

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -70,7 +70,7 @@ export class PyodideRuntime extends Runtime {
         await this.loadPackage('micropip');
 
         logger.info('importing pyscript.py');
-        await this.run(pyscript as string);
+        this.run(pyscript as string);
 
         logger.info('pyodide loaded and initialized');
     }

--- a/pyscriptjs/tests/unit/pyodide.test.ts
+++ b/pyscriptjs/tests/unit/pyodide.test.ts
@@ -50,19 +50,19 @@ describe('PyodideRuntime', () => {
     });
 
     it('should check if runtime can run python code asynchronously', async () => {
-        expect(await runtime.run("2+3")).toBe(5);
+        expect(runtime.run("2+3")).toBe(5);
     });
 
     it('should capture stdout', async () => {
         stdio.reset();
-        await runtime.run("print('hello')");
+        runtime.run("print('hello')");
         expect(stdio.captured_stdout).toBe("hello\n");
     });
 
     it('should check if runtime is able to load a package', async () => {
         await runtime.loadPackage("numpy");
-        await runtime.run("import numpy as np");
-        await runtime.run("x = np.ones((10,))");
+        runtime.run("import numpy as np");
+        runtime.run("x = np.ones((10,))");
         expect(runtime.globals.get('x').toJs()).toBeInstanceOf(Float64Array);
     });
 


### PR DESCRIPTION
With the merge #928 (`runtime.run` is no longer async), I realize I missed several spots where we were still `await`ing it (as well as in one test). This allowed other functions to no longer be async (`createElementsWithEventListeners`, `mountElements`, `initHandlers`), which are adjusted as well.