### PR TITLE
Use a more precise type

### DIFF
--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -58,7 +58,7 @@ More concretely:
 export class PyScriptApp {
     config: AppConfig;
     runtime: Runtime;
-    PyScript: any; // XXX would be nice to have a more precise type for the class itself
+    PyScript: ReturnType<typeof make_PyScript>;
     plugins: PluginManager;
     _stdioMultiplexer: StdioMultiplexer;
 


### PR DESCRIPTION
Hi,

This PR changes to use a more precise type instead of the `any` type.
Note: It uses `ReturnType<typeof make_PyScript>` as an alternative to `typeof PyScript` because the `PyScript` type is not exported.