### PR TITLE
Add changelog to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Pyscript Release Notes
+
+2023.01.1
+=========
+
+Bug fixes
+---------
+
+- Fixed an issue where `pyscript` would not be available when using the minified version of PyScript.
+- Fixed missing closing tag when rendering an image with `display`.
+- Fixed a bug where Python plugins methods were being executed twice.
+
+Documentation
+-------------
+
+- Fixed 'Direct usage of document is deprecated' warning in the getting started guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for wanting to contribute to the PyScript project!
     * [Asking questions](#asking-questions)
     * [Setting up your local environment and developing](#setting-up-your-local-environment-and-developing)
     * [Places to start](#places-to-start)
-    * [Submitting a change](#submitting-a-change)
+    * [Setting up your local environment and developing](#setting-up-your-local-environment-and-developing)
 * [License terms for contributions](#license-terms-for-contributions)
 * [Becoming a maintainer](#becoming-a-maintainer)
 * [Trademarks](#trademarks)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,11 +6,11 @@
 Bug fixes
 ---------
 
-- Fixed an issue where `pyscript` would not be available when using the minified version of PyScript.
-- Fixed missing closing tag when rendering an image with `display`.
-- Fixed a bug where Python plugins methods were being executed twice.
+- Fixed an issue where `pyscript` would not be available when using the minified version of PyScript. ([#1054](https://github.com/pyscript/pyscript/pull/1054))
+- Fixed missing closing tag when rendering an image with `display`. ([#1058](https://github.com/pyscript/pyscript/pull/1058))
+- Fixed a bug where Python plugins methods were being executed twice. ([#1064](https://github.com/pyscript/pyscript/pull/1064))
 
 Documentation
 -------------
 
-- Fixed 'Direct usage of document is deprecated' warning in the getting started guide.
+- Fixed 'Direct usage of document is deprecated' warning in the getting started guide. ([#1052](https://github.com/pyscript/pyscript/pull/1052))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,4 @@
-# Pyscript Release Notes
+# Release Notes
 
 2023.01.1
 =========

--- a/docs/development/developing.md
+++ b/docs/development/developing.md
@@ -46,6 +46,33 @@ make tests
 
 * When you make changes locally, double check that your contribution follows the PyScript formatting rules by running `npm run lint`. Note that in this case you're looking for the errors, <u>**NOT**</u> the warnings (Unless the warning is created by a local change). If an error is found by lint you should fix it <u>**before**</u> creating a pull request
 
+## Updating the changelog
+
+As you work on your changes, please update the changelog file `changelog.md` with a short description of the changes you made. This will help us keep track of what has changed in each release.
+
+You can look at the [changelog](../changelog.md) for examples on how to add your changes to the changelog. But here's a quick example:
+
+```
+2023.02.01
+=========
+
+Bug fixes
+---------
+
+- Fixed a bug that was causing the app to crash when you tried to do something #PR_NUMBER
+
+Enhancements
+------------
+
+- Made awesome new feature #PR_NUMBER
+
+Documentation
+-------------
+
+- Added a new section to the docs #PR_NUMBER
+
+```
+
 
 ## Rebasing changes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,4 +54,5 @@ tutorials/index
 guides/index
 concepts/index
 reference/index
+changelog
 ```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -5,6 +5,7 @@ This is the tutorials section for beginners.
 ```{toctree}
 ---
 maxdepth: 2
+glob:
 ---
 getting-started
 py-config-fetch


### PR DESCRIPTION
We are still talking about the changelog in #1060, but we may be inclined to start by writing it manually. 

This PR adds the `changelog.md` file under the root of our `docs/` and also adds the link to the header.

We could also move the changelog outside the docs and link it to github if you think that's better 😄 