### PR TITLE
Use response.ok instead of just status 200

### DIFF
--- a/pyscriptjs/src/fetch.ts
+++ b/pyscriptjs/src/fetch.ts
@@ -8,7 +8,8 @@ import { FetchError, ErrorCode } from "./exceptions";
 */
 export async function robustFetch(url: string, options?: RequestInit): Promise<Response> {
     const response = await fetch(url, options);
-    if (response.status !== 200) {
+    // Note that response.ok is true for 200-299 responses
+    if (!response.ok) {
         const errorMsg = `Fetching from URL ${url} failed with error ${response.status} (${response.statusText}).`;
         switch(response.status) {
             case 404:


### PR DESCRIPTION
When I wrote the `robustFetch` I was wondering if we should fail on any code that's not a 200. The fetch API will set `response.ok` for any 200-299 status code. 

This PR updates the logic to use this instead of a check on `response.status`