### PR TITLE
Add error codes to our custom errors

### DIFF
--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -14,7 +14,7 @@ This reference guide contains the error codes you might find and a description o
 
 ## Fetch Errors
 
-These error codes are related to any exception raised when trying to fetch a resource. If, while trying to fetch a resource, we encounter a status code that is not 200, the error code will contain the HTTP status code and the `PY2` prefix. For example, if we encounter a 404 error, the error code will be `PY2404`.
+These error codes are related to any exception raised when trying to fetch a resource. If, while trying to fetch a resource, we encounter a status code that is not 200, the error code will contain the HTTP status code and the `PY0` prefix. For example, if we encounter a 404 error, the error code will be `P02404`.
 
 
 | Error Code | Description                                                  |

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -22,11 +22,8 @@ These error codes are related to any exception raised when trying to fetch a res
 | PY2000     | Generic fetch error, failed to fetch page from the server    |
 | PY2001     | Parameter supplied to fetch is invalid                       |
 | PY2002     | Name supplied when trying to fetch resource is invalid       |
-| PY2301     | The page was moved permanently                               |
 | PY2401     | You are not authorized to access this resource.              |
 | PY2403     | You are not allowed to access this resource.                 |
 | PY2404     | The page you are trying to fetch does not exist.             |
 | PY2500     | The server encountered an internal error.                    |
-| PY2502     | The server encountered an invalid response.                  |
 | PY2503     | The server is currently unavailable.                         |
-| PY2504     | The server did not respond in time.                          |

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -5,24 +5,28 @@ This reference guide contains the error codes you might find and a description o
 
 ## User Errors
 
-| Error code | Description | Recommendation |
-|------------|--------------------------------|----------------|
-| PY0001     | Feature is deprecated | Check the documentation for the feature you are using and see recommendations. |
+| Error code | Description                    | Recommendation     |
+|------------|--------------------------------|--------------------|
+| PY0001     | Feature is deprecated          | Check the documentation for the feature you are using and see recommendations. |
 | PY1000     | Invalid configuration supplied | Confirm that your `py-config` tag is using a valid `TOML` or `JSON` syntax and is using the correct configuration type. |
 
 
 
 ## Fetch Errors
 
-Fetch error codes will contain the HTTP status code returned by the server, together with the "PY2" prefix. For example, if the server returns a 404 error, the error code will be "PY2404".
+These error codes are related to any exception raised when trying to fetch a resource. If, while trying to fetch a resource, we encounter a status code that is not 200, the error code will contain the HTTP status code and the `PY2` prefix. For example, if we encounter a 404 error, the error code will be `PY2404`.
 
-| Error Code | Description |
-|------------|--------------------------------------------------|
-| PY2301     | The page was moved permanently |
-| PY2401     | You are not authorized to access this resource. |
-| PY2403     | You are not allowed to access this resource. |
-| PY2404     | The page you are trying to fetch does not exist. |
-| PY2500     | The server encountered an internal error. |
-| PY2502     | The server encountered an invalid response. |
-| PY2503     | The server is currently unavailable. |
-| PY2504     | The server did not respond in time. |
+
+| Error Code | Description                                                  |
+|------------|--------------------------------------------------------------|
+| PY2000     | Generic fetch error, failed to fetch page from the server    |
+| PY2001     | Parameter supplied to fetch is invalid                       |
+| PY2002     | Name supplied when trying to fetch resource is invalid       |
+| PY2301     | The page was moved permanently                               |
+| PY2401     | You are not authorized to access this resource.              |
+| PY2403     | You are not allowed to access this resource.                 |
+| PY2404     | The page you are trying to fetch does not exist.             |
+| PY2500     | The server encountered an internal error.                    |
+| PY2502     | The server encountered an invalid response.                  |
+| PY2503     | The server is currently unavailable.                         |
+| PY2504     | The server did not respond in time.                          |

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,4 +1,4 @@
-# Exceptions
+# Exceptions and error codes
 
 When creating pages with PyScript, you may encounter exceptions. Each handled exception will contain a specific code which will give you more information about it.
 This reference guide contains the error codes you might find and a description of each of them.
@@ -7,8 +7,8 @@ This reference guide contains the error codes you might find and a description o
 
 | Error code | Description                    | Recommendation     |
 |------------|--------------------------------|--------------------|
-| PY0001     | Feature is deprecated          | Check the documentation for the feature you are using and see recommendations. |
 | PY1000     | Invalid configuration supplied | Confirm that your `py-config` tag is using a valid `TOML` or `JSON` syntax and is using the correct configuration type. |
+| PY9000     | Top level await is deprecated  | Create a coroutine with your code and schedule it with `asyncio.ensure_future` or similar |
 
 
 
@@ -19,11 +19,10 @@ These error codes are related to any exception raised when trying to fetch a res
 
 | Error Code | Description                                                  |
 |------------|--------------------------------------------------------------|
-| PY2000     | Generic fetch error, failed to fetch page from the server    |
-| PY2001     | Parameter supplied to fetch is invalid                       |
-| PY2002     | Name supplied when trying to fetch resource is invalid       |
-| PY2401     | You are not authorized to access this resource.              |
-| PY2403     | You are not allowed to access this resource.                 |
-| PY2404     | The page you are trying to fetch does not exist.             |
-| PY2500     | The server encountered an internal error.                    |
-| PY2503     | The server is currently unavailable.                         |
+| PY0001     | Generic fetch error, failed to fetch page from the server    |
+| PY0002     | Name supplied when trying to fetch resource is invalid       |
+| PY0401     | You are not authorized to access this resource.              |
+| PY0403     | You are not allowed to access this resource.                 |
+| PY0404     | The page you are trying to fetch does not exist.             |
+| PY0500     | The server encountered an internal error.                    |
+| PY0503     | The server is currently unavailable.                         |

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,0 +1,28 @@
+# Exceptions
+
+When creating pages with PyScript, you may encounter exceptions. Each handled exception will contain a specific code which will give you more information about it.
+This reference guide contains the error codes you might find and a description of each of them.
+
+## User Errors
+
+| Error code | Description | Recommendation |
+|------------|--------------------------------|----------------|
+| PY0001     | Feature is deprecated | Check the documentation for the feature you are using and see recommendations. |
+| PY1000     | Invalid configuration supplied | Confirm that your `py-config` tag is using a valid `TOML` or `JSON` syntax and is using the correct configuration type. |
+
+
+
+## Fetch Errors
+
+Fetch error codes will contain the HTTP status code returned by the server, together with the "PY2" prefix. For example, if the server returns a 404 error, the error code will be "PY2404".
+
+| Error Code | Description |
+|------------|--------------------------------------------------|
+| PY2301     | The page was moved permanently |
+| PY2401     | You are not authorized to access this resource. |
+| PY2403     | You are not allowed to access this resource. |
+| PY2404     | The page you are trying to fetch does not exist. |
+| PY2500     | The server encountered an internal error. |
+| PY2502     | The server encountered an invalid response. |
+| PY2503     | The server is currently unavailable. |
+| PY2504     | The server did not respond in time. |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -38,6 +38,15 @@ API/*
 
 ```{toctree}
 ---
+maxdepth: 2
+glob:
+caption: Exceptions
+---
+exceptions
+```
+
+```{toctree}
+---
 maxdepth: 1
 caption: Miscellaneous
 ---

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -26,7 +26,7 @@ export function make_PyScript(runtime: Runtime) {
                     );
                     _createAlertBanner(errorMessage);
                     this.innerHTML = '';
-                    throw new FetchError(errorMessage, `PY2${response.status}`);
+                    throw new FetchError(`PY2${response.status}`, errorMessage);
                 }
                 return await response.text();
             } else {

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -1,8 +1,9 @@
-import { htmlDecode, ensureUniqueId, fetchIt } from '../utils';
+import { htmlDecode, ensureUniqueId } from '../utils';
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
-import { FetchError, _createAlertBanner } from '../exceptions';
+import { _createAlertBanner } from '../exceptions';
+import { robustFetch } from '../fetch';
 
 const logger = getLogger('py-script');
 
@@ -19,7 +20,7 @@ export function make_PyScript(runtime: Runtime) {
             if (this.hasAttribute('src')) {
                 const url = this.getAttribute('src');
                 try {
-                    const response = await fetchIt(url);
+                    const response = await robustFetch(url);
                     return await response.text();
                 } catch(e) {
                     _createAlertBanner(e.message);

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -26,7 +26,7 @@ export function make_PyScript(runtime: Runtime) {
                     );
                     _createAlertBanner(errorMessage);
                     this.innerHTML = '';
-                    throw new FetchError(errorMessage, `PY${response.status}`);
+                    throw new FetchError(errorMessage, `PY2${response.status}`);
                 }
                 return await response.text();
             } else {

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -1,4 +1,4 @@
-import { htmlDecode, ensureUniqueId } from '../utils';
+import { htmlDecode, ensureUniqueId, fetchIt } from '../utils';
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
@@ -18,17 +18,14 @@ export function make_PyScript(runtime: Runtime) {
         async getPySrc(): Promise<string> {
             if (this.hasAttribute('src')) {
                 const url = this.getAttribute('src');
-                const response = await fetch(url);
-                if (response.status !== 200) {
-                    const errorMessage = (
-                        `Failed to fetch '${url}' - Reason: ` +
-                        `${response.status} ${response.statusText}`
-                    );
-                    _createAlertBanner(errorMessage);
+                try {
+                    const response = await fetchIt(url);
+                    return await response.text();
+                } catch(e) {
+                    _createAlertBanner(e.message);
                     this.innerHTML = '';
-                    throw new FetchError(`PY2${response.status}`, errorMessage);
+                    throw e
                 }
-                return await response.text();
             } else {
                 return htmlDecode(this.innerHTML);
             }

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -26,7 +26,7 @@ export function make_PyScript(runtime: Runtime) {
                     );
                     _createAlertBanner(errorMessage);
                     this.innerHTML = '';
-                    throw new FetchError(errorMessage);
+                    throw new FetchError(errorMessage, `PY${response.status}`);
                 }
                 return await response.text();
             } else {

--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -1,7 +1,7 @@
 import type { Runtime } from '../runtime';
 import type { PyProxy } from 'pyodide';
 import { getLogger } from '../logger';
-import { fetchIt } from '../utils'
+import { robustFetch } from '../fetch';
 
 const logger = getLogger('py-register-widget');
 
@@ -93,7 +93,7 @@ export function make_PyWidget(runtime: Runtime) {
         }
 
         async getSourceFromFile(s: string): Promise<string> {
-            const response = await fetchIt(s);
+            const response = await robustFetch(s);
             return await response.text();
         }
     }

--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -1,6 +1,7 @@
 import type { Runtime } from '../runtime';
 import type { PyProxy } from 'pyodide';
 import { getLogger } from '../logger';
+import { fetchIt } from '../utils'
 
 const logger = getLogger('py-register-widget');
 
@@ -92,7 +93,7 @@ export function make_PyWidget(runtime: Runtime) {
         }
 
         async getSourceFromFile(s: string): Promise<string> {
-            const response = await fetch(s);
+            const response = await fetchIt(s);
             return await response.text();
         }
     }

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -3,9 +3,9 @@ const CLOSEBUTTON = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'
 type MessageType = "text" | "html";
 
 export enum ErrorCode {
-  GENERIC = "PY0000", // Use this only for dev then change to a more specific error code
-  BAD_CONFIG = "PY1000",
+  GENERIC = "PY0000", // Use this only for development then change to a more specific error code
   DEPRECATED = "PY0001",
+  BAD_CONFIG = "PY1000",
   FETCH_ERROR = "PY2000",
   FETCH_PARAMETER_ERROR = "PY2001",
   FETCH_NAME_ERROR = "PY2002",

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -10,14 +10,11 @@ export enum ErrorCode {
   FETCH_PARAMETER_ERROR = "PY2001",
   FETCH_NAME_ERROR = "PY2002",
   // Currently these are created depending on error code received from fetching
-  FETCH_MOVED_ERROR = "PY2301",
   FETCH_NOT_FOUND_ERROR = "PY2404",
   FETCH_UNAUTHORIZED_ERROR = "PY2401",
   FETCH_FORBIDDEN_ERROR = "PY2403",
   FETCH_SERVER_ERROR = "PY2500",
-  FETCH_INVALID_RESPONSE = "PY2502",
-  FETCH_TIMEOUT_ERROR = "PY2503",
-  FETCH_CONNECTION_ERROR = "PY2504",
+  FETCH_UNAVAILABLE_ERROR = "PY2503",
 }
 
 export class UserError extends Error {
@@ -38,8 +35,11 @@ export class UserError extends Error {
 
 
 export class FetchError extends Error {
-  errorCode: string;
-  constructor(errorCode: string, message: string) {
+  static readonly ErrorCode = ErrorCode;
+  readonly ErrorCode = FetchError.ErrorCode;
+
+  errorCode: ErrorCode;
+  constructor(errorCode: ErrorCode, message: string) {
     super(message)
     this.name = "FetchError";
     this.errorCode = errorCode;

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -2,11 +2,32 @@ const CLOSEBUTTON = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'
 
 type MessageType = "text" | "html";
 
-export class UserError extends Error {
-  messageType: MessageType;
-  errorCode: string;
+export enum ErrorCode {
+  GENERIC = "PY0000", // Use this only for dev then change to a more specific error code
+  BAD_CONFIG = "PY1000",
+  DEPRECATED = "PY0001",
+  FETCH_ERROR = "PY2000",
+  FETCH_PARAMETER_ERROR = "PY2001",
+  FETCH_NAME_ERROR = "PY2002",
+  // Currently these are created depending on error code received from fetching
+  FETCH_MOVED_ERROR = "PY2301",
+  FETCH_NOT_FOUND_ERROR = "PY2404",
+  FETCH_UNAUTHORIZED_ERROR = "PY2401",
+  FETCH_FORBIDDEN_ERROR = "PY2403",
+  FETCH_SERVER_ERROR = "PY2500",
+  FETCH_INVALID_RESPONSE = "PY2502",
+  FETCH_TIMEOUT_ERROR = "PY2503",
+  FETCH_CONNECTION_ERROR = "PY2504",
+}
 
-  constructor(message: string, errorCode: string, t: MessageType = "text") {
+export class UserError extends Error {
+  static readonly ErrorCode = ErrorCode;
+  readonly ErrorCode = UserError.ErrorCode;
+
+  messageType: MessageType;
+  errorCode: ErrorCode;
+
+  constructor(message: string, errorCode: ErrorCode, t: MessageType = "text") {
     super(message);
     this.errorCode = errorCode;
     this.name = "UserError";

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -13,7 +13,7 @@ The convention is:
 export enum ErrorCode {
   GENERIC = "PY0000", // Use this only for development then change to a more specific error code
   FETCH_ERROR = "PY0001",
-  FETCH_NAME_ERROR = "PY2002",
+  FETCH_NAME_ERROR = "PY0002",
   // Currently these are created depending on error code received from fetching
   FETCH_UNAUTHORIZED_ERROR = "PY0401",
   FETCH_FORBIDDEN_ERROR = "PY0403",

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -2,25 +2,29 @@ const CLOSEBUTTON = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'
 
 type MessageType = "text" | "html";
 
+/*
+These error codes are used to identify the type of error that occurred.
+The convention is:
+* PY0 - errors that occur when fetching
+* PY1 - errors that occur in config
+* PY9 - Deprecation errors
+*/
+
 export enum ErrorCode {
   GENERIC = "PY0000", // Use this only for development then change to a more specific error code
-  DEPRECATED = "PY0001",
-  BAD_CONFIG = "PY1000",
-  FETCH_ERROR = "PY2000",
-  FETCH_PARAMETER_ERROR = "PY2001",
+  FETCH_ERROR = "PY0001",
   FETCH_NAME_ERROR = "PY2002",
   // Currently these are created depending on error code received from fetching
-  FETCH_NOT_FOUND_ERROR = "PY2404",
-  FETCH_UNAUTHORIZED_ERROR = "PY2401",
-  FETCH_FORBIDDEN_ERROR = "PY2403",
-  FETCH_SERVER_ERROR = "PY2500",
-  FETCH_UNAVAILABLE_ERROR = "PY2503",
+  FETCH_UNAUTHORIZED_ERROR = "PY0401",
+  FETCH_FORBIDDEN_ERROR = "PY0403",
+  FETCH_NOT_FOUND_ERROR = "PY0404",
+  FETCH_SERVER_ERROR = "PY0500",
+  FETCH_UNAVAILABLE_ERROR = "PY0503",
+  BAD_CONFIG = "PY1000",
+  TOP_LEVEL_AWAIT = "PY9000"
 }
 
 export class UserError extends Error {
-  static readonly ErrorCode = ErrorCode;
-  readonly ErrorCode = UserError.ErrorCode;
-
   messageType: MessageType;
   errorCode: ErrorCode;
 
@@ -35,9 +39,6 @@ export class UserError extends Error {
 
 
 export class FetchError extends Error {
-  static readonly ErrorCode = ErrorCode;
-  readonly ErrorCode = FetchError.ErrorCode;
-
   errorCode: ErrorCode;
   constructor(errorCode: ErrorCode, message: string) {
     super(message)

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -4,18 +4,24 @@ type MessageType = "text" | "html";
 
 export class UserError extends Error {
   messageType: MessageType;
+  errorCode: string;
 
-  constructor(message: string, t: MessageType = "text") {
+  constructor(message: string, errorCode: string, t: MessageType = "text") {
     super(message);
+    this.errorCode = errorCode;
     this.name = "UserError";
     this.messageType = t;
+    this.message = `(${errorCode}): ${message}`;
   }
 }
 
 export class FetchError extends Error {
-  constructor(message: string) {
+  errorCode: string;
+  constructor(message: string, errorCode: string) {
     super(message)
-    this.name = "FetchError"
+    this.name = "FetchError";
+    this.errorCode = errorCode;
+    this.message = `(${errorCode}): ${message}`;
   }
 }
 

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -27,7 +27,7 @@ export class UserError extends Error {
   messageType: MessageType;
   errorCode: ErrorCode;
 
-  constructor(message: string, errorCode: ErrorCode, t: MessageType = "text") {
+  constructor(errorCode: ErrorCode, message: string, t: MessageType = "text") {
     super(message);
     this.errorCode = errorCode;
     this.name = "UserError";
@@ -36,9 +36,10 @@ export class UserError extends Error {
   }
 }
 
+
 export class FetchError extends Error {
   errorCode: string;
-  constructor(message: string, errorCode: string) {
+  constructor(errorCode: string, message: string) {
     super(message)
     this.name = "FetchError";
     this.errorCode = errorCode;

--- a/pyscriptjs/src/fetch.ts
+++ b/pyscriptjs/src/fetch.ts
@@ -1,0 +1,47 @@
+import { FetchError, ErrorCode } from "./exceptions";
+
+
+/*
+    This is a fetch wrapper that handles any non 200 response and throws a FetchError
+    with the right ErrorCode.
+    TODO: Should we only throw on 4xx and 5xx responses?
+*/
+export async function robustFetch(url: string, options?: RequestInit): Promise<Response> {
+    const response = await fetch(url, options);
+    if (response.status !== 200) {
+        const errorMsg = `Fetching from URL ${url} failed with error ${response.status} (${response.statusText}).`;
+        switch(response.status) {
+            case 404:
+                throw new FetchError(
+                    ErrorCode.FETCH_NOT_FOUND_ERROR,
+                    errorMsg
+                );
+            case 401:
+                throw new FetchError(
+                    ErrorCode.FETCH_UNAUTHORIZED_ERROR,
+                    errorMsg
+                );
+            case 403:
+                throw new FetchError(
+                    ErrorCode.FETCH_FORBIDDEN_ERROR,
+                    errorMsg
+                );
+            case 500:
+                throw new FetchError(
+                    ErrorCode.FETCH_SERVER_ERROR,
+                    errorMsg
+                );
+            case 503:
+                throw new FetchError(
+                    ErrorCode.FETCH_UNAVAILABLE_ERROR,
+                    errorMsg
+                );
+            default:
+                throw new FetchError(
+                    ErrorCode.FETCH_ERROR,
+                    errorMsg
+                );
+        }
+    }
+    return response
+}

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -11,7 +11,7 @@ import { getLogger } from './logger';
 import { handleFetchError, showWarning, globalExport } from './utils';
 import { calculatePaths } from './plugins/fetch';
 import { createCustomElements } from './components/elements';
-import { UserError, _createAlertBanner } from "./exceptions"
+import { UserError, ErrorCode, _createAlertBanner } from "./exceptions"
 import { type Stdio, StdioMultiplexer, DEFAULT_STDIO } from './stdio';
 import { PyTerminalPlugin } from './plugins/pyterminal';
 import { SplashscreenPlugin } from './plugins/splashscreen';
@@ -133,7 +133,7 @@ export class PyScriptApp {
     loadRuntime() {
         logger.info('Initializing runtime');
         if (this.config.runtimes.length == 0) {
-            throw new UserError(UserError.ErrorCode.BAD_CONFIG, 'Fatal error: config.runtimes is empty');
+            throw new UserError(ErrorCode.BAD_CONFIG, 'Fatal error: config.runtimes is empty');
         }
 
         if (this.config.runtimes.length > 1) {

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -133,7 +133,7 @@ export class PyScriptApp {
     loadRuntime() {
         logger.info('Initializing runtime');
         if (this.config.runtimes.length == 0) {
-            throw new UserError('Fatal error: config.runtimes is empty');
+            throw new UserError('Fatal error: config.runtimes is empty', UserError.ErrorCode.BAD_CONFIG);
         }
 
         if (this.config.runtimes.length > 1) {

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -133,7 +133,7 @@ export class PyScriptApp {
     loadRuntime() {
         logger.info('Initializing runtime');
         if (this.config.runtimes.length == 0) {
-            throw new UserError('Fatal error: config.runtimes is empty', UserError.ErrorCode.BAD_CONFIG);
+            throw new UserError(UserError.ErrorCode.BAD_CONFIG, 'Fatal error: config.runtimes is empty');
         }
 
         if (this.config.runtimes.length > 1) {

--- a/pyscriptjs/src/plugins/fetch.ts
+++ b/pyscriptjs/src/plugins/fetch.ts
@@ -1,6 +1,6 @@
 import { joinPaths } from '../utils';
 import { FetchConfig } from "../pyconfig";
-import { UserError } from '../exceptions';
+import { UserError, ErrorCode } from '../exceptions';
 
 export function calculatePaths(fetch_cfg: FetchConfig[]) {
     const fetchPaths: string[] = [];
@@ -15,7 +15,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
             if (to_file !== undefined)
             {
                 throw new UserError(
-                    UserError.ErrorCode.FETCH_PARAMETER_ERROR,
+                    ErrorCode.BAD_CONFIG,
                     `Cannot use 'to_file' and 'files' parameters together!`
                 );
             }
@@ -33,7 +33,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
             const filename = to_file || from.split('/').pop();
             if (filename === '') {
                 throw new UserError(
-                    UserError.ErrorCode.FETCH_PARAMETER_ERROR,
+                    ErrorCode.BAD_CONFIG,
                     `Couldn't determine the filename from the path ${from}, please supply 'to_file' parameter.`
                 );
             }

--- a/pyscriptjs/src/plugins/fetch.ts
+++ b/pyscriptjs/src/plugins/fetch.ts
@@ -14,7 +14,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
         {
             if (to_file !== undefined)
             {
-                throw new UserError(`Cannot use 'to_file' and 'files' parameters together!`);
+                throw new UserError(`Cannot use 'to_file' and 'files' parameters together!`, UserError.ErrorCode.FETCH_PARAMETER_ERROR);
             }
             for (const each_f of files)
             {
@@ -29,7 +29,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
             fetchPaths.push(from);
             const filename = to_file || from.split('/').pop();
             if (filename === '') {
-                throw new UserError(`Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`);
+                throw new UserError(`Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`, UserError.ErrorCode.FETCH_NAME_ERROR);
             }
             else {
                 paths.push(joinPaths([to_folder, filename]));

--- a/pyscriptjs/src/plugins/fetch.ts
+++ b/pyscriptjs/src/plugins/fetch.ts
@@ -14,7 +14,10 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
         {
             if (to_file !== undefined)
             {
-                throw new UserError(`Cannot use 'to_file' and 'files' parameters together!`, UserError.ErrorCode.FETCH_PARAMETER_ERROR);
+                throw new UserError(
+                    UserError.ErrorCode.FETCH_PARAMETER_ERROR,
+                    `Cannot use 'to_file' and 'files' parameters together!`
+                );
             }
             for (const each_f of files)
             {
@@ -29,7 +32,10 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
             fetchPaths.push(from);
             const filename = to_file || from.split('/').pop();
             if (filename === '') {
-                throw new UserError(`Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`, UserError.ErrorCode.FETCH_NAME_ERROR);
+                throw new UserError(
+                    UserError.ErrorCode.FETCH_PARAMETER_ERROR,
+                    `Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`
+                );
             }
             else {
                 paths.push(joinPaths([to_folder, filename]));

--- a/pyscriptjs/src/plugins/fetch.ts
+++ b/pyscriptjs/src/plugins/fetch.ts
@@ -34,7 +34,7 @@ export function calculatePaths(fetch_cfg: FetchConfig[]) {
             if (filename === '') {
                 throw new UserError(
                     UserError.ErrorCode.FETCH_PARAMETER_ERROR,
-                    `Couldn't determine the filename from the path ${from}, supply ${to_file} parameter!`
+                    `Couldn't determine the filename from the path ${from}, please supply 'to_file' parameter.`
                 );
             }
             else {

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -24,8 +24,11 @@ export class PyTerminalPlugin extends Plugin {
             t !== false &&
             t !== "auto") {
             const got = JSON.stringify(t);
-            throw new UserError('Invalid value for config.terminal: the only accepted'  +
-                                `values are true, false and "auto", got "${got}".`, UserError.ErrorCode.BAD_CONFIG);
+            throw new UserError(
+                UserError.ErrorCode.BAD_CONFIG,
+                'Invalid value for config.terminal: the only accepted'  +
+                `values are true, false and "auto", got "${got}".`
+            );
         }
         if (t === undefined) {
             config.terminal = "auto"; // default value

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -25,7 +25,7 @@ export class PyTerminalPlugin extends Plugin {
             t !== "auto") {
             const got = JSON.stringify(t);
             throw new UserError('Invalid value for config.terminal: the only accepted'  +
-                                `values are true, false and "auto", got "${got}".`);
+                                `values are true, false and "auto", got "${got}".`, UserError.ErrorCode.BAD_CONFIG);
         }
         if (t === undefined) {
             config.terminal = "auto"; // default value

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -2,7 +2,7 @@ import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
 import type { Runtime } from '../runtime';
 import { Plugin } from '../plugin';
-import { UserError } from "../exceptions"
+import { UserError, ErrorCode } from "../exceptions"
 import { getLogger } from '../logger';
 import { type Stdio } from '../stdio';
 
@@ -25,7 +25,7 @@ export class PyTerminalPlugin extends Plugin {
             t !== "auto") {
             const got = JSON.stringify(t);
             throw new UserError(
-                UserError.ErrorCode.BAD_CONFIG,
+                ErrorCode.BAD_CONFIG,
                 'Invalid value for config.terminal: the only accepted'  +
                 `values are true, false and "auto", got "${got}".`
             );

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -145,22 +145,22 @@ function parseConfig(configText: string, configType = 'toml') {
         try {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
-                throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`, 'PY100');
+                throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`, UserError.ErrorCode.BAD_CONFIG);
             }
             config = toml.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`, 'Py100');
+            throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`, UserError.ErrorCode.BAD_CONFIG);
         }
     } else if (configType === 'json') {
         try {
             config = JSON.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`, 'Py100');
+            throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`, UserError.ErrorCode.BAD_CONFIG);
         }
     } else {
-        throw new UserError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`, 'Py100');
+        throw new UserError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`, UserError.ErrorCode.BAD_CONFIG);
     }
     return config;
 }

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -145,22 +145,34 @@ function parseConfig(configText: string, configType = 'toml') {
         try {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
-                throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`, UserError.ErrorCode.BAD_CONFIG);
+                throw new UserError(
+                    UserError.ErrorCode.BAD_CONFIG,
+                    `The config supplied: ${configText} is an invalid TOML and cannot be parsed`
+                );
             }
             config = toml.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`, UserError.ErrorCode.BAD_CONFIG);
+            throw new UserError(
+                UserError.ErrorCode.BAD_CONFIG,
+                `The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`
+            );
         }
     } else if (configType === 'json') {
         try {
             config = JSON.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`, UserError.ErrorCode.BAD_CONFIG);
+            throw new UserError(
+                UserError.ErrorCode.BAD_CONFIG,
+                `The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`,
+            );
         }
     } else {
-        throw new UserError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`, UserError.ErrorCode.BAD_CONFIG);
+        throw new UserError(
+            UserError.ErrorCode.BAD_CONFIG,
+            `The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`
+        );
     }
     return config;
 }

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -2,7 +2,7 @@ import toml from '../src/toml';
 import { getLogger } from './logger';
 import { version } from './runtime';
 import { getAttribute, readTextFromPath, htmlDecode } from './utils';
-import { UserError } from "./exceptions"
+import { UserError, ErrorCode } from "./exceptions"
 
 const logger = getLogger('py-config');
 
@@ -146,7 +146,7 @@ function parseConfig(configText: string, configType = 'toml') {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
                 throw new UserError(
-                    UserError.ErrorCode.BAD_CONFIG,
+                    ErrorCode.BAD_CONFIG,
                     `The config supplied: ${configText} is an invalid TOML and cannot be parsed`
                 );
             }
@@ -154,7 +154,7 @@ function parseConfig(configText: string, configType = 'toml') {
         } catch (err) {
             const errMessage: string = err.toString();
             throw new UserError(
-                UserError.ErrorCode.BAD_CONFIG,
+                ErrorCode.BAD_CONFIG,
                 `The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`
             );
         }
@@ -164,13 +164,13 @@ function parseConfig(configText: string, configType = 'toml') {
         } catch (err) {
             const errMessage: string = err.toString();
             throw new UserError(
-                UserError.ErrorCode.BAD_CONFIG,
+                ErrorCode.BAD_CONFIG,
                 `The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`,
             );
         }
     } else {
         throw new UserError(
-            UserError.ErrorCode.BAD_CONFIG,
+            ErrorCode.BAD_CONFIG,
             `The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`
         );
     }

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -145,22 +145,22 @@ function parseConfig(configText: string, configType = 'toml') {
         try {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
-                throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`);
+                throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`, 'PY100');
             }
             config = toml.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`);
+            throw new UserError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`, 'Py100');
         }
     } else if (configType === 'json') {
         try {
             config = JSON.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`);
+            throw new UserError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`, 'Py100');
         }
     } else {
-        throw new UserError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`);
+        throw new UserError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`, 'Py100');
     }
     return config;
 }

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -16,12 +16,12 @@ export function pyExec(runtime: Runtime, pysrc: string, outElem: HTMLElement) {
         try {
             if (usesTopLevelAwait(pysrc)){
                 throw new UserError(
-                'The use of top-level "await", "async for", and ' +
-                '"async with" is deprecated.' +
-                '\nPlease write a coroutine containing ' +
-                'your code and schedule it using asyncio.ensure_future() or similar.' +
-                '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
-                UserError.ErrorCode.DEPRECATED
+                    UserError.ErrorCode.DEPRECATED,
+                    'The use of top-level "await", "async for", and ' +
+                    '"async with" is deprecated.' +
+                    '\nPlease write a coroutine containing ' +
+                    'your code and schedule it using asyncio.ensure_future() or similar.' +
+                    '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
                 )
        }
        return runtime.run(pysrc);

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -1,5 +1,5 @@
 import { getLogger } from './logger';
-import { ensureUniqueId, ltrim } from './utils';
+import { ensureUniqueId } from './utils';
 import { UserError } from './exceptions';
 import type { Runtime } from './runtime';
 
@@ -20,7 +20,8 @@ export function pyExec(runtime: Runtime, pysrc: string, outElem: HTMLElement) {
                 '"async with" is deprecated.' +
                 '\nPlease write a coroutine containing ' +
                 'your code and schedule it using asyncio.ensure_future() or similar.' +
-                '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.'
+                '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
+                UserError.ErrorCode.DEPRECATED
                 )
        }
        return runtime.run(pysrc);

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -1,6 +1,6 @@
 import { getLogger } from './logger';
 import { ensureUniqueId } from './utils';
-import { UserError } from './exceptions';
+import { UserError, ErrorCode } from './exceptions';
 import type { Runtime } from './runtime';
 
 const logger = getLogger('pyexec');
@@ -16,7 +16,7 @@ export function pyExec(runtime: Runtime, pysrc: string, outElem: HTMLElement) {
         try {
             if (usesTopLevelAwait(pysrc)){
                 throw new UserError(
-                    UserError.ErrorCode.DEPRECATED,
+                    ErrorCode.TOP_LEVEL_AWAIT,
                     'The use of top-level "await", "async for", and ' +
                     '"async with" is deprecated.' +
                     '\nPlease write a coroutine containing ' +

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -4,7 +4,7 @@ import type { loadPyodide as loadPyodideDeclaration, PyodideInterface, PyProxy }
 // eslint-disable-next-line
 // @ts-ignore
 import pyscript from './python/pyscript.py';
-import { fetchIt } from './utils';
+import { robustFetch } from './fetch';
 import type { AppConfig } from './pyconfig';
 import type { Stdio } from './stdio';
 
@@ -111,7 +111,7 @@ export class PyodideRuntime extends Runtime {
                 this.interpreter.FS.mkdir(eachPath);
             }
         }
-        const response = await fetchIt(fetch_path);
+        const response = await robustFetch(fetch_path);
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);
         pathArr.push(filename);

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -1,11 +1,10 @@
-import { Runtime } from './runtime';
+import { Runtime, version } from './runtime';
 import { getLogger } from './logger';
-import { FetchError } from './exceptions'
 import type { loadPyodide as loadPyodideDeclaration, PyodideInterface, PyProxy } from 'pyodide';
 // eslint-disable-next-line
 // @ts-ignore
 import pyscript from './python/pyscript.py';
-import { version } from './runtime';
+import { fetchIt } from './utils';
 import type { AppConfig } from './pyconfig';
 import type { Stdio } from './stdio';
 
@@ -112,13 +111,7 @@ export class PyodideRuntime extends Runtime {
                 this.interpreter.FS.mkdir(eachPath);
             }
         }
-        const response = await fetch(fetch_path);
-        if (response.status !== 200) {
-            throw new FetchError(
-                `PY${response.status}`,
-                `Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`
-            );
-        }
+        const response = await fetchIt(fetch_path);
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);
         pathArr.push(filename);

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -114,7 +114,10 @@ export class PyodideRuntime extends Runtime {
         }
         const response = await fetch(fetch_path);
         if (response.status !== 200) {
-            throw new FetchError(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`, `PY${response.status}`);
+            throw new FetchError(
+                `PY${response.status}`,
+                `Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`
+            );
         }
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -114,7 +114,7 @@ export class PyodideRuntime extends Runtime {
         }
         const response = await fetch(fetch_path);
         if (response.status !== 200) {
-            throw new FetchError(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`);
+            throw new FetchError(`Unable to fetch  ${fetch_path}, reason: ${response.status} - ${response.statusText}`, `PY${response.status}`);
         }
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -50,19 +50,19 @@ export function handleFetchError(e: Error, singleFile: string) {
     // fragile. We need a better solution.
     let errorContent: string;
     if (e.message.includes('Failed to fetch')) {
-        errorContent = `<p>PyScript: Access to local files
+        errorContent = `PyScript: Access to local files
         (using "Paths:" in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files.
         See <a style="text-decoration: underline;" href="https://github.com/pyscript/pyscript/issues/257#issuecomment-1119595062">this reference</a>
-        on starting a simple webserver with Python.</p>`;
+        on starting a simple webserver with Python.`;
     } else if (e.message.includes('404')) {
         errorContent =
-            `<p>PyScript: Loading from file <u>` +
+            `PyScript: Loading from file <u>` +
             singleFile +
-            `</u> failed with error 404 (File not Found). Are your filename and path are correct?</p>`;
+            `</u> failed with error 404 (File not Found). Are your filename and path are correct?`;
     } else {
-        errorContent = `<p>PyScript encountered an error while loading from file: ${e.message} </p>`;
+        errorContent = `PyScript encountered an error while loading from file: ${e.message}`;
     }
     throw new UserError(errorContent, UserError.ErrorCode.FETCH_ERROR, "html");
 }

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -64,7 +64,7 @@ export function handleFetchError(e: Error, singleFile: string) {
     } else {
         errorContent = `PyScript encountered an error while loading from file: ${e.message}`;
     }
-    throw new UserError(errorContent, UserError.ErrorCode.FETCH_ERROR, "html");
+    throw new UserError(UserError.ErrorCode.FETCH_ERROR, errorContent, "html");
 }
 
 export function readTextFromPath(path: string) {

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -1,4 +1,4 @@
-import { _createAlertBanner, UserError, FetchError } from "./exceptions"
+import { _createAlertBanner, UserError, FetchError, ErrorCode } from "./exceptions"
 
 export function addClasses(element: HTMLElement, classes: string[]) {
     for (const entry of classes) {
@@ -64,7 +64,7 @@ export function handleFetchError(e: Error, singleFile: string) {
     } else {
         errorContent = `PyScript encountered an error while loading from file: ${e.message}`;
     }
-    throw new UserError(UserError.ErrorCode.FETCH_ERROR, errorContent, "html");
+    throw new UserError(ErrorCode.FETCH_ERROR, errorContent, "html");
 }
 
 export function readTextFromPath(path: string) {
@@ -117,44 +117,4 @@ export function createDeprecationWarning(msg: string, elementName: string): void
     if (bannerCount == 0) {
         _createAlertBanner(msg, "warning");
     }
-}
-
-export async function fetchIt(url: string, options?: RequestInit): Promise<Response> {
-    const response = await fetch(url, options);
-    if (response.status !== 200) {
-        const errorMsg = `Fetching from URL ${url} failed with error ${response.status} (${response.statusText}).`;
-        switch(response.status) {
-            case 404:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
-                    errorMsg
-                );
-            case 401:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_UNAUTHORIZED_ERROR,
-                    errorMsg
-                );
-            case 403:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_FORBIDDEN_ERROR,
-                    errorMsg
-                );
-            case 500:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_SERVER_ERROR,
-                    errorMsg
-                );
-            case 503:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_UNAVAILABLE_ERROR,
-                    errorMsg
-                );
-            default:
-                throw new FetchError(
-                    FetchError.ErrorCode.FETCH_ERROR,
-                    errorMsg
-                );
-        }
-    }
-    return response
 }

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -64,7 +64,7 @@ export function handleFetchError(e: Error, singleFile: string) {
     } else {
         errorContent = `<p>PyScript encountered an error while loading from file: ${e.message} </p>`;
     }
-    throw new UserError(errorContent, "html");
+    throw new UserError(errorContent, UserError.ErrorCode.FETCH_ERROR, "html");
 }
 
 export function readTextFromPath(path: string) {

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -1,4 +1,4 @@
-import { _createAlertBanner, UserError } from "./exceptions"
+import { _createAlertBanner, UserError, FetchError } from "./exceptions"
 
 export function addClasses(element: HTMLElement, classes: string[]) {
     for (const entry of classes) {
@@ -117,4 +117,44 @@ export function createDeprecationWarning(msg: string, elementName: string): void
     if (bannerCount == 0) {
         _createAlertBanner(msg, "warning");
     }
+}
+
+export async function fetchIt(url: string, options?: RequestInit): Promise<Response> {
+    const response = await fetch(url, options);
+    if (response.status !== 200) {
+        const errorMsg = `Fetching from URL ${url} failed with error ${response.status} (${response.statusText}).`;
+        switch(response.status) {
+            case 404:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
+                    errorMsg
+                );
+            case 401:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_UNAUTHORIZED_ERROR,
+                    errorMsg
+                );
+            case 403:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_FORBIDDEN_ERROR,
+                    errorMsg
+                );
+            case 500:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_SERVER_ERROR,
+                    errorMsg
+                );
+            case 503:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_UNAVAILABLE_ERROR,
+                    errorMsg
+                );
+            default:
+                throw new FetchError(
+                    FetchError.ErrorCode.FETCH_ERROR,
+                    errorMsg
+                );
+        }
+    }
+    return response
 }

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -145,7 +145,13 @@ class TestBasic(PyScriptTest):
             self.check_js_errors()
 
         error_msg = str(exc.value)
-        assert "Failed to fetch" in error_msg
+        if self.is_fake_server:
+            assert "Failed to fetch" in error_msg
+        else:
+            assert (
+                "Fetching from URL foo.py failed with error 404 (File not found)"
+                in error_msg
+            )
 
         pyscript_tag = self.page.locator("py-script")
         assert pyscript_tag.inner_html() == ""

--- a/pyscriptjs/tests/integration/test_py_config.py
+++ b/pyscriptjs/tests/integration/test_py_config.py
@@ -118,7 +118,7 @@ class TestConfig(PyScriptTest):
         banner = self.page.wait_for_selector(".py-error")
         assert "SyntaxError: Unexpected end of JSON input" in self.console.error.text
         expected = (
-            "The config supplied: [[ is an invalid JSON and cannot be "
+            "(PY1000): The config supplied: [[ is an invalid JSON and cannot be "
             "parsed: SyntaxError: Unexpected end of JSON input"
         )
         assert banner.inner_text() == expected
@@ -137,7 +137,7 @@ class TestConfig(PyScriptTest):
         banner = self.page.wait_for_selector(".py-error")
         assert "SyntaxError: Expected DoubleQuote" in self.console.error.text
         expected = (
-            "The config supplied: [[ is an invalid TOML and cannot be parsed: "
+            "(PY1000): The config supplied: [[ is an invalid TOML and cannot be parsed: "
             "SyntaxError: Expected DoubleQuote, Whitespace, or [a-z], [A-Z], "
             '[0-9], "-", "_" but "\\n" found.'
         )
@@ -178,7 +178,7 @@ class TestConfig(PyScriptTest):
         """
         self.pyscript_run(snippet, wait_for_pyscript=False)
         div = self.page.wait_for_selector(".py-error")
-        assert div.text_content() == "Fatal error: config.runtimes is empty"
+        assert div.text_content() == "(PY1000): Fatal error: config.runtimes is empty"
 
     def test_multiple_runtimes(self):
         snippet = """

--- a/pyscriptjs/tests/unit/exceptions.test.ts
+++ b/pyscriptjs/tests/unit/exceptions.test.ts
@@ -2,7 +2,6 @@ import { expect, it, jest } from "@jest/globals"
 import { _createAlertBanner, UserError, FetchError, ErrorCode } from "../../src/exceptions"
 
 describe("Test _createAlertBanner", () => {
-
   afterEach(() => {
     // Ensure we always have a clean body
     document.body.innerHTML = `<div>Hello World</div>`;
@@ -107,7 +106,9 @@ describe("Test _createAlertBanner", () => {
     expect(banner[0].innerHTML).toBe(message);
     expect(banner[0].textContent).toBe("Test message");
   })
+})
 
+describe("Test Exceptions", () => {
   it('UserError contains errorCode and shows in message', async() => {
     const errorCode = ErrorCode.BAD_CONFIG;
     const message = 'Test error';
@@ -117,7 +118,7 @@ describe("Test _createAlertBanner", () => {
   })
 
   it('FetchError contains errorCode and shows in message', async() => {
-    const errorCode = 'PY2404';
+    const errorCode = FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR;
     const message = 'Test error';
     const fetchError = new FetchError(errorCode, message);
     expect(fetchError.errorCode).toBe(errorCode);

--- a/pyscriptjs/tests/unit/exceptions.test.ts
+++ b/pyscriptjs/tests/unit/exceptions.test.ts
@@ -111,15 +111,15 @@ describe("Test _createAlertBanner", () => {
   it('UserError contains errorCode and shows in message', async() => {
     const errorCode = ErrorCode.BAD_CONFIG;
     const message = 'Test error';
-    const userError = new UserError(message, UserError.ErrorCode.BAD_CONFIG);
+    const userError = new UserError(UserError.ErrorCode.BAD_CONFIG, message);
     expect(userError.errorCode).toBe(errorCode);
     expect(userError.message).toBe(`(${errorCode}): ${message}`);
   })
 
   it('FetchError contains errorCode and shows in message', async() => {
-    const errorCode = 'PY404';
+    const errorCode = 'PY2404';
     const message = 'Test error';
-    const fetchError = new FetchError(message, errorCode);
+    const fetchError = new FetchError(errorCode, message);
     expect(fetchError.errorCode).toBe(errorCode);
     expect(fetchError.message).toBe(`(${errorCode}): ${message}`);
   })

--- a/pyscriptjs/tests/unit/exceptions.test.ts
+++ b/pyscriptjs/tests/unit/exceptions.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, jest } from "@jest/globals"
-import { _createAlertBanner, UserError, FetchError } from "../../src/exceptions"
+import { _createAlertBanner, UserError, FetchError, ErrorCode } from "../../src/exceptions"
 
 describe("Test _createAlertBanner", () => {
 
@@ -109,9 +109,9 @@ describe("Test _createAlertBanner", () => {
   })
 
   it('UserError contains errorCode and shows in message', async() => {
-    const errorCode = 'PY0000';
+    const errorCode = ErrorCode.BAD_CONFIG;
     const message = 'Test error';
-    const userError = new UserError(message, errorCode);
+    const userError = new UserError(message, UserError.ErrorCode.BAD_CONFIG);
     expect(userError.errorCode).toBe(errorCode);
     expect(userError.message).toBe(`(${errorCode}): ${message}`);
   })

--- a/pyscriptjs/tests/unit/exceptions.test.ts
+++ b/pyscriptjs/tests/unit/exceptions.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, jest } from "@jest/globals"
+import { expect, it, jest, describe, afterEach } from "@jest/globals"
 import { _createAlertBanner, UserError, FetchError, ErrorCode } from "../../src/exceptions"
 
 describe("Test _createAlertBanner", () => {
@@ -112,13 +112,13 @@ describe("Test Exceptions", () => {
   it('UserError contains errorCode and shows in message', async() => {
     const errorCode = ErrorCode.BAD_CONFIG;
     const message = 'Test error';
-    const userError = new UserError(UserError.ErrorCode.BAD_CONFIG, message);
+    const userError = new UserError(ErrorCode.BAD_CONFIG, message);
     expect(userError.errorCode).toBe(errorCode);
     expect(userError.message).toBe(`(${errorCode}): ${message}`);
   })
 
   it('FetchError contains errorCode and shows in message', async() => {
-    const errorCode = FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR;
+    const errorCode = ErrorCode.FETCH_NOT_FOUND_ERROR;
     const message = 'Test error';
     const fetchError = new FetchError(errorCode, message);
     expect(fetchError.errorCode).toBe(errorCode);

--- a/pyscriptjs/tests/unit/exceptions.test.ts
+++ b/pyscriptjs/tests/unit/exceptions.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, jest } from "@jest/globals"
-import { _createAlertBanner, UserError } from "../../src/exceptions"
+import { _createAlertBanner, UserError, FetchError } from "../../src/exceptions"
 
 describe("Test _createAlertBanner", () => {
 
@@ -106,5 +106,21 @@ describe("Test _createAlertBanner", () => {
     expect(banner.length).toBe(1);
     expect(banner[0].innerHTML).toBe(message);
     expect(banner[0].textContent).toBe("Test message");
+  })
+
+  it('UserError contains errorCode and shows in message', async() => {
+    const errorCode = 'PY0000';
+    const message = 'Test error';
+    const userError = new UserError(message, errorCode);
+    expect(userError.errorCode).toBe(errorCode);
+    expect(userError.message).toBe(`(${errorCode}): ${message}`);
+  })
+
+  it('FetchError contains errorCode and shows in message', async() => {
+    const errorCode = 'PY404';
+    const message = 'Test error';
+    const fetchError = new FetchError(message, errorCode);
+    expect(fetchError.errorCode).toBe(errorCode);
+    expect(fetchError.message).toBe(`(${errorCode}): ${message}`);
   })
 })

--- a/pyscriptjs/tests/unit/fetch.test.ts
+++ b/pyscriptjs/tests/unit/fetch.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { FetchError, ErrorCode } from "../../src/exceptions"
+import { robustFetch } from "../../src/fetch"
+import { Response } from 'node-fetch';
+
+describe("robustFetch", () => {
+
+  it("should return a response object", async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response(status="200", "Hello World"))));
+
+    const response = await robustFetch("https://pyscript.net");
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+  })
+
+  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
+
+    const url = "https://pyscript.net/non-existent-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_NOT_FOUND_ERROR,
+      `Fetching from URL ${url} failed with error 404 (Not Found).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
+
+    const url = "https://pyscript.net/non-existent-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_NOT_FOUND_ERROR,
+      `Fetching from URL ${url} failed with error 404 (Not Found).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 401 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 401}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_UNAUTHORIZED_ERROR,
+      `Fetching from URL ${url} failed with error 401 (Unauthorized).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 403 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 403}))));
+
+    const url = "https://pyscript.net/secret-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_FORBIDDEN_ERROR,
+      `Fetching from URL ${url} failed with error 403 (Forbidden).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 500 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 500}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_SERVER_ERROR,
+      `Fetching from URL ${url} failed with error 500 (Internal Server Error).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 503 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 503}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      ErrorCode.FETCH_UNAVAILABLE_ERROR,
+      `Fetching from URL ${url} failed with error 503 (Service Unavailable).`
+    )
+
+    expect(() => robustFetch(url)).rejects.toThrow(expectedError);
+  })
+});

--- a/pyscriptjs/tests/unit/main.test.ts
+++ b/pyscriptjs/tests/unit/main.test.ts
@@ -1,5 +1,5 @@
-import { jest } from "@jest/globals"
-import { UserError } from "../../src/exceptions"
+import { describe, it, beforeEach, expect } from "@jest/globals"
+import { UserError, ErrorCode } from "../../src/exceptions"
 import { PyScriptApp } from "../../src/main"
 
 describe("Test withUserErrorHandler", () => {
@@ -24,7 +24,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError doesn't stop execution", () => {
         function myRealMain() {
-            throw new UserError(UserError.ErrorCode.GENERIC, "Computer says no");
+            throw new UserError(ErrorCode.GENERIC, "Computer says no");
         }
 
         const app = new MyApp(myRealMain);
@@ -36,7 +36,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError escapes by default", () => {
         function myRealMain() {
-            throw new UserError(UserError.ErrorCode.GENERIC, "hello <br>");
+            throw new UserError(ErrorCode.GENERIC, "hello <br>");
         }
 
         const app = new MyApp(myRealMain);
@@ -48,7 +48,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError messageType=html don't escape", () => {
         function myRealMain() {
-            throw new UserError(UserError.ErrorCode.GENERIC, "hello <br>", "html");
+            throw new UserError(ErrorCode.GENERIC, "hello <br>", "html");
         }
 
         const app = new MyApp(myRealMain);

--- a/pyscriptjs/tests/unit/main.test.ts
+++ b/pyscriptjs/tests/unit/main.test.ts
@@ -24,7 +24,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError doesn't stop execution", () => {
         function myRealMain() {
-            throw new UserError("Computer says no", UserError.ErrorCode.GENERIC);
+            throw new UserError(UserError.ErrorCode.GENERIC, "Computer says no");
         }
 
         const app = new MyApp(myRealMain);
@@ -36,7 +36,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError escapes by default", () => {
         function myRealMain() {
-            throw new UserError("hello <br>", UserError.ErrorCode.GENERIC);
+            throw new UserError(UserError.ErrorCode.GENERIC, "hello <br>");
         }
 
         const app = new MyApp(myRealMain);
@@ -48,7 +48,7 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError messageType=html don't escape", () => {
         function myRealMain() {
-            throw new UserError("hello <br>", UserError.ErrorCode.GENERIC, "html");
+            throw new UserError(UserError.ErrorCode.GENERIC, "hello <br>", "html");
         }
 
         const app = new MyApp(myRealMain);

--- a/pyscriptjs/tests/unit/main.test.ts
+++ b/pyscriptjs/tests/unit/main.test.ts
@@ -24,38 +24,38 @@ describe("Test withUserErrorHandler", () => {
 
     it("userError doesn't stop execution", () => {
         function myRealMain() {
-            throw new UserError("Computer says no");
+            throw new UserError("Computer says no", UserError.ErrorCode.GENERIC);
         }
 
         const app = new MyApp(myRealMain);
         app.main();
         const banners = document.getElementsByClassName("alert-banner");
         expect(banners.length).toBe(1);
-        expect(banners[0].innerHTML).toBe("Computer says no");
+        expect(banners[0].innerHTML).toBe("(PY0000): Computer says no");
     });
 
     it("userError escapes by default", () => {
         function myRealMain() {
-            throw new UserError("hello <br>");
+            throw new UserError("hello <br>", UserError.ErrorCode.GENERIC);
         }
 
         const app = new MyApp(myRealMain);
         app.main();
         const banners = document.getElementsByClassName("alert-banner");
         expect(banners.length).toBe(1);
-        expect(banners[0].innerHTML).toBe("hello &lt;br&gt;");
+        expect(banners[0].innerHTML).toBe("(PY0000): hello &lt;br&gt;");
     });
 
     it("userError messageType=html don't escape", () => {
         function myRealMain() {
-            throw new UserError("hello <br>", "html");
+            throw new UserError("hello <br>", UserError.ErrorCode.GENERIC, "html");
         }
 
         const app = new MyApp(myRealMain);
         app.main();
         const banners = document.getElementsByClassName("alert-banner");
         expect(banners.length).toBe(1);
-        expect(banners[0].innerHTML).toBe("hello <br>");
+        expect(banners[0].innerHTML).toBe("(PY0000): hello <br>");
     });
 
     it("any other exception should stop execution and raise", () => {

--- a/pyscriptjs/tests/unit/pyconfig.test.ts
+++ b/pyscriptjs/tests/unit/pyconfig.test.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { jest, describe, it, expect,  } from '@jest/globals';
 import { loadConfigFromElement, defaultConfig } from '../../src/pyconfig';
 import { version } from '../../src/runtime';
 import { UserError } from '../../src/exceptions'

--- a/pyscriptjs/tests/unit/pyodide.test.ts
+++ b/pyscriptjs/tests/unit/pyodide.test.ts
@@ -2,6 +2,7 @@ import type { AppConfig } from '../../src/pyconfig';
 import { Runtime } from '../../src/runtime';
 import { PyodideRuntime } from '../../src/pyodide';
 import { CaptureStdio } from '../../src/stdio';
+import { make_PyScript } from '../../src/components/pyscript';
 
 import { TextEncoder, TextDecoder } from 'util'
 global.TextEncoder = TextEncoder

--- a/pyscriptjs/tests/unit/pyodide.test.ts
+++ b/pyscriptjs/tests/unit/pyodide.test.ts
@@ -2,7 +2,6 @@ import type { AppConfig } from '../../src/pyconfig';
 import { Runtime } from '../../src/runtime';
 import { PyodideRuntime } from '../../src/pyodide';
 import { CaptureStdio } from '../../src/stdio';
-import { make_PyScript } from '../../src/components/pyscript';
 
 import { TextEncoder, TextDecoder } from 'util'
 global.TextEncoder = TextEncoder

--- a/pyscriptjs/tests/unit/utils.test.ts
+++ b/pyscriptjs/tests/unit/utils.test.ts
@@ -1,6 +1,7 @@
-import { expect } from "@jest/globals"
-import { ensureUniqueId, joinPaths } from "../../src/utils"
-
+import { beforeEach, expect, jest } from "@jest/globals"
+import { ensureUniqueId, joinPaths, fetchIt } from "../../src/utils"
+import { FetchError } from "../../src/exceptions"
+import { Response } from 'node-fetch';
 
 describe("Utils", () => {
 
@@ -51,5 +52,88 @@ describe("JoinPaths", () => {
     const paths: string[] = ['', '///hhh/ll/pp///', '', 'kkk'];
     const joinedPath = joinPaths(paths);
     expect(joinedPath).toStrictEqual('hhh/ll/pp/kkk');
+  })
+})
+
+describe("fetchIt", () => {
+
+  it("should return a response object", async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response(status="200", "Hello World"))));
+
+    const response = await fetchIt("https://pyscript.net");
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+  })
+
+  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
+
+    const url = "https://pyscript.net/non-existent-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
+      `Fetching from URL ${url} failed with error 404 (Not Found).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
+
+    const url = "https://pyscript.net/non-existent-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
+      `Fetching from URL ${url} failed with error 404 (Not Found).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 401 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 401}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_UNAUTHORIZED_ERROR,
+      `Fetching from URL ${url} failed with error 401 (Unauthorized).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 403 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 403}))));
+
+    const url = "https://pyscript.net/secret-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_FORBIDDEN_ERROR,
+      `Fetching from URL ${url} failed with error 403 (Forbidden).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 500 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 500}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_SERVER_ERROR,
+      `Fetching from URL ${url} failed with error 500 (Internal Server Error).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
+  })
+
+  it('receiving a 503 when fetching should throw FetchError with the right errorCode', async () => {
+    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 503}))));
+
+    const url = "https://pyscript.net/protected-page"
+    const expectedError = new FetchError(
+      FetchError.ErrorCode.FETCH_UNAVAILABLE_ERROR,
+      `Fetching from URL ${url} failed with error 503 (Service Unavailable).`
+    )
+
+    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
   })
 })

--- a/pyscriptjs/tests/unit/utils.test.ts
+++ b/pyscriptjs/tests/unit/utils.test.ts
@@ -1,7 +1,5 @@
-import { beforeEach, expect, jest } from "@jest/globals"
-import { ensureUniqueId, joinPaths, fetchIt } from "../../src/utils"
-import { FetchError } from "../../src/exceptions"
-import { Response } from 'node-fetch';
+import { beforeEach, expect, describe, it } from "@jest/globals"
+import { ensureUniqueId, joinPaths} from "../../src/utils"
 
 describe("Utils", () => {
 
@@ -52,88 +50,5 @@ describe("JoinPaths", () => {
     const paths: string[] = ['', '///hhh/ll/pp///', '', 'kkk'];
     const joinedPath = joinPaths(paths);
     expect(joinedPath).toStrictEqual('hhh/ll/pp/kkk');
-  })
-})
-
-describe("fetchIt", () => {
-
-  it("should return a response object", async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response(status="200", "Hello World"))));
-
-    const response = await fetchIt("https://pyscript.net");
-    expect(response).toBeInstanceOf(Response);
-    expect(response.status).toBe(200);
-  })
-
-  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
-
-    const url = "https://pyscript.net/non-existent-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
-      `Fetching from URL ${url} failed with error 404 (Not Found).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
-  })
-
-  it('receiving a 404 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 404}))));
-
-    const url = "https://pyscript.net/non-existent-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_NOT_FOUND_ERROR,
-      `Fetching from URL ${url} failed with error 404 (Not Found).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
-  })
-
-  it('receiving a 401 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 401}))));
-
-    const url = "https://pyscript.net/protected-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_UNAUTHORIZED_ERROR,
-      `Fetching from URL ${url} failed with error 401 (Unauthorized).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
-  })
-
-  it('receiving a 403 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("", {status: 403}))));
-
-    const url = "https://pyscript.net/secret-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_FORBIDDEN_ERROR,
-      `Fetching from URL ${url} failed with error 403 (Forbidden).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
-  })
-
-  it('receiving a 500 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 500}))));
-
-    const url = "https://pyscript.net/protected-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_SERVER_ERROR,
-      `Fetching from URL ${url} failed with error 500 (Internal Server Error).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
-  })
-
-  it('receiving a 503 when fetching should throw FetchError with the right errorCode', async () => {
-    global.fetch = jest.fn(() => (Promise.resolve(new Response("Not Found", {status: 503}))));
-
-    const url = "https://pyscript.net/protected-page"
-    const expectedError = new FetchError(
-      FetchError.ErrorCode.FETCH_UNAVAILABLE_ERROR,
-      `Fetching from URL ${url} failed with error 503 (Service Unavailable).`
-    )
-
-    expect(() => fetchIt(url)).rejects.toThrow(expectedError);
   })
 })


### PR DESCRIPTION
This PR adds error codes and documentation for our custom errors.  There is still a few items left to do on the PR:

- [ ] ~~Add test to confirm that docs have all the error types~~ (can't read this file)
- [x] Handle `fetch` errors better

On the 'handle fetch errors better' front, I am planning to create a custom function that will call fetch under the hood, but handles the status codes and includes the respective error code so we can replace the `errorCode` type from string to ErrorCode similar to `UserError`

Closes: #956