### PR TITLE
Fix Flaky `test_execute_on_shift_enter`

### DIFF
--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -398,6 +398,7 @@ def wait_for_render(page, selector, pattern):
 
     assert py_rendered  # nosec
 
+
 class JsErrors(Exception):
     """
     Represent one or more exceptions which happened in JS.

--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -1,4 +1,5 @@
 import dataclasses
+import math
 import os
 import pdb
 import re
@@ -372,6 +373,30 @@ class PyScriptTest:
 
 # ============== Helpers and utility functions ==============
 
+MAX_TEST_TIME = 30  # Number of seconds allowed for checking a testing condition
+TEST_TIME_INCREMENT = 0.25  # 1/4 second, the length of each iteration
+TEST_ITERATIONS = math.ceil(
+    MAX_TEST_TIME / TEST_TIME_INCREMENT
+)  # 120 iters of 1/4 second
+
+
+def wait_for_render(page, selector, pattern):
+    """
+    Assert that rendering inserts data into the page as expected: search the
+    DOM from within the timing loop for a string that is not present in the
+    initial markup but should appear by way of rendering
+    """
+    re_sub_content = re.compile(pattern)
+    py_rendered = False  # Flag to be set to True when condition met
+
+    for _ in range(TEST_ITERATIONS):
+        content = page.inner_html(selector)
+        if re_sub_content.search(content):
+            py_rendered = True
+            break
+        time.sleep(TEST_TIME_INCREMENT)
+
+    assert py_rendered  # nosec
 
 class JsErrors(Exception):
     """

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -1,4 +1,4 @@
-from .support import PyScriptTest
+from .support import PyScriptTest, wait_for_render
 
 
 class TestPyRepl(PyScriptTest):
@@ -65,6 +65,7 @@ class TestPyRepl(PyScriptTest):
         )
         self.page.wait_for_selector("#runButton")
         self.page.keyboard.press("Shift+Enter")
+        wait_for_render(self.page, "*", 'hello world')
 
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert self.console.log.lines[-1] == "hello world"

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -65,7 +65,7 @@ class TestPyRepl(PyScriptTest):
         )
         self.page.wait_for_selector("#runButton")
         self.page.keyboard.press("Shift+Enter")
-        wait_for_render(self.page, "*", 'hello world')
+        wait_for_render(self.page, "*", "hello world")
 
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert self.console.log.lines[-1] == "hello world"

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -1,6 +1,5 @@
 import base64
 import io
-import math
 import os
 import re
 import time
@@ -9,32 +8,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from .support import ROOT, PyScriptTest
-
-MAX_TEST_TIME = 30  # Number of seconds allowed for checking a testing condition
-TEST_TIME_INCREMENT = 0.25  # 1/4 second, the length of each iteration
-TEST_ITERATIONS = math.ceil(
-    MAX_TEST_TIME / TEST_TIME_INCREMENT
-)  # 120 iters of 1/4 second
-
-
-def wait_for_render(page, selector, pattern):
-    """
-    Assert that rendering inserts data into the page as expected: search the
-    DOM from within the timing loop for a string that is not present in the
-    initial markup but should appear by way of rendering
-    """
-    re_sub_content = re.compile(pattern)
-    py_rendered = False  # Flag to be set to True when condition met
-
-    for _ in range(TEST_ITERATIONS):
-        content = page.inner_html(selector)
-        if re_sub_content.search(content):
-            py_rendered = True
-            break
-        time.sleep(TEST_TIME_INCREMENT)
-
-    assert py_rendered  # nosec
+from .support import ROOT, PyScriptTest, wait_for_render
 
 
 @pytest.mark.usefixtures("chdir")


### PR DESCRIPTION
Fixes an issue where `test_execute_on_shift_enter` test was "flaky", passing intermitantly.

The root cause of the issue was one of timing. There was no explicit wait for whether the code inside the py-repl had been executed by the time we reached the relevant `assert` statements. So, sometimes, by luck, it would have executed and the console log would contain the relevant text ("hello world"). Sometimes, it wouldn't have finished executing, and the console log would be wrong. 

The solution involved re-using the `wait_for_render` function (now moved into `support.py`) to ensure that "hello world" is rendered on the page before checking for it in the captured log lines.

As a data point:

  - Prior to this change, 19 out of 40 iterations of this test succeeded.
  - After the change,     40 out of 40 iterations of this test succeeded.

---

Interestingly, when the test failed, the text would often still be printed while Pytest was tearing down, like so:

```
Success
-------------------- Captured stdout call --------------------------
...
[  3.97 console.info    ] [pyscript/main] PyScript page fully initialized
[  4.13 console.log     ] hello world


Fail:
-------------------- Captured stdout call --------------------------
...
[  4.32 console.info    ] [pyscript/main] PyScript page fully initialized
--------------------- Captured stdout teardown ---------------------
[  4.50 console.log     ] hello world
```
