### PR TITLE
fix py-markdown plugin test

### DIFF
--- a/pyscriptjs/src/plugins/python/py_markdown.py
+++ b/pyscriptjs/src/plugins/python/py_markdown.py
@@ -30,5 +30,5 @@ class PyMarkdown:
     def connect(self):
         unescaped_content = html.unescape(self.element.originalInnerHTML)
         original = dedent(unescaped_content)
-        inner = markdown(original, extensions=["fenced_code"])
+        inner = markdown(original, extensions=["markdown.extensions.fenced_code"])
         self.element.innerHTML = inner


### PR DESCRIPTION
Fixes https://github.com/pyscript/pyscript/issues/1107

Source: https://stackoverflow.com/questions/59052079/pyinstaller-and-python-markdown-importerror-no-module-named-extra