### PR TITLE
Fix failing integration tests

### DIFF
--- a/examples/panel_kmeans.html
+++ b/examples/panel_kmeans.html
@@ -44,7 +44,6 @@
     <link rel="stylesheet" href="./assets/css/examples.css" />
     <link rel="stylesheet" href="./assets/prism/prism.css" />
     <script defer src="./assets/prism/prism.js"></script>
-    <script defer src="https://pyscript.net/latest/pyscript.js"></script>
   </head>
 
   <body>

--- a/examples/repl.html
+++ b/examples/repl.html
@@ -31,7 +31,7 @@
       [[fetch]]
       files = ["./antigravity.py"]
     </py-config>
-    <div>
+    <div style="margin-right: 3rem;">
       <py-repl id="my-repl" auto-generate="true"> </py-repl>
     </div>
    </section>

--- a/examples/repl2.html
+++ b/examples/repl2.html
@@ -35,7 +35,7 @@
         [[fetch]]
         files = ["./utils.py", "./antigravity.py"]
       </py-config>
-      <div>
+      <div style="margin-right: 3rem;">
         <py-repl id="my-repl" auto-generate="true"> </py-repl>
         <div id="output" class="p-4"></div>
       </div>

--- a/pyscriptjs/src/plugins/splashscreen.ts
+++ b/pyscriptjs/src/plugins/splashscreen.ts
@@ -1,4 +1,3 @@
-import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
 import type { UserError } from '../exceptions';
 import type { Runtime } from '../runtime';
@@ -44,7 +43,6 @@ export class SplashscreenPlugin extends Plugin {
         customElements.define('py-splashscreen', PySplashscreen);
         this.elem = <PySplashscreen>document.createElement('py-splashscreen');
         document.body.append(this.elem);
-
         document.addEventListener("py-status-message", (e: CustomEvent) => {
             const msg = e.detail;
             this.elem.log(msg);

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -152,11 +152,14 @@ class TestExamples(PyScriptTest):
         assert self.page.title() == "Matplotlib"
         wait_for_render(self.page, "*", "<img src=['\"]data:image")
         # The image is being rended using base64, lets fetch its source
-        # and replace everything but the actual base64 string.\
-        img_src = (
-            self.page.wait_for_selector("img")
-            .get_attribute("src")
-            .replace("data:image/png;charset=utf-8;base64,", "")
+        # and replace everything but the actual base64 string.
+        # Note: The first image on the page is the logo, so we are lookin
+        # at the mpl-1 div which is rendered once the image is in the page
+        # if this test fails, confirm that the div has the right id using
+        # the --dev flag when running the tests
+        test = self.page.wait_for_selector("#mpl-1 >> img")
+        img_src = test.get_attribute("src").replace(
+            "data:image/png;charset=utf-8;base64,", ""
         )
         # Finally, let's  get the np array from the previous data
         img_data = np.asarray(Image.open(io.BytesIO(base64.b64decode(img_src))))
@@ -261,7 +264,7 @@ class TestExamples(PyScriptTest):
         wait_for_render(self.page, "*", "<py-repl.*?>")
 
         self.page.locator("py-repl").type("display('Hello, World!')")
-        self.page.locator("button").click()
+        self.page.locator("#runButton").click()
 
         assert self.page.locator("#my-repl-2").text_content() == "Hello, World!"
 
@@ -280,7 +283,7 @@ class TestExamples(PyScriptTest):
         wait_for_render(self.page, "*", "<py-repl.*?>")
         # confirm we can import utils and run one command
         self.page.locator("py-repl").type("import utils\ndisplay(utils.now())")
-        self.page.locator("button").click()
+        self.page.wait_for_selector("#runButton").click()
         # Make sure the output is in the page
         self.page.wait_for_selector("#my-repl-1-1")
         # utils.now returns current date time


### PR DESCRIPTION
Tests in main have been failing since #968 was merged, this PR fixes the failing tests. Looking into it, it seems that the failures are caused by:

- importing pyscriptjs twice
- The 'view code' button was blocking the run button so playwright couldn't click it
- The logo in the navbar was being picked up in the matplotlib

Not sure what's happening yet, but running `pytest` manually sees to produce different failures than when we run `make test-integration-parallel`.  

These failures weren't also caught by our CI because it's being run only when we have changes to pyscriptjs  and the above PR only changed things in the example folder