### PR TITLE
Remove hardcoded cursor for <input>

### DIFF
--- a/pyscriptjs/src/styles/pyscript_base.css
+++ b/pyscriptjs/src/styles/pyscript_base.css
@@ -273,7 +273,6 @@ input {
     text-align: start;
     appearance: auto;
     -webkit-rtl-ordering: logical;
-    cursor: text;
     background-color: -internal-light-dark(rgb(255, 255, 255), rgb(59, 59, 59));
     margin: 0em;
     padding: 1px 2px;


### PR DESCRIPTION
As I mentioned in issue #966, this PR fixes that the cursor style is set to 'text' for all input types. This is necessary because some types (like 'range') use the default cursor style. 

Fixes: #966