### PR TITLE
Deprecate pyscript output attribute

### DIFF
--- a/docs/reference/elements/py-config.md
+++ b/docs/reference/elements/py-config.md
@@ -127,8 +127,8 @@ If your `.whl` is not a pure Python wheel, then open a PR or issue with [pyodide
 
 If there's enough popular demand, the pyodide team will likely work on supporting your package. Regardless, things will likely move faster if you make the PR and consult with the team to get unblocked.
 
-For example, NumPy and Matplotlib are available. Notice here we're using `<py-script output="plot">`
-as a shortcut, which takes the expression on the last line of the script and runs `pyscript.write('plot', fig)`.
+For example, NumPy and Matplotlib are available. Notice here we're using `display(fig, target="plot")`, which takes the graph and displays it in the element with the id `plot`.
+
 
 ```html
 <html>
@@ -145,14 +145,14 @@ as a shortcut, which takes the expression on the last line of the script and run
           "packages": ["numpy", "matplotlib"]
         }
     </py-config>
-    <py-script output="plot">
+    <py-script>
       import matplotlib.pyplot as plt
       import numpy as np
       x = np.random.randn(1000)
       y = np.random.randn(1000)
       fig, ax = plt.subplots()
       ax.scatter(x, y)
-      fig
+      display(fig, target="plot")
     </py-script>
   </body>
 </html>
@@ -192,13 +192,13 @@ In the HTML tag `<py-config>`, paths to local modules are provided in the
         [[fetch]]
         files = ["./data.py"]
     </py-config>
-    <py-script output="plot">
+    <py-script>
       import matplotlib.pyplot as plt
       from data import make_x_and_y
       x, y = make_x_and_y(n=1000)
       fig, ax = plt.subplots()
       ax.scatter(x, y)
-      fig
+      display(fig, target="plot")
     </py-script>
   </body>
 </html>

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -266,8 +266,7 @@ If your `.whl` is not a pure Python wheel, then open a PR or issue with [pyodide
 
 If there's enough popular demand, the pyodide team will likely work on supporting your package. Regardless, things will likely move faster if you make the PR and consult with the team to get unblocked.
 
-For example, NumPy and Matplotlib are available. Notice here we're using `<py-script output="plot">`
-as a shortcut, which takes the expression on the last line of the script and runs `pyscript.write('plot', fig)`.
+For example, NumPy and Matplotlib are available. Notice here we're using `display(fig, target="plot")`, which takes the graph and displays it in the element with the id `plot`.
 
 ```html
 <html>
@@ -284,14 +283,14 @@ as a shortcut, which takes the expression on the last line of the script and run
           "packages": ["numpy", "matplotlib"]
         }
     </py-config>
-    <py-script output="plot">
+    <py-script>
       import matplotlib.pyplot as plt
       import numpy as np
       x = np.random.randn(1000)
       y = np.random.randn(1000)
       fig, ax = plt.subplots()
       ax.scatter(x, y)
-      fig
+      display(fig, target="plot")
     </py-script>
   </body>
 </html>
@@ -331,13 +330,13 @@ In the HTML tag `<py-config>`, paths to local modules are provided in the
         [[fetch]]
         files = ["./data.py"]
     </py-config>
-    <py-script output="plot">
+    <py-script>
       import matplotlib.pyplot as plt
       from data import make_x_and_y
       x, y = make_x_and_y(n=1000)
       fig, ax = plt.subplots()
       ax.scatter(x, y)
-      fig
+      display(fig, target="plot")
     </py-script>
   </body>
 </html>

--- a/examples/simple_clock.html
+++ b/examples/simple_clock.html
@@ -32,7 +32,7 @@
       [[fetch]]
       files = ["./utils.py"]
     </py-config>
-    <py-script output="outputDiv">
+    <py-script>
 import utils
 display(utils.now())
     </py-script>

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -11,8 +11,8 @@ export function make_PyScript(runtime: Runtime) {
         async connectedCallback() {
             if (this.hasAttribute('output')) {
                 const deprecationMessage = (
-                    "The 'output' attribute is deprecated. You should use the " +
-                    "'display' API to output the content to a specific element. " +
+                    "The 'output' attribute is deprecated and ignored. You should use " +
+                    "'display()' to output the content to a specific element. " +
                     'For example display(myElement, target="divID").'
                 )
                 showWarning(deprecationMessage)

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -1,4 +1,4 @@
-import { htmlDecode, ensureUniqueId } from '../utils';
+import { htmlDecode, ensureUniqueId, showWarning } from '../utils';
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
@@ -9,6 +9,14 @@ const logger = getLogger('py-script');
 export function make_PyScript(runtime: Runtime) {
     class PyScript extends HTMLElement {
         async connectedCallback() {
+            if (this.hasAttribute('output')) {
+                const deprecationMessage = (
+                    "The 'output' attribute is deprecated. You should use the " +
+                    "'display' API to output the content to a specific element. " +
+                    'For example display(myElement, target="divID").'
+                )
+                showWarning(deprecationMessage)
+            }
             ensureUniqueId(this);
             const pySrc = await this.getPySrc();
             this.innerHTML = '';

--- a/pyscriptjs/tests/integration/test_02_output.py
+++ b/pyscriptjs/tests/integration/test_02_output.py
@@ -37,8 +37,7 @@ class TestOutput(PyScriptTest):
         lines = [line for line in lines if line != ""]  # remove empty lines
         assert lines == ["hello 1", "hello 2", "hello 3"]
 
-    @pytest.mark.xfail(reason="fix me")
-    def test_output_attribute(self):
+    def test_output_attribute_shows_deprecated_warning(self):
         self.pyscript_run(
             """
             <py-script output="mydiv">
@@ -47,8 +46,8 @@ class TestOutput(PyScriptTest):
             <div id="mydiv"></div>
             """
         )
-        mydiv = self.page.locator("#mydiv")
-        assert mydiv.inner_text() == "hello world"
+        warning_banner = self.page.locator(".alert-banner")
+        assert "The 'output' attribute is deprecated" in warning_banner.inner_text()
 
     def test_multiple_display_calls_same_tag(self):
         self.pyscript_run(


### PR DESCRIPTION
This PR deprecates the `output` attribute in the `py-script` tag and updates the docs that use it.


Closes: #973