### PR TITLE
Fix import warning for js.document in get started tutorial

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -197,6 +197,7 @@ Now that we have a way to explore the data using `py-repl` and a way to create t
     </py-config>
 
     <py-script>
+      import js
       import pandas as pd
       import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Small fix for the get started tutorial so we don't show the import warning when trying to use js directly