### PR TITLE
Fix py-markdown plugin

### DIFF
--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 -   pre-commit
 -   pillow
 -   numpy
-
+-   markdown
 -   pip:
     -   playwright
     -   pytest-playwright

--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -3,7 +3,6 @@ from textwrap import dedent
 
 from js import console
 from markdown import markdown
-
 from pyscript import Plugin
 
 console.warn(

--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 from js import console
 from markdown import markdown
-from pyscript import Plugin, console
+from pyscript import Plugin
 
 console.warn(
     "WARNING: This plugin is still in a very experimental phase and will likely change"

--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -1,9 +1,11 @@
 from textwrap import dedent
-
+import html
 from markdown import markdown
 from pyscript import Plugin, console
+from js import console
 
-console.warning(
+
+console.warn(
     "WARNING: This plugin is still in a very experimental phase and will likely change"
     " and potentially break in the future releases. Use it with caution."
 )
@@ -26,6 +28,7 @@ class PyMarkdown:
         self.element = element
 
     def connect(self):
-        self.element.innerHTML = markdown(
-            dedent(self.element.source), extensions=["fenced_code"]
-        )
+        unescaped_content = html.unescape(self.element.originalInnerHTML)
+        original = dedent(unescaped_content)
+        inner = markdown(original, extensions=["fenced_code"])
+        self.element.innerHTML = inner

--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from js import console
 from markdown import markdown
+
 from pyscript import Plugin
 
 console.warn(

--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -1,9 +1,9 @@
-from textwrap import dedent
 import html
+from textwrap import dedent
+
+from js import console
 from markdown import markdown
 from pyscript import Plugin, console
-from js import console
-
 
 console.warn(
     "WARNING: This plugin is still in a very experimental phase and will likely change"

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -146,6 +146,17 @@ class TestExamples(PyScriptTest):
         assert "−" in zoom_out.inner_text()
         zoom_out.click()
 
+    def test_markdown_plugin(self):
+        # Given the example page with:
+        # * <title>PyMarkdown</title>
+        # * <py-md>#Hello world!</py-md>
+        self.goto("examples/markdown-plugin.html")
+        self.wait_for_pyscript()
+        # ASSERT title is rendered correctly
+        assert self.page.title() == "PyMarkdown"
+        # ASSERT markdown is rendered to the corresponding HTML tag
+        wait_for_render(self.page, "*", "<h1>Hello world!</h1>")
+
     def test_matplotlib(self):
         self.goto("examples/matplotlib.html")
         self.wait_for_pyscript()

--- a/pyscriptjs/tests/py-unit/conftest.py
+++ b/pyscriptjs/tests/py-unit/conftest.py
@@ -4,5 +4,10 @@ import sys
 
 # current working directory
 base_path = pathlib.Path().absolute()
+# add pyscript folder to path
 python_source = base_path / "src" / "python"
 sys.path.append(str(python_source))
+
+# add Python plugins folder to path
+python_plugins_source = base_path / "src" / "plugins" / "python"
+sys.path.append(str(python_plugins_source))

--- a/pyscriptjs/tests/py-unit/test_python_plugins.py
+++ b/pyscriptjs/tests/py-unit/test_python_plugins.py
@@ -1,5 +1,3 @@
-import sys
-import textwrap
 from unittest.mock import Mock
 
 import py_markdown

--- a/pyscriptjs/tests/py-unit/test_python_plugins.py
+++ b/pyscriptjs/tests/py-unit/test_python_plugins.py
@@ -17,16 +17,3 @@ class TestPyMarkdown:
         
         py_markdown.plugin.afterStartup(runtime)
         console_mock.log.assert_called_with("runtime received: just a runtime")
-
-    # def test_connected(self, monkeypatch):
-    #     el = pyscript.Element("something")
-    #     document_mock = Mock()
-    #     call_result = "some_result"
-    #     document_mock.querySelector = Mock(return_value=call_result)
-    #     monkeypatch.setattr(pyscript, "document", document_mock)
-    #     assert not el._element
-    #     real_element = el.element
-    #     assert real_element
-    #     assert pyscript.document.querySelector.call_count == 1
-    #     pyscript.document.querySelector.assert_called_with("#something")
-    #     assert real_element == call_result

--- a/pyscriptjs/tests/py-unit/test_python_plugins.py
+++ b/pyscriptjs/tests/py-unit/test_python_plugins.py
@@ -1,0 +1,32 @@
+import sys
+import textwrap
+from unittest.mock import Mock
+
+import py_markdown
+
+
+class TestPyMarkdown:
+    def test_plugin_hooks(self, monkeypatch):
+        console_mock = Mock()
+        monkeypatch.setattr(py_markdown, "console", console_mock)
+        config = "just a config"
+        runtime = "just a runtime"
+
+        py_markdown.plugin.configure(config)
+        console_mock.log.assert_called_with("configuration received: just a config")
+        
+        py_markdown.plugin.afterStartup(runtime)
+        console_mock.log.assert_called_with("runtime received: just a runtime")
+
+    # def test_connected(self, monkeypatch):
+    #     el = pyscript.Element("something")
+    #     document_mock = Mock()
+    #     call_result = "some_result"
+    #     document_mock.querySelector = Mock(return_value=call_result)
+    #     monkeypatch.setattr(pyscript, "document", document_mock)
+    #     assert not el._element
+    #     real_element = el.element
+    #     assert real_element
+    #     assert pyscript.document.querySelector.call_count == 1
+    #     pyscript.document.querySelector.assert_called_with("#something")
+    #     assert real_element == call_result


### PR DESCRIPTION
Unescape the tag content before actually running `markdown` and actually explicitly import console since we now are importing pyscript as a module