### PR TITLE
Improve UX when user forgets to add id to element with py attribute

### DIFF
--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -9,6 +9,7 @@ This reference guide contains the error codes you might find and a description o
 |------------|--------------------------------|--------------------|
 | PY1000     | Invalid configuration supplied | Confirm that your `py-config` tag is using a valid `TOML` or `JSON` syntax and is using the correct configuration type. |
 | PY1001     | Unable to install package(s)   | Confirm that the package contains a pure Python 3 wheel or the name of the package is correct. |
+| PY3000     | Missing `id` attribute        | Add an `id` attribute to the element. |
 | PY9000     | Top level await is deprecated  | Create a coroutine with your code and schedule it with `asyncio.ensure_future` or similar |
 
 
@@ -37,3 +38,11 @@ Pyscript cannot install the package(s) you specified in your `py-config` tag. Th
 - An error occurred while trying to install the package
 
 An error banner should appear on your page with the error code and a description of the error or a traceback. You can also check the developer console for more information.
+
+## PY3000
+
+When using any of the `py-*` attributes, you must specify an `id` for the element. This is required for all `py-*` attributes to work. For example, if you want to use the `py-click` attribute, you must specify an `id` for the element.
+
+```html
+<button py-click="my_function()" id="my-button">Click me</button>
+```

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -2,7 +2,7 @@ import { htmlDecode, ensureUniqueId, showWarning, createDeprecationWarning } fro
 import type { Runtime } from '../runtime';
 import { getLogger } from '../logger';
 import { pyExec } from '../pyexec';
-import { _createAlertBanner } from '../exceptions';
+import { _createAlertBanner, UserError, ErrorCode } from '../exceptions';
 import { robustFetch } from '../fetch';
 
 const logger = getLogger('py-script');
@@ -157,8 +157,12 @@ function createElementsWithEventListeners(runtime: Runtime, pyAttribute: string)
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll(`[${pyAttribute}]`);
     for (const el of matches) {
         if (el.id.length === 0) {
-            throw new TypeError(
-                `<${el.tagName.toLowerCase()}> must have an id attribute, when using the ${pyAttribute} attribute`,
+            const tag = el.tagName.toLowerCase();
+            throw new UserError(
+                ErrorCode.NO_ID_IN_ELEMENT,
+                `The element '${el.outerHTML}' must have an 'id' attribute, when using the ` +
+                    `'${pyAttribute}' attribute. For example: ` +
+                    `'<${tag} id="myDiv" ${pyAttribute}="myFunction()">${el.textContent}</${tag}>'.`,
             );
         }
         const handlerCode = el.getAttribute(pyAttribute);

--- a/pyscriptjs/src/exceptions.ts
+++ b/pyscriptjs/src/exceptions.ts
@@ -7,55 +7,56 @@ These error codes are used to identify the type of error that occurred.
 The convention is:
 * PY0 - errors that occur when fetching
 * PY1 - errors that occur in config
+* NOTE: Skipping PY2 for now since the plugin PR is not merged yet
+* PY3 - errors that occur in user code/tags
 * PY9 - Deprecation errors
 */
 
 export enum ErrorCode {
-  GENERIC = "PY0000", // Use this only for development then change to a more specific error code
-  FETCH_ERROR = "PY0001",
-  FETCH_NAME_ERROR = "PY0002",
-  // Currently these are created depending on error code received from fetching
-  FETCH_UNAUTHORIZED_ERROR = "PY0401",
-  FETCH_FORBIDDEN_ERROR = "PY0403",
-  FETCH_NOT_FOUND_ERROR = "PY0404",
-  FETCH_SERVER_ERROR = "PY0500",
-  FETCH_UNAVAILABLE_ERROR = "PY0503",
-  BAD_CONFIG = "PY1000",
-  MICROPIP_INSTALL_ERROR = "PY1001",
-  TOP_LEVEL_AWAIT = "PY9000"
+    GENERIC = 'PY0000', // Use this only for development then change to a more specific error code
+    FETCH_ERROR = 'PY0001',
+    FETCH_NAME_ERROR = 'PY0002',
+    // Currently these are created depending on error code received from fetching
+    FETCH_UNAUTHORIZED_ERROR = 'PY0401',
+    FETCH_FORBIDDEN_ERROR = 'PY0403',
+    FETCH_NOT_FOUND_ERROR = 'PY0404',
+    FETCH_SERVER_ERROR = 'PY0500',
+    FETCH_UNAVAILABLE_ERROR = 'PY0503',
+    BAD_CONFIG = 'PY1000',
+    MICROPIP_INSTALL_ERROR = 'PY1001',
+    NO_ID_IN_ELEMENT = 'PY3000',
+    TOP_LEVEL_AWAIT = 'PY9000',
 }
 
 export class UserError extends Error {
-  messageType: MessageType;
-  errorCode: ErrorCode;
+    messageType: MessageType;
+    errorCode: ErrorCode;
 
-  constructor(errorCode: ErrorCode, message: string, t: MessageType = "text") {
-    super(message);
-    this.errorCode = errorCode;
-    this.name = "UserError";
-    this.messageType = t;
-    this.message = `(${errorCode}): ${message}`;
-  }
+    constructor(errorCode: ErrorCode, message: string, t: MessageType = 'text') {
+        super(message);
+        this.errorCode = errorCode;
+        this.name = 'UserError';
+        this.messageType = t;
+        this.message = `(${errorCode}): ${message}`;
+    }
 }
-
 
 export class FetchError extends Error {
-  errorCode: ErrorCode;
-  constructor(errorCode: ErrorCode, message: string) {
-    super(message)
-    this.name = "FetchError";
-    this.errorCode = errorCode;
-    this.message = `(${errorCode}): ${message}`;
-  }
+    errorCode: ErrorCode;
+    constructor(errorCode: ErrorCode, message: string) {
+        super(message);
+        this.name = 'FetchError';
+        this.errorCode = errorCode;
+        this.message = `(${errorCode}): ${message}`;
+    }
 }
 
-
 export class InstallError extends UserError {
-  errorCode: ErrorCode;
-  constructor(errorCode: ErrorCode, message: string) {
-    super(errorCode, message)
-    this.name = "InstallError";
-  }
+    errorCode: ErrorCode;
+    constructor(errorCode: ErrorCode, message: string) {
+        super(errorCode, message);
+        this.name = 'InstallError';
+    }
 }
 
 export function _createAlertBanner(

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -311,3 +311,24 @@ class TestBasic(PyScriptTest):
             "'py-keydown=\"myFunction()\"' instead."
         )
         assert banner.inner_text() == expected_message
+
+    def test_py_attribute_shows_error_if_no_id(self):
+        self.pyscript_run(
+            """
+            <button py-click="myfunc()">Click me</button>
+            <py-script>
+                def myfunc():
+                    print("hello world")
+            </py-script>
+            """,
+            wait_for_pyscript=False,
+        )
+
+        banner = self.page.locator(".alert-banner")
+        expected_message = (
+            "(PY3000): The element '<button py-click=\"myfunc()\">Click me</button>' "
+            "must have an 'id' attribute, when using the 'py-click' attribute. For "
+            'example: \'<button id="myDiv" py-click="myFunction()">Click me</button>\'.'
+        )
+
+        assert banner.inner_text() == expected_message


### PR DESCRIPTION
When working on the py-click tutorial, I forgot to add the id attribute to the button. The error was only shown in the console, this PR updates the error message a bit and raises an UserError instead so the alert banner is created 😄 

Here's the alert banner:

![Screenshot 2023-01-04 at 14 23 52](https://user-images.githubusercontent.com/3131401/210592731-c28346bd-aec1-4c54-bcb8-889f01053850.png)
