### PR TITLE
Invalidate cache on FS writes

### DIFF
--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -179,6 +179,8 @@ export class PyScriptApp {
         // lifecycle (6.5)
         this.plugins.afterSetup(runtime);
 
+        //Refresh module cache in case plugins have modified the filesystem
+        runtime.interpreter.runPython(`import importlib; importlib.invalidate_caches()`)
         this.logStatus('Executing <py-script> tags...');
         this.executeScripts(runtime);
 
@@ -205,6 +207,8 @@ export class PyScriptApp {
 
         // Save and load pyscript.py from FS
         runtime.interpreter.FS.writeFile('pyscript.py', pyscript, { encoding: 'utf8' });
+        //Refresh the module cache so Python consistently finds pyscript module
+        runtime.interpreter.runPython(`import importlib; importlib.invalidate_caches()`)
 
         // inject `define_custom_element` it into the PyScript module scope
         const pyscript_module = runtime.interpreter.pyimport('pyscript');
@@ -273,6 +277,10 @@ from pyscript import micropip, Element, console, document`);
                 // TODO: Would be probably be better to store plugins somewhere like /plugins/python/ or similar
                 const destPath = `./${filename}`;
                 await runtime.loadFromFile(destPath, singleFile);
+
+                //refresh module cache before trying to import module files into runtime
+                runtime.interpreter.runPython(`import importlib; importlib.invalidate_caches()`)
+
                 const modulename = singleFile.replace(/^.*[\\/]/, '').replace('.py', '');
 
                 console.log(`importing ${modulename}`);


### PR DESCRIPTION
Following the merge of #961, there have been intermittent issues with loading modules via [[fetch]] and the plugin loading mechanism. I believe the issue is that `importlib` is (sometimes) using an invalid module cache, and therefore is unable to find the specified files even when they're present in the Emscripten filesystem.

This PR adds cache invalidation to several points in the lifecycle to alleviate this issue.

This PR is a work in progress, as there may be further points in the lifecycle at which we should invalidate the module path cache, or the three current ones may be redundant in some way.

---

From the [Python documentation](https://docs.python.org/3/library/importlib.html#importlib.import_module):

> If you are dynamically importing a module that was created since the interpreter began execution (e.g., created a Python source file), you may need to call invalidate_caches() in order for the new module to be noticed by the import system.

One observation that supports the idea that the issue is an invalid import cache: even when loading plugin files were failing with a `ModuleNotFoundError`, the file is visible in the filesystem. If we add logging of the current working directory to the dev log, the desired module file (in this case, 'first_plugin.py') is present, but cannot be imported.

https://github.com/JeffersGlass/pyscript/blob/f80745fe5d2de44ce7c198d8ec0408ff33eaa21f/pyscriptjs/src/main.ts#L279-L280
![Screenshot from 2022-11-29 11-00-34](https://user-images.githubusercontent.com/1931111/204604872-f2c59714-95bd-45ad-8c27-7ea80ebae6a2.png)

Fixes #989 