### PR TITLE
Bump bokeh, panel versions

### DIFF
--- a/examples/panel.html
+++ b/examples/panel.html
@@ -3,10 +3,10 @@
     <title>Panel Example</title>
     <meta charset="iso-8859-1">
     <link rel="icon" type="image/x-icon" href="./favicon.png">
-    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.js"></script>
-    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.2.min.js"></script>
-    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.2.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/panel.min.js"></script>
+    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.js"></script>
+    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
+    <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.14.1/dist/panel.min.js"></script>
     <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
     <script defer src="https://pyscript.net/latest/pyscript.js"></script>
     <link rel="stylesheet" href="./assets/css/examples.css" />
@@ -29,7 +29,7 @@
       packages = [
         "bokeh",
         "numpy",
-        "panel==0.13.1"
+        "panel==0.14.1"
       ]
     </py-config>
 


### PR DESCRIPTION
This bumps the version of `panel` from 13.1 to 14.1, to avoid showing a deprecation warning for the use of `pyodide.to_js` which was still present in the earlier version of panel.

Also bumps the version of `bokeh` from 2.4.2 to 2.4.3 to avoid a warning in the console about a mismatch between bokeh and Python versions, caused by the panel version increase.