### PR TITLE
Export Version from JS Module

### DIFF
--- a/docs/reference/modules/pyscript.md
+++ b/docs/reference/modules/pyscript.md
@@ -4,6 +4,17 @@ The code underlying PyScript is a TypeScript/JavaScript module, which is loaded 
 
 The module is exported to the browser as `pyscript`. The exports from this module are:
 
+## pyscript.version
+
+Once `pyscript.js` has loaded, the version of PyScript that is currently running can be accessed via `pyscript.version`.
+```html
+<script defer onload="console.log(`${pyscript.version})" src="https://pyscript.net/latest/pyscript.js"></script>
+```
+```js
+//example result
+Object { year: 2022, month: 11, patch: 1, releaselevel: "dev" }
+```
+
 ## pyscript.runtime
 
 The RunTime object which is responsible for executing Python code in the Browser. Currently, all runtimes are assumed to be Pyodide runtimes, but there is flexibility to expand this to other web-based Python runtimes in future versions.

--- a/docs/reference/modules/pyscript.md
+++ b/docs/reference/modules/pyscript.md
@@ -8,7 +8,7 @@ The module is exported to the browser as `pyscript`. The exports from this modul
 
 Once `pyscript.js` has loaded, the version of PyScript that is currently running can be accessed via `pyscript.version`.
 ```html
-<script defer onload="console.log(`${pyscript.version})" src="https://pyscript.net/latest/pyscript.js"></script>
+<script defer onload="console.log(`${pyscript.version}`)" src="https://pyscript.net/latest/pyscript.js"></script>
 ```
 ```js
 //example result

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -3,6 +3,7 @@ import './styles/pyscript_base.css';
 import { loadConfigFromElement } from './pyconfig';
 import type { AppConfig } from './pyconfig';
 import type { Runtime } from './runtime';
+import { version } from './runtime';
 import { PluginManager } from './plugin';
 import { make_PyScript, initHandlers, mountElements } from './components/pyscript';
 import { PyodideRuntime } from './pyodide';
@@ -261,4 +262,5 @@ globalExport('pyscript_get_config', pyscript_get_config);
 const globalApp = new PyScriptApp();
 globalApp.main();
 
+export { version }
 export const runtime = globalApp.runtime;

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -157,11 +157,12 @@ class TestBasic(PyScriptTest):
             </py-script>
             """
         )
-        self.page.add_script_tag(
-            content= "console.log(pyscript.version)"
-        )
+        self.page.add_script_tag(content="console.log(pyscript.version)")
 
-        assert re.match(r"\d{4}\.\d{2}\.\d+(\.[a-zA-Z0-9]+)?", self.console.log.lines[-1]) is not None
+        assert (
+            re.match(r"\d{4}\.\d{2}\.\d+(\.[a-zA-Z0-9]+)?", self.console.log.lines[-1])
+            is not None
+        )
 
     def test_python_version(self):
         self.pyscript_run(

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -150,6 +150,19 @@ class TestBasic(PyScriptTest):
         pyscript_tag = self.page.locator("py-script")
         assert pyscript_tag.inner_html() == ""
 
+    def test_js_version(self):
+        self.pyscript_run(
+            """
+            <py-script>
+            </py-script>
+            """
+        )
+        self.page.add_script_tag(
+            content= "console.log(pyscript.version)"
+        )
+
+        assert re.match(r"\d{4}\.\d{2}\.\d+(\.[a-zA-Z0-9]+)?", self.console.log.lines[-1]) is not None
+
     def test_python_version(self):
         self.pyscript_run(
             """


### PR DESCRIPTION
Exports the version number as an attribute of the JS module.

```html
<script defer 
    src="https://pyscript.net/latest/pyscript.js"
    onload="console.log(`${pyscript.version}`)" 
>
</script>
```
```js
//example result
Object { year: 2022, month: 11, patch: 1, releaselevel: "dev" }
```

Though the version number is stored in `runtime.ts`, it's really a version number for PyScript, not the runtime, so it's exported as an attribute of the `pyscript` module itself instead of the `runtime`.

Updated `/docs/modules/pyscript` with this info.

