### PR TITLE
Minor refactoring in logger and pyconfig

### DIFF
--- a/pyscriptjs/src/logger.ts
+++ b/pyscriptjs/src/logger.ts
@@ -10,8 +10,8 @@
        logger.warn('...');
        logger.error('...');
 
-   The logger automatically adds the prefix "[my-prefix]" to all logs; so e.g., the
-   above call would print:
+   The logger automatically adds the prefix "[my-prefix]" to all logs.
+   E.g., the above call would print:
 
        [my-prefix] hello world
 
@@ -42,7 +42,7 @@ function getLogger(prefix: string): Logger {
 }
 
 function _makeLogger(prefix: string): Logger {
-    prefix = '[' + prefix + '] ';
+    prefix =`[${prefix}] `;
 
     function make(level: string) {
         const out_fn = console[level].bind(console);

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -75,7 +75,7 @@ export function loadConfigFromElement(el: Element): AppConfig {
     srcConfig = mergeConfig(srcConfig, defaultConfig);
     const result = mergeConfig(inlineConfig, srcConfig);
     result.pyscript = {
-        version: version,
+        version,
         time: new Date().toISOString(),
     };
     return result;
@@ -140,41 +140,29 @@ function mergeConfig(inlineConfig: AppConfig, externalConfig: AppConfig): AppCon
 }
 
 function parseConfig(configText: string, configType = 'toml') {
-    let config: object;
+    const generateError = (errMsg: string) => new UserError(ErrorCode.BAD_CONFIG, errMsg);
+
     if (configType === 'toml') {
         try {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
-                throw new UserError(
-                    ErrorCode.BAD_CONFIG,
-                    `The config supplied: ${configText} is an invalid TOML and cannot be parsed`
-                );
+              throw generateError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`);
             }
-            config = toml.parse(configText);
+            return toml.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(
-                ErrorCode.BAD_CONFIG,
-                `The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`
-            );
+            throw generateError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`);
         }
     } else if (configType === 'json') {
         try {
-            config = JSON.parse(configText);
+            return JSON.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw new UserError(
-                ErrorCode.BAD_CONFIG,
-                `The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`,
-            );
+            throw generateError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`);
         }
     } else {
-        throw new UserError(
-            ErrorCode.BAD_CONFIG,
-            `The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`
-        );
+        throw generateError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`);
     }
-    return config;
 }
 
 function validateConfig(configText: string, configType = 'toml') {

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -140,28 +140,38 @@ function mergeConfig(inlineConfig: AppConfig, externalConfig: AppConfig): AppCon
 }
 
 function parseConfig(configText: string, configType = 'toml') {
-    const generateError = (errMsg: string) => new UserError(ErrorCode.BAD_CONFIG, errMsg);
-
     if (configType === 'toml') {
         try {
             // TOML parser is soft and can parse even JSON strings, this additional check prevents it.
             if (configText.trim()[0] === '{') {
-              throw generateError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed`);
+                throw new UserError(
+                    ErrorCode.BAD_CONFIG,
+                    `The config supplied: ${configText} is an invalid TOML and cannot be parsed`
+                );
             }
             return toml.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw generateError(`The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`);
+            throw new UserError(
+                ErrorCode.BAD_CONFIG,
+                `The config supplied: ${configText} is an invalid TOML and cannot be parsed: ${errMessage}`
+            );
         }
     } else if (configType === 'json') {
         try {
             return JSON.parse(configText);
         } catch (err) {
             const errMessage: string = err.toString();
-            throw generateError(`The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`);
+            throw new UserError(
+                ErrorCode.BAD_CONFIG,
+                `The config supplied: ${configText} is an invalid JSON and cannot be parsed: ${errMessage}`,
+            );
         }
     } else {
-        throw generateError(`The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`);
+        throw new UserError(
+            ErrorCode.BAD_CONFIG,
+            `The type of config supplied '${configType}' is not supported, supported values are ["toml", "json"]`
+        );
     }
 }
 


### PR DESCRIPTION
- logger.ts
  - Comment readability improvement
  -  String interpolation instead of string concatenation
- pyconfig.ts
  - Use shorthand syntax for object property 
  - Refactor parseConfig
    - Extract a function to generate errors
    - Return config directly instead of setting a variable and returning it at the end of the function 