### PR TITLE
Change Plugin Hooks to Use options object/kwargs

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -24,7 +24,7 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
             const pySrc = await this.getPySrc();
             this.innerHTML = '';
 
-            app.plugins.beforePyScriptExec(interpreter, pySrc, this);
+            app.plugins.beforePyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this});
             const result = pyExec(interpreter, pySrc, this);
             app.plugins.afterPyScriptExec(interpreter, pySrc, this, result);
         }

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -26,7 +26,7 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
 
             app.plugins.beforePyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this});
             const result = pyExec(interpreter, pySrc, this);
-            app.plugins.afterPyScriptExec(interpreter, pySrc, this, result);
+            app.plugins.afterPyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this, result: result});
         }
 
         async getPySrc(): Promise<string> {

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -42,11 +42,11 @@ export class Plugin {
     /** The source of a <py-script>> tag has been fetched, and we're about
      * to evaluate that source using the provided interpreter.
      *
-     * @param interpreter The Interpreter object that will be used to evaluated the Python source code
-     * @param src {string} The Python source code to be evaluated
-     * @param PyScriptTag The <py-script> HTML tag that originated the evaluation
+     * @param options.interpreter The Interpreter object that will be used to evaluated the Python source code
+     * @param options.src {string} The Python source code to be evaluated
+     * @param options.PyScriptTag The <py-script> HTML tag that originated the evaluation
      */
-    beforePyScriptExec(interpreter: Interpreter, src: string, PyScriptTag: HTMLElement) {}
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement}) {}
 
     /** The Python in a <py-script> has just been evaluated, but control
      * has not been ceded back to the JavaScript event loop yet
@@ -120,10 +120,10 @@ export class PluginManager {
         for (const p of this._pythonPlugins) p.afterStartup?.(interpreter);
     }
 
-    beforePyScriptExec(interpreter: Interpreter, src: string, pyscriptTag: HTMLElement) {
-        for (const p of this._plugins) p.beforePyScriptExec(interpreter, src, pyscriptTag);
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement}) {
+        for (const p of this._plugins) p.beforePyScriptExec(options);
 
-        for (const p of this._pythonPlugins) p.beforePyScriptExec?.(interpreter, src, pyscriptTag);
+        for (const p of this._pythonPlugins) p.beforePyScriptExec?.callKwargs(options);
     }
 
     afterPyScriptExec(interpreter: Interpreter, src: string, pyscriptTag: HTMLElement, result) {

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -44,19 +44,19 @@ export class Plugin {
      *
      * @param options.interpreter The Interpreter object that will be used to evaluated the Python source code
      * @param options.src {string} The Python source code to be evaluated
-     * @param options.PyScriptTag The <py-script> HTML tag that originated the evaluation
+     * @param options.pyScriptTag The <py-script> HTML tag that originated the evaluation
      */
     beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement}) {}
 
     /** The Python in a <py-script> has just been evaluated, but control
      * has not been ceded back to the JavaScript event loop yet
      *
-     * @param interpreter The Interpreter object that will be used to evaluated the Python source code
-     * @param src {string} The Python source code to be evaluated
-     * @param PyScriptTag The <py-script> HTML tag that originated the evaluation
-     * @param result The returned result of evaluating the Python (if any)
+     * @param options.interpreter The Interpreter object that will be used to evaluated the Python source code
+     * @param options.src {string} The Python source code to be evaluated
+     * @param options.pyScriptTag The <py-script> HTML tag that originated the evaluation
+     * @param options.result The returned result of evaluating the Python (if any)
      */
-    afterPyScriptExec(interpreter: Interpreter, src: string, PyScriptTag: HTMLElement, result) {}
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement, result: any}) {}
 
     /** Startup complete. The interpreter is initialized and ready, user
      * scripts have been executed: the main initialization logic ends here and
@@ -126,10 +126,10 @@ export class PluginManager {
         for (const p of this._pythonPlugins) p.beforePyScriptExec?.callKwargs(options);
     }
 
-    afterPyScriptExec(interpreter: Interpreter, src: string, pyscriptTag: HTMLElement, result) {
-        for (const p of this._plugins) p.afterPyScriptExec(interpreter, src, pyscriptTag, result);
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement, result: any}) {
+        for (const p of this._plugins) p.afterPyScriptExec(options);
 
-        for (const p of this._pythonPlugins) p.afterPyScriptExec?.(interpreter, src, pyscriptTag, result);
+        for (const p of this._pythonPlugins) p.afterPyScriptExec?.callKwargs(options);
     }
 
     onUserError(error: UserError) {

--- a/pyscriptjs/src/plugins/stdiodirector.ts
+++ b/pyscriptjs/src/plugins/stdiodirector.ts
@@ -41,14 +41,14 @@ export class StdioDirector extends Plugin {
     /** After a <py-script> tag is evaluated, if that tag has a 'stdout_manager'
      *  (presumably TargetedStdio, or some other future IO handler), it is removed.
      */
-    afterPyScriptExec(interpreter: Interpreter, src: string, PyScriptTag: any, result: any): void {
-        if (PyScriptTag.stdout_manager != null){
-            this._stdioMultiplexer.removeListener(PyScriptTag.stdout_manager)
-            PyScriptTag.stdout_manager = null
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: any, result: any}): void {
+        if (options.pyScriptTag.stdout_manager != null){
+            this._stdioMultiplexer.removeListener(options.pyScriptTag.stdout_manager)
+            options.pyScriptTag.stdout_manager = null
         }
-        if (PyScriptTag.stderr_manager != null){
-            this._stdioMultiplexer.removeListener(PyScriptTag.stderr_manager)
-            PyScriptTag.stderr_manager = null
+        if (options.pyScriptTag.stderr_manager != null){
+            this._stdioMultiplexer.removeListener(options.pyScriptTag.stderr_manager)
+            options.pyScriptTag.stderr_manager = null
         }
     }
 }

--- a/pyscriptjs/src/plugins/stdiodirector.ts
+++ b/pyscriptjs/src/plugins/stdiodirector.ts
@@ -25,15 +25,15 @@ export class StdioDirector extends Plugin {
      * with that ID for the duration of the evaluation.
      *
      */
-    beforePyScriptExec(interpreter: Interpreter, src: string, PyScriptTag: any): void {
-        if (PyScriptTag.hasAttribute("output")){
-            const targeted_io = new TargetedStdio(PyScriptTag, "output", true, true)
-            PyScriptTag.stdout_manager = targeted_io
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: any}): void {
+        if (options.pyScriptTag.hasAttribute("output")){
+            const targeted_io = new TargetedStdio(options.pyScriptTag, "output", true, true)
+            options.pyScriptTag.stdout_manager = targeted_io
             this._stdioMultiplexer.addListener(targeted_io)
         }
-        if (PyScriptTag.hasAttribute("stderr")){
-            const targeted_io = new TargetedStdio(PyScriptTag, "stderr", false, true)
-            PyScriptTag.stderr_manager = targeted_io
+        if (options.pyScriptTag.hasAttribute("stderr")){
+            const targeted_io = new TargetedStdio(options.pyScriptTag, "stderr", false, true)
+            options.pyScriptTag.stderr_manager = targeted_io
             this._stdioMultiplexer.addListener(targeted_io)
         }
     }

--- a/pyscriptjs/tests/integration/test_plugins.py
+++ b/pyscriptjs/tests/integration/test_plugins.py
@@ -37,7 +37,7 @@ class TestLogger(Plugin):
     def afterStartup(self, config):
         console.log('afterStartup called')
 
-    def beforePyScriptExec(self, interpreter, src, pyscript_tag):
+    def beforePyScriptExec(self, interpreter, src, pyScriptTag):
         console.log(f'beforePyScriptExec called')
         console.log(f'before_src:{src}')
 
@@ -60,10 +60,10 @@ from js import console
 
 class ExecTestLogger(Plugin):
 
-    def beforePyScriptExec(self, interpreter, src, pyscript_tag):
+    def beforePyScriptExec(self, interpreter, src, pyScriptTag):
         console.log(f'beforePyScriptExec called')
         console.log(f'before_src:{src}')
-        console.log(f'before_id:{pyscript_tag.id}')
+        console.log(f'before_id:{pyScriptTag.id}')
 
     def afterPyScriptExec(self, interpreter, src, pyscript_tag, result):
         console.log(f'afterPyScriptExec called')

--- a/pyscriptjs/tests/integration/test_plugins.py
+++ b/pyscriptjs/tests/integration/test_plugins.py
@@ -41,7 +41,7 @@ class TestLogger(Plugin):
         console.log(f'beforePyScriptExec called')
         console.log(f'before_src:{src}')
 
-    def afterPyScriptExec(self, interpreter, src, pyscript_tag, result):
+    def afterPyScriptExec(self, interpreter, src, pyScriptTag, result):
         console.log(f'afterPyScriptExec called')
         console.log(f'after_src:{src}')
 
@@ -65,10 +65,10 @@ class ExecTestLogger(Plugin):
         console.log(f'before_src:{src}')
         console.log(f'before_id:{pyScriptTag.id}')
 
-    def afterPyScriptExec(self, interpreter, src, pyscript_tag, result):
+    def afterPyScriptExec(self, interpreter, src, pyScriptTag, result):
         console.log(f'afterPyScriptExec called')
         console.log(f'after_src:{src}')
-        console.log(f'after_id:{pyscript_tag.id}')
+        console.log(f'after_id:{pyScriptTag.id}')
         console.log(f'result:{result}')
 
 


### PR DESCRIPTION
In #1063, we/I introduced a couple of new lifecycle hooks that took several positional arguments, like so:

```ts
//Before: bad
beforePyScriptExec(interpreter: Interpreter, src: string, pyscriptTag: HTMLElement)
afterPyScriptExec(interpreter: Interpreter, src: string, pyscriptTag: HTMLElement, result)
```

This is unfortunately error-prone, as it's easy for users to get the argument error wrong. There were even a couple of tests in the PR where _I_ got the order wrong, which happened to pass by chance! 😶

---

This PR changes the interface for both of those hooks, and sets a precedent for arguments for future hooks. Instead of lots of positional arguments, these hooks now accept an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) with the desired properties, as in:

```ts
//This PR: better
beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement})
afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement, result: any})
```

This a common JS pattern for passing multiple arguments in a structured, order-independent way.

---

Similarly, Python plugins using these hooks now have their arguments passed as _keyword arguments_ (using [PyProxy.callKwargs()](https://pyodide.org/en/stable/usage/api/js-api.html#PyProxy.callKwargs)). The keywords will be the same as the object property keys in JS. As long as users use the matching keywords for their arguments, their order doesn't matter.  For example, a user could write a plugin with the following hook:

```py
#my_plugin.py
class MyPlugin():
	#Note the different argument order; this still works, as functions are called with keyword arguments
	def beforePyScriptExec(src, interpreter, pyScriptTag):
		console.log(f"Got the source {src}")
```