### PR TITLE
Add f-string quotes rule to flake8 ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ max-complexity = 10
 max-line-length = 100
 show-source = True
 statistics = True
-extend-ignore = E731,B011,E266
+extend-ignore = E731,B011,E266,B028


### PR DESCRIPTION
It seems that the latest version of flake8 is causing pre-commit to fail, this is happening because it's suggested that we use `!r` instead of using `"{test}"`. This causes lines such as these to fail;

```
pyscriptjs/src/python/pyscript.py:52:12: B028 'data' is manually surrounded by quotes, consider using the `!r` conversion flag.
    return f'<img src="{data}" {attrs}></img>'
```

I think for our use-case, we should explicitly add the quotes since it makes it clearer and prevent us from missing the `!r` in fstrings.