### PR TITLE
Don't add Python Plugins to Manager Twice

### DIFF
--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -497,7 +497,6 @@ class Plugin:
 
     def init(self, app):
         self.app = app
-        self.app.plugins.addPythonPlugin(create_proxy(self))
 
     def register_custom_element(self, tag):
         # TODO: Ideally would be better to use the logger.

--- a/pyscriptjs/tests/integration/test_plugins.py
+++ b/pyscriptjs/tests/integration/test_plugins.py
@@ -164,7 +164,7 @@ class TestPlugin(PyScriptTest):
         # EXPECT it to log the correct logs for the events it intercepts
         log_lines = self.console.log.lines
         for method in hooks_available:
-            assert f"{method} called" in log_lines
+            assert log_lines.count(f"{method} called") == 1
 
         # EXPECT it to NOT be called (hence not log anything) the events that happen
         # before it's ready, hence is not called


### PR DESCRIPTION
Python plugins were being registered with the App's plugin manager twice: once in `fetchPythonPlugins`:

https://github.com/pyscript/pyscript/blob/c0f36aa047fb967c2dfe9d98bda836fb01e29ba1/pyscriptjs/src/main.ts#L294-L297

And once in the `init` method of the Python Plugin class itself:

https://github.com/pyscript/pyscript/blob/c0f36aa047fb967c2dfe9d98bda836fb01e29ba1/pyscriptjs/src/python/pyscript.py#L498-L500

This PR removes the second registration, and improves `test_execution_hooks` to check that the specified hooks are called _exactly_ once, instead of at least once.

Fixes #1049 