### PR TITLE
Adjust `test_version_info` - no dot in releaselevel

### DIFF
--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -226,7 +226,7 @@ class TestBasic(PyScriptTest):
         assert (
             re.match(
                 r"version_info\(year=\d{4}, month=\d{2}, "
-                r"minor=\d+, releaselevel='(\.[a-zA-Z0-9]+)?'\)",
+                r"minor=\d+, releaselevel='([a-zA-Z0-9]+)?'\)",
                 self.console.log.lines[-1],
             )
             is not None


### PR DESCRIPTION
A small PR - the change to `test_version_info` to remove an extraneous '.' from the regex checking the 'releaselevel'.