### PR TITLE
In a Py-Repl, Shift Enter Shouldn't Insert Newline

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -68,8 +68,8 @@ export function make_PyRepl(runtime: Runtime) {
                 languageConf.of(python()),
                 keymap.of([
                     ...defaultKeymap,
-                    { key: 'Ctrl-Enter', run: this.execute.bind(this) },
-                    { key: 'Shift-Enter', run: this.execute.bind(this) },
+                    { key: 'Ctrl-Enter', run: this.execute.bind(this), preventDefault: true },
+                    { key: 'Shift-Enter', run: this.execute.bind(this), preventDefault: true },
                 ]),
             ];
 

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -69,6 +69,9 @@ class TestPyRepl(PyScriptTest):
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert self.console.log.lines[-1] == "hello world"
 
+        # Shift-enter should not add a newline to the editor
+        assert self.page.locator(".cm-line").count() == 1
+
     def test_display(self):
         self.pyscript_run(
             """


### PR DESCRIPTION
A minor change to the CodeMirror configuration used for py-repl to prevent `shift`+`enter` from inserting a newline. Added a test for this.

Fixes #984