### PR TITLE
Improve UX when we can't install a package

### DIFF
--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -8,6 +8,7 @@ This reference guide contains the error codes you might find and a description o
 | Error code | Description                    | Recommendation     |
 |------------|--------------------------------|--------------------|
 | PY1000     | Invalid configuration supplied | Confirm that your `py-config` tag is using a valid `TOML` or `JSON` syntax and is using the correct configuration type. |
+| PY1001     | Unable to install package(s)   | Confirm that the package contains a pure Python 3 wheel or the name of the package is correct. |
 | PY9000     | Top level await is deprecated  | Create a coroutine with your code and schedule it with `asyncio.ensure_future` or similar |
 
 

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -27,3 +27,13 @@ These error codes are related to any exception raised when trying to fetch a res
 | PY0404     | The page you are trying to fetch does not exist.             |
 | PY0500     | The server encountered an internal error.                    |
 | PY0503     | The server is currently unavailable.                         |
+
+## PY1001
+
+Pyscript cannot install the package(s) you specified in your `py-config` tag. This can happen for a few reasons:
+
+- The package does not exist
+- The package does not contain a pure Python 3 wheel
+- An error occurred while trying to install the package
+
+An error banner should appear on your page with the error code and a description of the error or a traceback. You can also check the developer console for more information.

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -54,7 +54,7 @@ export class InstallError extends UserError {
   errorCode: ErrorCode;
   constructor(errorCode: ErrorCode, message: string) {
     super(errorCode, message)
-    this.name = "FetchError";
+    this.name = "InstallError";
   }
 }
 

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -21,6 +21,7 @@ export enum ErrorCode {
   FETCH_SERVER_ERROR = "PY0500",
   FETCH_UNAVAILABLE_ERROR = "PY0503",
   BAD_CONFIG = "PY1000",
+  MICROPIP_INSTALL_ERROR = "PY1001",
   TOP_LEVEL_AWAIT = "PY9000"
 }
 
@@ -45,6 +46,15 @@ export class FetchError extends Error {
     this.name = "FetchError";
     this.errorCode = errorCode;
     this.message = `(${errorCode}): ${message}`;
+  }
+}
+
+
+export class InstallError extends UserError {
+  errorCode: ErrorCode;
+  constructor(errorCode: ErrorCode, message: string) {
+    super(errorCode, message)
+    this.name = "FetchError";
   }
 }
 

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -227,8 +227,10 @@ be removed from the Python global namespace in the following release. \
 To avoid errors in future releases use import from pyscript instead. For instance: \
 from pyscript import micropip, Element, console, document`);
 
-        logger.info('Packages to install: ', this.config.packages);
-        await runtime.installPackage(this.config.packages);
+        if (this.config.packages) {
+            logger.info('Packages to install: ', this.config.packages);
+            await runtime.installPackage(this.config.packages);
+        }
         await this.fetchPaths(runtime);
 
         //This may be unnecessary - only useful if plugins try to import files fetch'd in fetchPaths()

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -67,8 +67,10 @@ export class PyodideRuntime extends Runtime {
 
         this.globals = this.interpreter.globals;
 
-        // XXX: ideally, we should load micropip only if we actually need it
-        await this.loadPackage('micropip');
+        if (this.config.packages) {
+            logger.info("Found packages in configuration to install. Loading micropip...")
+            await this.loadPackage('micropip');
+        }
         logger.info('pyodide loaded and initialized');
     }
 

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -92,7 +92,7 @@ export class PyodideRuntime extends Runtime {
         if (package_name.length > 0) {
             logger.info(`micropip install ${package_name.toString()}`);
             const micropip = this.globals.get('micropip') as Micropip;
-            try{
+            try {
                 await micropip.install(package_name);
                 micropip.destroy();
             } catch(e) {
@@ -116,6 +116,8 @@ export class PyodideRuntime extends Runtime {
                 } else {
                     exceptionMessage += ` Reason: ${e.message as string}`
                 }
+
+                logger.error(e);
 
                 throw new InstallError(
                     ErrorCode.MICROPIP_INSTALL_ERROR,

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -105,7 +105,7 @@ export class PyodideRuntime extends Runtime {
                 if (e.message.includes("Can't find a pure Python 3 wheel")) {
                     exceptionMessage += (
                         ` Reason: Can't find a pure Python 3 Wheel for package(s) '` + package_name +
-                        `. See: https://pyodide.org/en/stable/usage/faq.html#micropip-can-t-find-a-pure-python-wheel ` +
+                        `'. See: https://pyodide.org/en/stable/usage/faq.html#micropip-can-t-find-a-pure-python-wheel ` +
                         `for more information.`
                     )
                 } else if (e.message.includes("Can't fetch metadata")) {

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -114,7 +114,10 @@ export class PyodideRuntime extends Runtime {
                         "Please make sure you have entered a correct package name."
                     )
                 } else {
-                    exceptionMessage += ` Reason: ${e.message as string}`
+                    exceptionMessage += (
+                        ` Reason: ${e.message as string}. Please open an issue at ` +
+                        `https://github.com/pyscript/pyscript/issues/new if you require help or ` +
+                        `you think it's a bug.`)
                 }
 
                 logger.error(e);

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -101,6 +101,47 @@ class TestBasic(PyScriptTest):
             "hello asciitree",  # printed by us
         ]
 
+    def test_non_existent_package(self):
+        self.pyscript_run(
+            """
+            <py-config>
+                # we use asciitree because it's one of the smallest packages
+                # which are built and distributed with pyodide
+                packages = ["nonexistendright"]
+            </py-config>
+            """,
+            wait_for_pyscript=False,
+        )
+
+        expected_alert_banner_msg = (
+            "(PY1001): Unable to install package(s) 'nonexistendright'. "
+            "Unable to find package in PyPI. Please make sure you have "
+            "entered a correct package name."
+        )
+
+        alert_banner = self.page.wait_for_selector(".alert-banner")
+        assert expected_alert_banner_msg in alert_banner.inner_text()
+
+    def test_no_python_wheel(self):
+        self.pyscript_run(
+            """
+            <py-config>
+                # we use asciitree because it's one of the smallest packages
+                # which are built and distributed with pyodide
+                packages = ["opsdroid"]
+            </py-config>
+            """,
+            wait_for_pyscript=False,
+        )
+
+        expected_alert_banner_msg = (
+            "(PY1001): Unable to install package(s) 'opsdroid'. "
+            "Reason: Can't find a pure Python 3 Wheel for package(s) 'opsdroid'"
+        )
+
+        alert_banner = self.page.wait_for_selector(".alert-banner")
+        assert expected_alert_banner_msg in alert_banner.inner_text()
+
     def test_dynamically_add_py_script_tag(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -105,8 +105,6 @@ class TestBasic(PyScriptTest):
         self.pyscript_run(
             """
             <py-config>
-                # we use asciitree because it's one of the smallest packages
-                # which are built and distributed with pyodide
                 packages = ["nonexistendright"]
             </py-config>
             """,
@@ -126,8 +124,6 @@ class TestBasic(PyScriptTest):
         self.pyscript_run(
             """
             <py-config>
-                # we use asciitree because it's one of the smallest packages
-                # which are built and distributed with pyodide
                 packages = ["opsdroid"]
             </py-config>
             """,


### PR DESCRIPTION
Currently when we try to install a package that does not exist or there are no pure wheels for, things fail *silently* (we do have console logs), and the splash screen also doesn't close.

This PR handles exceptions on `await micropip.install` and throws a new error InstallError (should we reuse the fetch error instead?). It also addresses a comment left by @antocuni  that, ideally, we should only load micropip if we have packages to install.

![Screenshot from 2022-11-30 18-41-43](https://user-images.githubusercontent.com/3131401/204882565-d9d73d61-ff60-4799-803e-11883f92dc31.png)

After this PR, the load screen will close and the alert banner will be shown with a helpful message. Unfortunately, we can't simply use the exception message because it contains a big Python traceback.

Fixes: #911