### PR TITLE
Improve typing on PyScriptTag Object

### DIFF
--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -2,8 +2,10 @@ import type { AppConfig } from './pyconfig';
 import type { Interpreter } from './interpreter';
 import type { UserError } from './exceptions';
 import { getLogger } from './logger';
+import { make_PyScript } from './components/pyscript';
 
 const logger = getLogger('plugin');
+type PyScriptTag =  InstanceType<ReturnType<typeof make_PyScript>>;
 
 export class Plugin {
     /** Validate the configuration of the plugin and handle default values.
@@ -46,7 +48,7 @@ export class Plugin {
      * @param options.src {string} The Python source code to be evaluated
      * @param options.pyScriptTag The <py-script> HTML tag that originated the evaluation
      */
-    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement}) {}
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag}) {}
 
     /** The Python in a <py-script> has just been evaluated, but control
      * has not been ceded back to the JavaScript event loop yet
@@ -56,7 +58,7 @@ export class Plugin {
      * @param options.pyScriptTag The <py-script> HTML tag that originated the evaluation
      * @param options.result The returned result of evaluating the Python (if any)
      */
-    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement, result: any}) {}
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag, result: any}) {}
 
     /** Startup complete. The interpreter is initialized and ready, user
      * scripts have been executed: the main initialization logic ends here and
@@ -120,13 +122,13 @@ export class PluginManager {
         for (const p of this._pythonPlugins) p.afterStartup?.(interpreter);
     }
 
-    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement}) {
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag}) {
         for (const p of this._plugins) p.beforePyScriptExec(options);
 
         for (const p of this._pythonPlugins) p.beforePyScriptExec?.callKwargs(options);
     }
 
-    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: HTMLElement, result: any}) {
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag, result: any}) {
         for (const p of this._plugins) p.afterPyScriptExec(options);
 
         for (const p of this._pythonPlugins) p.afterPyScriptExec?.callKwargs(options);

--- a/pyscriptjs/src/plugins/stdiodirector.ts
+++ b/pyscriptjs/src/plugins/stdiodirector.ts
@@ -1,7 +1,9 @@
 import { Plugin } from "../plugin";
 import { TargetedStdio, StdioMultiplexer } from "../stdio";
 import type { Interpreter } from "../interpreter";
+import { make_PyScript } from "../components/pyscript";
 
+type PyScriptTag =  InstanceType<ReturnType<typeof make_PyScript>>;
 
 /**
  * The StdioDirector plugin captures the output to Python's sys.stdio and
@@ -25,7 +27,7 @@ export class StdioDirector extends Plugin {
      * with that ID for the duration of the evaluation.
      *
      */
-    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: any}): void {
+    beforePyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag}): void {
         if (options.pyScriptTag.hasAttribute("output")){
             const targeted_io = new TargetedStdio(options.pyScriptTag, "output", true, true)
             options.pyScriptTag.stdout_manager = targeted_io
@@ -41,7 +43,7 @@ export class StdioDirector extends Plugin {
     /** After a <py-script> tag is evaluated, if that tag has a 'stdout_manager'
      *  (presumably TargetedStdio, or some other future IO handler), it is removed.
      */
-    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: any, result: any}): void {
+    afterPyScriptExec(options: {interpreter: Interpreter, src: string, pyScriptTag: PyScriptTag, result: any}): void {
         if (options.pyScriptTag.stdout_manager != null){
             this._stdioMultiplexer.removeListener(options.pyScriptTag.stdout_manager)
             options.pyScriptTag.stdout_manager = null


### PR DESCRIPTION
Improves the typing of the `pyScriptTag` argument to the `beforePyScriptExec` and `afterPyScriptExec` hooks that were added in #1063 .

Previously, it was just an `HTMLElement`. Now it is properly typed, using 'InstanceOf' and 'ReturnType' to type that argument as an instance of the class returned from `make_PyScript()`.