### PR TITLE
pys-onClick shouldn't prevent splashscreen from closing on errors

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -9,16 +9,15 @@ const logger = getLogger('py-script');
 
 export function make_PyScript(runtime: Runtime) {
     class PyScript extends HTMLElement {
-        srcCode: string
+        srcCode: string;
 
         async connectedCallback() {
             if (this.hasAttribute('output')) {
-                const deprecationMessage = (
+                const deprecationMessage =
                     "The 'output' attribute is deprecated and ignored. You should use " +
                     "'display()' to output the content to a specific element. " +
-                    'For example display(myElement, target="divID").'
-                )
-                showWarning(deprecationMessage)
+                    'For example display(myElement, target="divID").';
+                showWarning(deprecationMessage);
             }
             ensureUniqueId(this);
             // Save innerHTML information in srcCode so we can access it later
@@ -36,10 +35,10 @@ export function make_PyScript(runtime: Runtime) {
                 try {
                     const response = await robustFetch(url);
                     return await response.text();
-                } catch(e) {
+                } catch (e) {
                     _createAlertBanner(e.message);
                     this.innerHTML = '';
-                    throw e
+                    throw e;
                 }
             } else {
                 return htmlDecode(this.srcCode);
@@ -173,7 +172,15 @@ function createElementsWithEventListeners(runtime: Runtime, pyAttribute: string)
             from pyodide.ffi import create_proxy
             Element("${el.id}").element.addEventListener("${event}",  create_proxy(${handlerCode}))
             `;
-            runtime.run(source);
+
+            // We meed to run the source code in a try/catch block, because
+            // the source code may contain a syntax error, which will cause
+            // the splashscreen to not be removed.
+            try {
+                runtime.run(source);
+            } catch (e) {
+                logger.error((e as Error).message);
+            }
         } else {
             el.addEventListener(event, () => {
                 runtime.run(handlerCode);

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -78,3 +78,22 @@ class TestSplashscreen(PyScriptTest):
         expect(div).to_contain_text("Startup complete")
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert "hello pyscript" in self.console.log.lines
+
+    def test_splashscreen_closes_on_error_with_pys_onClick(self):
+        self.pyscript_run(
+            """
+            <button id="submit-button" type="submit" pys-onClick="myFunc">OK</button>
+
+            <py-script>
+            from js import console
+
+            def myFunc(*args, **kwargs):
+                text = Element('test-input').element.value
+            Element('test-output').element.innerText = text
+
+            </py-script>
+            """,
+        )
+
+        assert self.page.locator("py-splashscreen").count() == 0
+        assert "Python exception" in self.console.error.text


### PR DESCRIPTION
If a user adds a `pys-onClick` or `pys-onKeyDown` we are adding the event listener using Element and pyodide. Although any exception in the code, prevents the splashscreen to close.

This PR simply adds a try/catch  so the splashscreen doesn't just hang.

I think these attributes will (or should) be removed before the next release, but maybe it's okay to add the try/catch for now

Fixes: #1068