### PR TITLE
Remove freedom units from examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -256,20 +256,6 @@
 
       <div class="card">
         <div class="card-content">
-            <a href="./toga/freedom.html" target="_blank">
-              <h2 class="text-2xl font-bold text-blue-600">
-                Freedom Units!
-              </h2>
-            </a>
-            <p>
-              A <a href="https://beeware.org/project/projects/libraries/toga/" target="_blank">Toga</a>
-              application (a Fahrenheit to Celsius converter), rendered as a Single Page App
-            </p>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-content">
             <a href="./numpy_canvas_fractals.html" target="_blank">
               <h2 class="text-2xl font-bold text-blue-600">
                 Fractals with NumPy and canvas


### PR DESCRIPTION
This PR removes the toga example from the examples list.

Looking at the code it seems that we have two things happening:

- Toga is printing some things and its being captured by stdio
- The calculate button doesn't seem to work due to calling `pys-onClick`

I haven't figured out where this attribute is added to yet