### PR TITLE
Add name: "pyscript" to rollup config for minified verison

### DIFF
--- a/pyscriptjs/rollup.config.js
+++ b/pyscriptjs/rollup.config.js
@@ -25,17 +25,18 @@ export default {
   input: "src/main.ts",
   output:[
     {
-    sourcemap: true,
+    file: "build/pyscript.js",
     format: "iife",
+    sourcemap: true,
     inlineDynamicImports: true,
     name: "pyscript",
-    file: "build/pyscript.js",
     },
     {
       file: "build/pyscript.min.js",
       format: "iife",
       sourcemap: true,
       inlineDynamicImports: true,
+      name: "pyscript",
       plugins: [terser()],
     },
   ],


### PR DESCRIPTION
`pyscript.min.js` does not currently export `pyscript` as a JavaScript module, meaning that all the functionality that's intended to be exposed via [the pyscript js module](https://docs.pyscript.net/latest/reference/modules/pyscript.html) does not work when using the minified version.

This PR rectifies that by adding `name: "pyscript"` to the the minified configuration in the rollup config. I also re-arranged the keys in the normal and minified versions so they're in the same order.

First spotted by user "tuxprint" on the PyScript Discord.