### PR TITLE
Add config option to splashscreen so users can disable it plus docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@ Bug fixes
 Enhancements
 ------------
 - When adding a `py-` attribute to an element but didn't added an `id` attribute, PyScript will now generate a random ID for the element instead of throwing an error which caused the splash screen to not shutdown. ([#1122](https://github.com/pyscript/pyscript/pull/1122))
-- You can now disable the splashscreen by setting `splashscreen.disabled = false` in your `py-config`. ([#1138](https://github.com/pyscript/pyscript/pull/1138))
+- You can now disable the splashscreen by setting `disabled = false` in your `py-config` under the `[splashscreen]` configuration section. ([#1138](https://github.com/pyscript/pyscript/pull/1138))
 
 Documentation
 -------------

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,11 +19,13 @@ Bug fixes
 Enhancements
 ------------
 - When adding a `py-` attribute to an element but didn't added an `id` attribute, PyScript will now generate a random ID for the element instead of throwing an error which caused the splash screen to not shutdown. ([#1122](https://github.com/pyscript/pyscript/pull/1122))
+- You can now disable the splashscreen by setting `splashscreen.disabled = false` in your `py-config`. ([#1138](https://github.com/pyscript/pyscript/pull/1138))
 
 Documentation
 -------------
 
 - Fixed 'Direct usage of document is deprecated' warning in the getting started guide. ([#1052](https://github.com/pyscript/pyscript/pull/1052))
+- Added reference documentation for the `py-splashscreen` plugin ([#1138](https://github.com/pyscript/pyscript/pull/1138))
 
 Deprecations and Removals
 -------------------------

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@ Bug fixes
 Enhancements
 ------------
 - When adding a `py-` attribute to an element but didn't added an `id` attribute, PyScript will now generate a random ID for the element instead of throwing an error which caused the splash screen to not shutdown. ([#1122](https://github.com/pyscript/pyscript/pull/1122))
-- You can now disable the splashscreen by setting `disabled = false` in your `py-config` under the `[splashscreen]` configuration section. ([#1138](https://github.com/pyscript/pyscript/pull/1138))
+- You can now disable the splashscreen by setting `enabled = false` in your `py-config` under the `[splashscreen]` configuration section. ([#1138](https://github.com/pyscript/pyscript/pull/1138))
 
 Documentation
 -------------

--- a/docs/reference/plugins/py-splashscreen.md
+++ b/docs/reference/plugins/py-splashscreen.md
@@ -8,27 +8,27 @@ This is one of the core plugins in PyScript, which is active by default. The spl
 You can control how `<py-splashscreen>` behaves by setting the value of the  `splashscreen` configuration in your `<py-config>`.
 
 
-| parameter   | default | description |
-|-------------|---------|-------------|
-| `autoclose` | `true`  | Whether to close the splashscreen automatically when the page is ready or not |
-| `disabled` | `true`    | Whether to show the splashscreen or not |
+| parameter   | default   | description |
+|-------------|-----------|-------------|
+| `autoclose` | `true`    | Whether to close the splashscreen automatically when the page is ready or not |
+| `enabled`   | `true`    | Whether to show the splashscreen or not |
 
 ### Examples
 
 #### Disabling the splashscreen
 
-If you don't want the splashscreen to show and log any loading messages, you can disable it by setting the splashscreen option `disabled` to `false`.
+If you don't want the splashscreen to show and log any loading messages, you can disable it by setting the splashscreen option `enabled` to `false`.
 
 ```html
 <py-config>
     [splashscreen]
-        disabled = true
+        enabled = false
 </py-config>
 ```
 
 #### Disabling autoclose
 
-If you want to keep the splashscreen open even after the page is ready, you can disable autoclose by setting `splashscreen.autoclose` to `false`.
+If you want to keep the splashscreen open even after the page is ready, you can disable autoclose by setting `autoclose` to `false`.
 
 ```html
 <py-config>

--- a/docs/reference/plugins/py-splashscreen.md
+++ b/docs/reference/plugins/py-splashscreen.md
@@ -11,13 +11,13 @@ You can control how `<py-splashscreen>` behaves by setting the value of the  `sp
 | parameter   | default | description |
 |-------------|---------|-------------|
 | `autoclose` | `true`  | Whether to close the splashscreen automatically when the page is ready or not |
-| `enabled` | `true`    | Whether to show the splashscreen or not |
+| `disabled` | `true`    | Whether to show the splashscreen or not |
 
 ### Examples
 
 #### Disabling the splashscreen
 
-If you don't want the splashscreen to show and log any loading messages, you can disable it by setting `splashscreen.disabled` to `false`.
+If you don't want the splashscreen to show and log any loading messages, you can disable it by setting the splashscreen option `disabled` to `false`.
 
 ```html
 <py-config>

--- a/docs/reference/plugins/py-splashscreen.md
+++ b/docs/reference/plugins/py-splashscreen.md
@@ -1,0 +1,65 @@
+
+# &lt;py-splashscreen&gt;
+
+This is one of the core plugins in PyScript, which is active by default. The splashscreen is the first thing you see when you open a page with Pyscript while it is loading itself and all the necessary resources.
+
+## Configuration
+
+You can control how `<py-splashscreen>` behaves by setting the value of the  `splashscreen` configuration in your `<py-config>`.
+
+
+| parameter   | default | description |
+|-------------|---------|-------------|
+| `autoclose` | `true`  | Whether to close the splashscreen automatically when the page is ready or not |
+| `enabled` | `true`    | Whether to show the splashscreen or not |
+
+### Examples
+
+#### Disabling the splashscreen
+
+If you don't want the splashscreen to show and log any loading messages, you can disable it by setting `splashscreen.disabled` to `false`.
+
+```html
+<py-config>
+    [splashscreen]
+        disabled = true
+</py-config>
+```
+
+#### Disabling autoclose
+
+If you want to keep the splashscreen open even after the page is ready, you can disable autoclose by setting `splashscreen.autoclose` to `false`.
+
+```html
+<py-config>
+    [splashscreen]
+        autoclose = false
+</py-config>
+```
+
+## Adding custom messages
+
+You can add custom messages to the splashscreen. This is useful if you want to show the user that something is happening in the background for your PyScript app.
+
+There are two ways to add your custom messages to the splashscreen, either by dispatching a new custom event, `py-status-message` to the document:
+
+
+```js
+document.dispatchEvent(new CustomEvent("py-status-message", {detail: "Hello, world!"}))
+```
+
+Or by using the `log` method of the `py-splashscreen` tag directly:
+
+```js
+const splashscreen = document.querySelector("py-splashscreen")
+splashscreen.log("Hello, world!")
+```
+
+If you wish, you can also send messages directly to the splashscreen from your python code:
+
+```python
+from js import document
+
+splashscreen = document.querySelector("py-splashscreen")
+splashscreen.log("Hello, world!")
+```

--- a/pyscriptjs/src/plugins/splashscreen.ts
+++ b/pyscriptjs/src/plugins/splashscreen.ts
@@ -56,13 +56,13 @@ export class SplashscreenPlugin extends Plugin {
     }
 
     afterStartup(interpreter: Interpreter) {
-        if (this.autoclose && !this.enabled) {
+        if (this.autoclose && this.enabled) {
             this.elem.close();
         }
     }
 
     onUserError(error: UserError) {
-        if (this.elem !== undefined && !this.enabled) {
+        if (this.elem !== undefined && this.enabled) {
             // Remove the splashscreen so users can see the banner better
             this.elem.close();
         }

--- a/pyscriptjs/src/plugins/splashscreen.ts
+++ b/pyscriptjs/src/plugins/splashscreen.ts
@@ -20,6 +20,7 @@ autoclose = false
 export class SplashscreenPlugin extends Plugin {
     elem: PySplashscreen;
     autoclose: boolean;
+    disabled: boolean;
 
     configure(config: AppConfig) {
         // the officially supported setting is config.splashscreen.autoclose,
@@ -35,9 +36,14 @@ export class SplashscreenPlugin extends Plugin {
         if (config.splashscreen) {
             this.autoclose = config.splashscreen.autoclose ?? true;
         }
+
+        this.disabled = config.splashscreen.disabled ?? false;
     }
 
     beforeLaunch(config: AppConfig) {
+        if (this.disabled) {
+            return;
+        }
         // add the splashscreen to the DOM
         logger.info('add py-splashscreen');
         customElements.define('py-splashscreen', PySplashscreen);
@@ -50,13 +56,13 @@ export class SplashscreenPlugin extends Plugin {
     }
 
     afterStartup(interpreter: Interpreter) {
-        if (this.autoclose) {
+        if (this.autoclose && !this.disabled) {
             this.elem.close();
         }
     }
 
     onUserError(error: UserError) {
-        if (this.elem !== undefined) {
+        if (this.elem !== undefined && !this.disabled) {
             // Remove the splashscreen so users can see the banner better
             this.elem.close();
         }

--- a/pyscriptjs/src/plugins/splashscreen.ts
+++ b/pyscriptjs/src/plugins/splashscreen.ts
@@ -20,14 +20,14 @@ autoclose = false
 export class SplashscreenPlugin extends Plugin {
     elem: PySplashscreen;
     autoclose: boolean;
-    disabled: boolean;
+    enabled: boolean;
 
     configure(config: AppConfig) {
         // the officially supported setting is config.splashscreen.autoclose,
         // but we still also support the old config.autoclose_loader (with a
         // deprecation warning)
         this.autoclose = true;
-        this.disabled = false;
+        this.enabled = true;
 
         if ('autoclose_loader' in config) {
             this.autoclose = config.autoclose_loader;
@@ -36,12 +36,12 @@ export class SplashscreenPlugin extends Plugin {
 
         if (config.splashscreen) {
             this.autoclose = config.splashscreen.autoclose ?? true;
-            this.disabled = config.splashscreen.disabled ?? false;
+            this.enabled = config.splashscreen.enabled ?? true;
         }
     }
 
     beforeLaunch(config: AppConfig) {
-        if (this.disabled) {
+        if (!this.enabled) {
             return;
         }
         // add the splashscreen to the DOM
@@ -56,13 +56,13 @@ export class SplashscreenPlugin extends Plugin {
     }
 
     afterStartup(interpreter: Interpreter) {
-        if (this.autoclose && !this.disabled) {
+        if (this.autoclose && !this.enabled) {
             this.elem.close();
         }
     }
 
     onUserError(error: UserError) {
-        if (this.elem !== undefined && !this.disabled) {
+        if (this.elem !== undefined && !this.enabled) {
             // Remove the splashscreen so users can see the banner better
             this.elem.close();
         }

--- a/pyscriptjs/src/plugins/splashscreen.ts
+++ b/pyscriptjs/src/plugins/splashscreen.ts
@@ -27,6 +27,7 @@ export class SplashscreenPlugin extends Plugin {
         // but we still also support the old config.autoclose_loader (with a
         // deprecation warning)
         this.autoclose = true;
+        this.disabled = false;
 
         if ('autoclose_loader' in config) {
             this.autoclose = config.autoclose_loader;
@@ -35,9 +36,8 @@ export class SplashscreenPlugin extends Plugin {
 
         if (config.splashscreen) {
             this.autoclose = config.splashscreen.autoclose ?? true;
+            this.disabled = config.splashscreen.disabled ?? false;
         }
-
-        this.disabled = config.splashscreen.disabled ?? false;
     }
 
     beforeLaunch(config: AppConfig) {

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -43,29 +43,29 @@ class TestBasic(PyScriptTest):
         assert tb_lines[0] == "Traceback (most recent call last):"
         assert tb_lines[-1] == "Exception: this is an error"
 
-    def test_python_exception_in_event_handler(self):
-        self.pyscript_run(
-            """
-            <button py-click="onclick()">Click me</button>
-            <py-script>
-                def onclick():
-                    raise Exception("this is an error inside handler")
-            </py-script>
-        """
-        )
+    # def test_python_exception_in_event_handler(self):
+    #     self.pyscript_run(
+    #         """
+    #         <button py-click="onclick()">Click me</button>
+    #         <py-script>
+    #             def onclick():
+    #                 raise Exception("this is an error inside handler")
+    #         </py-script>
+    #     """
+    #     )
 
-        self.page.locator("button").click()
+    #     self.page.locator("button").click()
 
-        ## error in console
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "[pyexec] Python exception:"
-        assert tb_lines[1] == "Traceback (most recent call last):"
-        assert tb_lines[-1] == "Exception: this is an error inside handler"
+    #     ## error in console
+    #     tb_lines = self.console.error.lines[-1].splitlines()
+    #     assert tb_lines[0] == "[pyexec] Python exception:"
+    #     assert tb_lines[1] == "Traceback (most recent call last):"
+    #     assert tb_lines[-1] == "Exception: this is an error inside handler"
 
-        ## error in DOM
-        tb_lines = self.page.locator(".py-error").inner_text().splitlines()
-        assert tb_lines[0] == "Traceback (most recent call last):"
-        assert tb_lines[-1] == "Exception: this is an error inside handler"
+    #     ## error in DOM
+    #     tb_lines = self.page.locator(".py-error").inner_text().splitlines()
+    #     assert tb_lines[0] == "Traceback (most recent call last):"
+    #     assert tb_lines[-1] == "Exception: this is an error inside handler"
 
     def test_execution_in_order(self):
         """

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -43,29 +43,29 @@ class TestBasic(PyScriptTest):
         assert tb_lines[0] == "Traceback (most recent call last):"
         assert tb_lines[-1] == "Exception: this is an error"
 
-    # def test_python_exception_in_event_handler(self):
-    #     self.pyscript_run(
-    #         """
-    #         <button py-click="onclick()">Click me</button>
-    #         <py-script>
-    #             def onclick():
-    #                 raise Exception("this is an error inside handler")
-    #         </py-script>
-    #     """
-    #     )
+    def test_python_exception_in_event_handler(self):
+        self.pyscript_run(
+            """
+            <button py-click="onclick()">Click me</button>
+            <py-script>
+                def onclick():
+                    raise Exception("this is an error inside handler")
+            </py-script>
+        """
+        )
 
-    #     self.page.locator("button").click()
+        self.page.locator("button").click()
 
-    #     ## error in console
-    #     tb_lines = self.console.error.lines[-1].splitlines()
-    #     assert tb_lines[0] == "[pyexec] Python exception:"
-    #     assert tb_lines[1] == "Traceback (most recent call last):"
-    #     assert tb_lines[-1] == "Exception: this is an error inside handler"
+        ## error in console
+        tb_lines = self.console.error.lines[-1].splitlines()
+        assert tb_lines[0] == "[pyexec] Python exception:"
+        assert tb_lines[1] == "Traceback (most recent call last):"
+        assert tb_lines[-1] == "Exception: this is an error inside handler"
 
-    #     ## error in DOM
-    #     tb_lines = self.page.locator(".py-error").inner_text().splitlines()
-    #     assert tb_lines[0] == "Traceback (most recent call last):"
-    #     assert tb_lines[-1] == "Exception: this is an error inside handler"
+        ## error in DOM
+        tb_lines = self.page.locator(".py-error").inner_text().splitlines()
+        assert tb_lines[0] == "Traceback (most recent call last):"
+        assert tb_lines[-1] == "Exception: this is an error inside handler"
 
     def test_execution_in_order(self):
         """

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -103,7 +103,7 @@ class TestSplashscreen(PyScriptTest):
             """
             <py-config>
                 [splashscreen]
-                enabled = false
+                disabled = true
             </py-config>
 
             <py-script>

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -97,3 +97,23 @@ class TestSplashscreen(PyScriptTest):
 
         assert self.page.locator("py-splashscreen").count() == 0
         assert "Python exception" in self.console.error.text
+
+    def test_splashscreen_disabled_option(self):
+        self.pyscript_run(
+            """
+            <py-config>
+                [splashscreen]
+                disabled = true
+            </py-config>
+
+            <py-script>
+                def test():
+                    print("Hello pyscript!")
+                test()
+            </py-script>
+            """,
+        )
+        assert self.page.locator("py-splashscreen").count() == 0
+        assert self.console.log.lines[-1] == "Hello pyscript!"
+        py_terminal = self.page.wait_for_selector("py-terminal")
+        assert py_terminal.inner_text() == "Hello pyscript!\n"

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -103,7 +103,7 @@ class TestSplashscreen(PyScriptTest):
             """
             <py-config>
                 [splashscreen]
-                disabled = true
+                enabled = false
             </py-config>
 
             <py-script>

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -117,3 +117,24 @@ class TestSplashscreen(PyScriptTest):
         assert self.console.log.lines[-1] == "Hello pyscript!"
         py_terminal = self.page.wait_for_selector("py-terminal")
         assert py_terminal.inner_text() == "Hello pyscript!\n"
+
+    def test_splashscreen_custom_message(self):
+        self.pyscript_run(
+            """
+            <py-config>
+                [splashscreen]
+                    autoclose = false
+            </py-config>
+
+            <py-script>
+                from js import document
+
+                splashscreen = document.querySelector("py-splashscreen")
+                splashscreen.log("Hello, world!")
+            </py-script>
+            """,
+        )
+
+        splashscreen = self.page.locator("py-splashscreen")
+        assert splashscreen.count() == 1
+        assert "Hello, world!" in splashscreen.inner_text()


### PR DESCRIPTION
This PR adds a `disabled = false` option to the splashscreen which allows users to disable it if they so wish to do so. It also adds docs for the `py-splashscreen` and how to add custom messages to the splashscreen 😄 

Fixes: #900
Closes:  #1004