### PR TITLE
wrap runPython in async

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -166,9 +166,7 @@ export function make_PyRepl(interpreter: Interpreter) {
             outEl.innerHTML = '';
 
             // execute the python code
-            const temp = (await pyExec(interpreter, pySrc, outEl));
-            console.info(">>>> TEMP >>>>", temp);
-            const pyResult = temp.result;
+            const pyResult = (await pyExec(interpreter, pySrc, outEl)).result;
 
             // display the value of the last evaluated expression (REPL-style)
             if (pyResult !== undefined) {

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -166,7 +166,9 @@ export function make_PyRepl(interpreter: Interpreter) {
             outEl.innerHTML = '';
 
             // execute the python code
-            const pyResult = await pyExec(interpreter, pySrc, outEl);
+            const temp = (await pyExec(interpreter, pySrc, outEl));
+            console.info(">>>> TEMP >>>>", temp);
+            const pyResult = temp.result;
 
             // display the value of the last evaluated expression (REPL-style)
             if (pyResult !== undefined) {

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -150,7 +150,7 @@ export function make_PyRepl(interpreter: Interpreter) {
         /** Execute the python code written in the editor, and automatically
          *  display() the last evaluated expression
          */
-        execute(): void {
+        async execute(): Promise<void> {
             const pySrc = this.getPySrc();
 
             // determine the output element
@@ -166,7 +166,7 @@ export function make_PyRepl(interpreter: Interpreter) {
             outEl.innerHTML = '';
 
             // execute the python code
-            const pyResult = pyExec(interpreter, pySrc, outEl);
+            const pyResult = await pyExec(interpreter, pySrc, outEl);
 
             // display the value of the last evaluated expression (REPL-style)
             if (pyResult !== undefined) {

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -25,7 +25,7 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
             this.innerHTML = '';
 
             app.plugins.beforePyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this});
-            const result = pyExec(interpreter, pySrc, this);
+            const result = await pyExec(interpreter, pySrc, this);
             app.plugins.afterPyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this, result: result});
         }
 
@@ -182,9 +182,9 @@ function createElementsWithEventListeners(interpreter: Interpreter, pyAttribute:
                 logger.error((e as Error).message);
             }
         } else {
-            el.addEventListener(event, () => {
+            el.addEventListener(event, async () => {
                 try {
-                    interpreter.run(handlerCode)
+                    await interpreter.run(handlerCode)
                 }
                 catch (err) {
                     displayPyException(err, el.parentElement);

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -16,8 +16,13 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
         stderr_manager: Stdio | null;
 
         async connectedCallback() {
-
-            // TODO: ADD A COMMENT TO EXPLAIN WHY LOCKING IS NEEDED
+            /**
+             * Since connectedCallback is async, multiple py-script tags can be executed in
+             * an order which is not particularly sequential. The locking mechanism here ensures
+             * a sequential execution of multiple py-script tags present in one page.
+             *
+             * Concurrent access to the multiple py-script tags is thus avoided.
+             */
             let releaseLock: any;
             try {
                 releaseLock = await app.tagExecutionLock();

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -17,6 +17,7 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
 
         async connectedCallback() {
 
+            // TODO: ADD A COMMENT TO EXPLAIN WHY LOCKING IS NEEDED
             let releaseLock: any;
             try {
                 releaseLock = await app.tagExecutionLock();

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -1,4 +1,4 @@
-import { htmlDecode, ensureUniqueId, createDeprecationWarning, } from '../utils';
+import { htmlDecode, ensureUniqueId, createDeprecationWarning } from '../utils';
 import type { Interpreter } from '../interpreter';
 import { getLogger } from '../logger';
 import { pyExec, displayPyException } from '../pyexec';
@@ -17,10 +17,9 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
 
         async connectedCallback() {
 
-            let releaseLock;
+            let releaseLock: any;
             try {
-                releaseLock = await app.tagExecitionLock();
-
+                releaseLock = await app.tagExecutionLock();
                 ensureUniqueId(this);
                 // Save innerHTML information in srcCode so we can access it later
                 // once we clean innerHTML (which is required since we don't want
@@ -32,10 +31,9 @@ export function make_PyScript(interpreter: Interpreter, app: PyScriptApp) {
                 app.plugins.beforePyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this});
                 const result = (await pyExec(interpreter, pySrc, this)).result;
                 app.plugins.afterPyScriptExec({interpreter: interpreter, src: pySrc, pyScriptTag: this, result: result});
-            } finally{
+            } finally {
                 releaseLock()
             }
-
         }
 
         async getPySrc(): Promise<string> {

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -190,13 +190,15 @@ function createElementsWithEventListeners(interpreter: Interpreter, pyAttribute:
                 logger.error((e as Error).message);
             }
         } else {
-            el.addEventListener(event, async () => {
-                try {
-                    await interpreter.run(handlerCode)
-                }
-                catch (err) {
-                    displayPyException(err, el.parentElement);
-                }
+            el.addEventListener(event, () => {
+                void (async () => {
+                    try {
+                        await interpreter.run(handlerCode);
+                    }
+                    catch (err) {
+                        displayPyException(err, el.parentElement);
+                    }
+                })();
             });
         }
         // TODO: Should we actually map handlers in JS instead of Python?

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -216,7 +216,7 @@ function createElementsWithEventListeners(interpreter: Interpreter, pyAttribute:
 }
 
 /** Mount all elements with attribute py-mount into the Python namespace */
-export function mountElements(interpreter: Interpreter) {
+export async function mountElements(interpreter: Interpreter) {
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[py-mount]');
     logger.info(`py-mount: found ${matches.length} elements`);
 
@@ -225,5 +225,5 @@ export function mountElements(interpreter: Interpreter) {
         const mountName = el.getAttribute('py-mount') || el.id.split('-').join('_');
         source += `\n${mountName} = Element("${el.id}")`;
     }
-    interpreter.run(source);
+    await interpreter.run(source);
 }

--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -26,8 +26,8 @@ function createWidget(interpreter: Interpreter, name: string, code: string, klas
             this.shadow.appendChild(this.wrapper);
         }
 
-        connectedCallback() {
-            interpreter.runButDontRaise(this.code);
+        async connectedCallback() {
+            await interpreter.runButDontRaise(this.code);
             this.proxyClass = interpreter.globals.get(this.klass);
             this.proxy = this.proxyClass(this);
             this.proxy.connect();

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -51,7 +51,7 @@ export abstract class Interpreter extends Object {
      * (asynchronously) which can call its own API behind the scenes.
      * Python exceptions are turned into JS exceptions.
      * */
-    abstract run(code: string): Promise<void>;
+    abstract run(code: string): Promise<{result:any}>;
 
     /**
      * Same as run, but Python exceptions are not propagated: instead, they
@@ -63,7 +63,7 @@ export abstract class Interpreter extends Object {
     async runButDontRaise(code: string): Promise<unknown> {
         let result: unknown;
         try {
-            result = await this.run(code);
+            result = (await this.run(code)).result;
         } catch (error: unknown) {
             logger.error('Error:', error);
         }

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -51,7 +51,7 @@ export abstract class Interpreter extends Object {
      * (asynchronously) which can call its own API behind the scenes.
      * Python exceptions are turned into JS exceptions.
      * */
-    abstract run(code: string): Promise<{result:any}>;
+    abstract run(code: string): Promise<{result: any}>;
 
     /**
      * Same as run, but Python exceptions are not propagated: instead, they

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -60,10 +60,10 @@ export abstract class Interpreter extends Object {
      * This is a bad API and should be killed/refactored/changed eventually,
      * but for now we have code which relies on it.
      * */
-    runButDontRaise(code: string): unknown {
+    async runButDontRaise(code: string): Promise<unknown> {
         let result: unknown;
         try {
-            result = this.run(code);
+            result = await this.run(code);
         } catch (error: unknown) {
             logger.error('Error:', error);
         }

--- a/pyscriptjs/src/interpreter.ts
+++ b/pyscriptjs/src/interpreter.ts
@@ -51,7 +51,7 @@ export abstract class Interpreter extends Object {
      * (asynchronously) which can call its own API behind the scenes.
      * Python exceptions are turned into JS exceptions.
      * */
-    abstract run(code: string): unknown;
+    abstract run(code: string): Promise<void>;
 
     /**
      * Same as run, but Python exceptions are not propagated: instead, they

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -226,12 +226,12 @@ export class PyScriptApp {
         pyscript_module.destroy();
 
         // import some carefully selected names into the global namespace
-        (await interpreter.run(`
+        await interpreter.run(`
         import js
         import pyscript
         from pyscript import Element, display, HTML
         pyscript._install_deprecated_globals_2022_12_1(globals())
-        `)).result;
+        `);
 
         if (this.config.packages) {
             logger.info('Packages to install: ', this.config.packages);

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -21,7 +21,6 @@ import { StdioDirector as StdioDirector } from './plugins/stdiodirector';
 // @ts-ignore
 import pyscript from './python/pyscript.py';
 import { robustFetch } from './fetch';
-import type { Plugin } from './plugin';
 
 const logger = getLogger('pyscript/main');
 
@@ -65,8 +64,8 @@ export class PyScriptApp {
     PyScript: ReturnType<typeof make_PyScript>;
     plugins: PluginManager;
     _stdioMultiplexer: StdioMultiplexer;
-    tagExecitionLock: any;
- 
+    tagExecutionLock: any;
+
     constructor() {
         // initialize the builtin plugins
         this.plugins = new PluginManager();
@@ -76,7 +75,7 @@ export class PyScriptApp {
         this._stdioMultiplexer.addListener(DEFAULT_STDIO);
 
         this.plugins.add(new StdioDirector(this._stdioMultiplexer));
-        this.tagExecitionLock = createLock();
+        this.tagExecutionLock = createLock();
     }
 
     // Error handling logic: if during the execution we encounter an error

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -181,7 +181,7 @@ export class PyScriptApp {
 
         this.logStatus('Setting up virtual environment...');
         await this.setupVirtualEnv(interpreter);
-        mountElements(interpreter);
+        await mountElements(interpreter);
 
         // lifecycle (6.5)
         this.plugins.afterSetup(interpreter);

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -64,7 +64,7 @@ export class PyScriptApp {
     PyScript: ReturnType<typeof make_PyScript>;
     plugins: PluginManager;
     _stdioMultiplexer: StdioMultiplexer;
-    tagExecutionLock: any;
+    tagExecutionLock: any; // this is used to ensure that py-script tags are executed sequentially
 
     constructor() {
         // initialize the builtin plugins

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -5,16 +5,10 @@ import type { Interpreter } from './interpreter';
 
 const logger = getLogger('pyexec');
 
-function sleep(ms) {
-    return new Promise(res => setTimeout(res, ms))
-}
-
 export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: HTMLElement) {
     //This is pyscript.py
     const pyscript_py = interpreter.interface.pyimport('pyscript');
-    await sleep(1000);
     ensureUniqueId(outElem);
-    console.info("pyExec 1");
     pyscript_py.set_current_display_target(outElem.id);
     try {
         try {
@@ -28,23 +22,17 @@ export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: H
                         '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
                 );
             }
-            console.info("pyExec 2");
-            const x = interpreter.run(pysrc);
-            console.info("pyExec 2.5");
-            return x
+            return await interpreter.run(pysrc);
         } catch (err) {
             // XXX: currently we display exceptions in the same position as
             // the output. But we probably need a better way to do that,
             // e.g. allowing plugins to intercept exceptions and display them
-            // in a configurable way.\
-            console.info("pyExec 3");
+            // in a configurable way.
             displayPyException(err, outElem);
         }
     } finally {
-        console.info("pyExec 4");
         pyscript_py.set_current_display_target(undefined);
         pyscript_py.destroy();
-        console.info("pyExec 5");
     }
 }
 

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -10,6 +10,7 @@ export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: H
     const pyscript_py = interpreter.interface.pyimport('pyscript');
     ensureUniqueId(outElem);
     pyscript_py.set_current_display_target(outElem.id);
+    console.info("pyexec 1")
     try {
         try {
             if (pyscript_py.uses_top_level_await(pysrc)) {
@@ -22,15 +23,20 @@ export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: H
                         '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
                 );
             }
-            return await interpreter.run(pysrc);
+            console.info("pyexec 2")
+            const result = (await interpreter.run(pysrc));
+            console.info("pyexec 2.5")
+            return result
         } catch (err) {
             // XXX: currently we display exceptions in the same position as
             // the output. But we probably need a better way to do that,
             // e.g. allowing plugins to intercept exceptions and display them
             // in a configurable way.
             displayPyException(err, outElem);
+            return {result: undefined}
         }
     } finally {
+        console.info("pyexec 3")
         pyscript_py.set_current_display_target(undefined);
         pyscript_py.destroy();
     }

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -5,11 +5,16 @@ import type { Interpreter } from './interpreter';
 
 const logger = getLogger('pyexec');
 
-export function pyExec(interpreter: Interpreter, pysrc: string, outElem: HTMLElement) {
+function sleep(ms) {
+    return new Promise(res => setTimeout(res, ms))
+}
+
+export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: HTMLElement) {
     //This is pyscript.py
     const pyscript_py = interpreter.interface.pyimport('pyscript');
-
+    await sleep(1000);
     ensureUniqueId(outElem);
+    console.info("pyExec 1");
     pyscript_py.set_current_display_target(outElem.id);
     try {
         try {
@@ -23,17 +28,23 @@ export function pyExec(interpreter: Interpreter, pysrc: string, outElem: HTMLEle
                         '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
                 );
             }
-            return interpreter.run(pysrc);
+            console.info("pyExec 2");
+            const x = interpreter.run(pysrc);
+            console.info("pyExec 2.5");
+            return x
         } catch (err) {
             // XXX: currently we display exceptions in the same position as
             // the output. But we probably need a better way to do that,
             // e.g. allowing plugins to intercept exceptions and display them
-            // in a configurable way.
+            // in a configurable way.\
+            console.info("pyExec 3");
             displayPyException(err, outElem);
         }
     } finally {
+        console.info("pyExec 4");
         pyscript_py.set_current_display_target(undefined);
         pyscript_py.destroy();
+        console.info("pyExec 5");
     }
 }
 

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -10,7 +10,6 @@ export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: H
     const pyscript_py = interpreter.interface.pyimport('pyscript');
     ensureUniqueId(outElem);
     pyscript_py.set_current_display_target(outElem.id);
-    console.info("pyexec 1")
     try {
         try {
             if (pyscript_py.uses_top_level_await(pysrc)) {
@@ -23,20 +22,16 @@ export async function pyExec(interpreter: Interpreter, pysrc: string, outElem: H
                         '\nSee https://docs.pyscript.net/latest/guides/asyncio.html for more information.',
                 );
             }
-            console.info("pyexec 2")
-            const result = (await interpreter.run(pysrc));
-            console.info("pyexec 2.5")
-            return result
+            return (await interpreter.run(pysrc));
         } catch (err) {
             // XXX: currently we display exceptions in the same position as
             // the output. But we probably need a better way to do that,
             // e.g. allowing plugins to intercept exceptions and display them
             // in a configurable way.
             displayPyException(err, outElem);
-            return {result: undefined}
+            return {result: undefined};
         }
     } finally {
-        console.info("pyexec 3")
         pyscript_py.set_current_display_target(undefined);
         pyscript_py.destroy();
     }

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -78,11 +78,13 @@ export class PyodideInterpreter extends Interpreter {
             await this.loadPackage('micropip');
         }
         logger.info('pyodide loaded and initialized');
-        await this.run('print("Python initialization complete")')
+        (await this.run('print("Python initialization complete")'))
     }
 
-    async run(code: string): Promise<any> {
-        return this.interface.runPython(code);
+    async run(code: string): Promise<{result: any}> {
+        const x = {result: this.interface.runPython(code)};
+        console.info("llllll", x)
+        return x
     }
 
     registerJsModule(name: string, module: object): void {
@@ -96,7 +98,11 @@ export class PyodideInterpreter extends Interpreter {
         // but one of our tests tries to use a locally downloaded older version of pyodide
         // for which the signature of `loadPackage` accepts the above params as args i.e.
         // the call uses `logger.info.bind(logger), logger.info.bind(logger)`.
-        const pyodide_version = (await this.run("import sys; sys.modules['pyodide'].__version__")).toString();
+        const raw_result = this.run("import sys; sys.modules['pyodide'].__version__")
+        //console.log(raw_result)
+        const awaited = await raw_result
+        //console.log(awaited)
+        const pyodide_version = awaited.result.toString();
         if (pyodide_version.startsWith("0.22")) {
             await this.interface.loadPackage(names, { messageCallback: logger.info.bind(logger), errorCallback: logger.info.bind(logger) });
         }

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -81,10 +81,12 @@ export class PyodideInterpreter extends Interpreter {
         await this.run('print("Python initialization complete")')
     }
 
+    /* eslint-disable */
     async run(code: string): Promise<{result: any}> {
         // TODO: ADD A COMMENT TO EXPLAIN WHY RESULT IS WRAPPED IN A DICTIONARY
-        return { result: await this.interface.runPython(code) };
+        return { result: this.interface.runPython(code) };
     }
+    /* eslint-enable */
 
     registerJsModule(name: string, module: object): void {
         this.interface.registerJsModule(name, module);

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -83,7 +83,24 @@ export class PyodideInterpreter extends Interpreter {
 
     /* eslint-disable */
     async run(code: string): Promise<{result: any}> {
-        // TODO: ADD A COMMENT TO EXPLAIN WHY RESULT IS WRAPPED IN A DICTIONARY
+        /**
+         * eslint wants `await` keyword to be used i.e.
+         * { result: await this.interface.runPython(code) }
+         * However, `await` is not a no-op (no-operation) i.e.
+         * `await 42` is NOT the same as `42` i.e. if the awaited
+         * thing is not a promise, it is wrapped inside a promise and
+         * that promise is awaited. Thus, it changes the execution order.
+         * See https://stackoverflow.com/questions/55262996/does-awaiting-a-non-promise-have-any-detectable-effect
+         * Thus, `eslint` is disabled for this block / snippet.
+         */
+
+        /**
+         * The output of `runPython` is wrapped inside an object
+         * since an object is not thennable and avoids return of
+         * a coroutine directly. This is so we do not `await` the results
+         * of the underlying python execution, even if it's an
+         * awaitable object (Future, Task, etc.)
+         */
         return { result: this.interface.runPython(code) };
     }
     /* eslint-enable */

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -83,7 +83,7 @@ export class PyodideInterpreter extends Interpreter {
 
     async run(code: string): Promise<{result: any}> {
         // TODO: ADD A COMMENT TO EXPLAIN WHY RESULT IS WRAPPED IN A DICTIONARY
-        return {result: this.interface.runPython(code)};
+        return { result: await this.interface.runPython(code) };
     }
 
     registerJsModule(name: string, module: object): void {

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -78,13 +78,11 @@ export class PyodideInterpreter extends Interpreter {
             await this.loadPackage('micropip');
         }
         logger.info('pyodide loaded and initialized');
-        (await this.run('print("Python initialization complete")'))
+        await this.run('print("Python initialization complete")')
     }
 
     async run(code: string): Promise<{result: any}> {
-        const x = {result: this.interface.runPython(code)};
-        console.info("llllll", x)
-        return x
+        return {result: this.interface.runPython(code)};
     }
 
     registerJsModule(name: string, module: object): void {
@@ -98,11 +96,7 @@ export class PyodideInterpreter extends Interpreter {
         // but one of our tests tries to use a locally downloaded older version of pyodide
         // for which the signature of `loadPackage` accepts the above params as args i.e.
         // the call uses `logger.info.bind(logger), logger.info.bind(logger)`.
-        const raw_result = this.run("import sys; sys.modules['pyodide'].__version__")
-        //console.log(raw_result)
-        const awaited = await raw_result
-        //console.log(awaited)
-        const pyodide_version = awaited.result.toString();
+        const pyodide_version = (await this.run("import sys; sys.modules['pyodide'].__version__")).result.toString();
         if (pyodide_version.startsWith("0.22")) {
             await this.interface.loadPackage(names, { messageCallback: logger.info.bind(logger), errorCallback: logger.info.bind(logger) });
         }

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -78,7 +78,7 @@ export class PyodideInterpreter extends Interpreter {
             await this.loadPackage('micropip');
         }
         logger.info('pyodide loaded and initialized');
-        this.run('print("Python initialization complete")')
+        await this.run('print("Python initialization complete")')
     }
 
     async run(code: string): Promise<any> {
@@ -96,7 +96,8 @@ export class PyodideInterpreter extends Interpreter {
         // but one of our tests tries to use a locally downloaded older version of pyodide
         // for which the signature of `loadPackage` accepts the above params as args i.e.
         // the call uses `logger.info.bind(logger), logger.info.bind(logger)`.
-        if (this.run("import sys; sys.modules['pyodide'].__version__").toString().startsWith("0.22")) {
+        const pyodide_version = (await this.run("import sys; sys.modules['pyodide'].__version__")).toString();
+        if (pyodide_version.startsWith("0.22")) {
             await this.interface.loadPackage(names, { messageCallback: logger.info.bind(logger), errorCallback: logger.info.bind(logger) });
         }
         else {

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -81,7 +81,7 @@ export class PyodideInterpreter extends Interpreter {
         this.run('print("Python initialization complete")')
     }
 
-    run(code: string): unknown {
+    async run(code: string): Promise<any> {
         return this.interface.runPython(code);
     }
 

--- a/pyscriptjs/src/pyodide.ts
+++ b/pyscriptjs/src/pyodide.ts
@@ -82,6 +82,7 @@ export class PyodideInterpreter extends Interpreter {
     }
 
     async run(code: string): Promise<{result: any}> {
+        // TODO: ADD A COMMENT TO EXPLAIN WHY RESULT IS WRAPPED IN A DICTIONARY
         return {result: this.interface.runPython(code)};
     }
 

--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -202,15 +202,11 @@ get_current_display_target._id = None
 
 
 def display(*values, target=None, append=True):
-    # print('ddd 1')
     default_target = get_current_display_target()
-    # print('ddd 2', default_target, target)
     if default_target is None and target is None:
-        # print('ddd 3')
         raise Exception(
             "Implicit target not allowed here. Please use display(..., target=...)"
         )
-    # print('ddd 4')
     if target is not None:
         for v in values:
             Element(target).write(v, append=append)

--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -202,13 +202,15 @@ get_current_display_target._id = None
 
 
 def display(*values, target=None, append=True):
+    # print('ddd 1')
     default_target = get_current_display_target()
-
+    # print('ddd 2', default_target, target)
     if default_target is None and target is None:
+        # print('ddd 3')
         raise Exception(
             "Implicit target not allowed here. Please use display(..., target=...)"
         )
-
+    # print('ddd 4')
     if target is not None:
         for v in values:
             Element(target).write(v, append=append)

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -112,3 +112,27 @@ export function createSingularWarning(msg: string, sentinelText: string | null =
         _createAlertBanner(msg, 'warning');
     }
 }
+
+/**
+ * @returns A new asynchronous lock
+ * @private
+ */
+export function createLock() {
+    // This is a promise that is resolved when the lock is open, not resolved when lock is held.
+    let _lock = Promise.resolve();
+  
+    /**
+     * Acquire the async lock
+     * @returns A zero argument function that releases the lock.
+     * @private
+     */
+    async function acquireLock() {
+      const old_lock = _lock;
+      let releaseLock: () => void;
+      _lock = new Promise((resolve) => (releaseLock = resolve));
+      await old_lock;
+      // @ts-ignore
+      return releaseLock;
+    }
+    return acquireLock;
+  }

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -131,7 +131,6 @@ export function createLock() {
       let releaseLock: () => void;
       _lock = new Promise((resolve) => (releaseLock = resolve));
       await old_lock;
-      // @ts-ignore
       return releaseLock;
     }
     return acquireLock;

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -120,7 +120,7 @@ export function createSingularWarning(msg: string, sentinelText: string | null =
 export function createLock() {
     // This is a promise that is resolved when the lock is open, not resolved when lock is held.
     let _lock = Promise.resolve();
-  
+
     /**
      * Acquire the async lock
      * @returns A zero argument function that releases the lock.

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -15,7 +15,7 @@ class TestBasic(PyScriptTest):
             """
         )
         assert self.console.log.lines[0] == self.PY_COMPLETE
-        assert self.console.log.lines[-1] == "hellopytpyscript"
+        assert self.console.log.lines[-1] == "hello pyscript"
 
     def test_python_exception(self):
         self.pyscript_run(

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -15,7 +15,7 @@ class TestBasic(PyScriptTest):
             """
         )
         assert self.console.log.lines[0] == self.PY_COMPLETE
-        assert self.console.log.lines[-1] == "hello pyscript"
+        assert self.console.log.lines[-1] == "hellopytpyscript"
 
     def test_python_exception(self):
         self.pyscript_run(

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -311,7 +311,7 @@ class TestBasic(PyScriptTest):
             == 'print("hello world!")\n'
         )
 
-    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it")
+    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it, see #1213")
     def test_pys_onClick_shows_deprecation_warning(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -311,6 +311,7 @@ class TestBasic(PyScriptTest):
             == 'print("hello world!")\n'
         )
 
+    @pytest.mark.skip(reason="pys-onclick is broken, we should kill it")
     def test_pys_onClick_shows_deprecation_warning(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -311,7 +311,7 @@ class TestBasic(PyScriptTest):
             == 'print("hello world!")\n'
         )
 
-    @pytest.mark.skip(reason="pys-onclick is broken, we should kill it")
+    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it")
     def test_pys_onClick_shows_deprecation_warning(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -133,22 +133,19 @@ class TestAsync(PyScriptTest):
 
                     async def a_func():
                         try:
-                            js.console.info("JEFF WROTE THIS")
-                            await asyncio.sleep(0.1)
                             display('A')
-                            
-                            
+                            await asyncio.sleep(0.1)
                         except Exception as err:
                             js.console.error(str(err))
                         await asyncio.sleep(1)
                         js.console.log("DONE")
 
-                    asyncio.ensure_future(a_func())
+                    # explanation for semi-colon needed pending!
+                    asyncio.ensure_future(a_func());
                 </py-script>
             """
         )
         self.wait_for_console("DONE")
-        print("xxx", self.console.error.lines)
         assert (
             self.console.error.lines[-1]
             == "Implicit target not allowed here. Please use display(..., target=...)"

--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -140,8 +140,10 @@ class TestAsync(PyScriptTest):
                         await asyncio.sleep(1)
                         js.console.log("DONE")
 
-                    # explanation for semi-colon needed pending!
-                    asyncio.ensure_future(a_func());
+                    asyncio.ensure_future(a_func())
+                    # The following None return value is important! If we return the Task
+                    # FIX FIX FIX
+                    ...
                 </py-script>
             """
         )

--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -141,9 +141,6 @@ class TestAsync(PyScriptTest):
                         js.console.log("DONE")
 
                     asyncio.ensure_future(a_func())
-                    # The following None return value is important! If we return the Task
-                    # FIX FIX FIX
-                    ...
                 </py-script>
             """
         )

--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -133,8 +133,11 @@ class TestAsync(PyScriptTest):
 
                     async def a_func():
                         try:
-                            display('A')
+                            js.console.info("JEFF WROTE THIS")
                             await asyncio.sleep(0.1)
+                            display('A')
+                            
+                            
                         except Exception as err:
                             js.console.error(str(err))
                         await asyncio.sleep(1)
@@ -145,6 +148,7 @@ class TestAsync(PyScriptTest):
             """
         )
         self.wait_for_console("DONE")
+        print("xxx", self.console.error.lines)
         assert (
             self.console.error.lines[-1]
             == "Implicit target not allowed here. Please use display(..., target=...)"

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -80,7 +80,7 @@ class TestSplashscreen(PyScriptTest):
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert "hello pyscript" in self.console.log.lines
 
-    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it")
+    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it, see #1213")
     def test_splashscreen_closes_on_error_with_pys_onClick(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_splashscreen.py
+++ b/pyscriptjs/tests/integration/test_splashscreen.py
@@ -1,3 +1,4 @@
+import pytest
 from playwright.sync_api import expect
 
 from .support import PyScriptTest
@@ -79,6 +80,7 @@ class TestSplashscreen(PyScriptTest):
         assert self.console.log.lines[0] == self.PY_COMPLETE
         assert "hello pyscript" in self.console.log.lines
 
+    @pytest.mark.skip(reason="pys-onClick is broken, we should kill it")
     def test_splashscreen_closes_on_error_with_pys_onClick(self):
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_stdio_handling.py
+++ b/pyscriptjs/tests/integration/test_stdio_handling.py
@@ -16,11 +16,11 @@ class TestOutputHandling(PyScriptTest):
                 <div id="second"></div>
                 <div id="third"></div>
             </div>
-            <py-script output="first">print("first 1.");</py-script>
-            <py-script output="second">print("second.");</py-script>
-            <py-script output="third">print("third.");</py-script>
-            <py-script output="first">print("first 2.");</py-script>
-            <py-script>print("no output.");</py-script>
+            <py-script output="first">print("first 1.")</py-script>
+            <py-script output="second">print("second.")</py-script>
+            <py-script output="third">print("third.")</py-script>
+            <py-script output="first">print("first 2.")</py-script>
+            <py-script>print("no output.")</py-script>
             """
         )
 
@@ -110,26 +110,25 @@ class TestOutputHandling(PyScriptTest):
                     print(value)
                     await asyncio.sleep(delay)
                     js.console.log(f"DONE {value}")
-                None
             </py-script>
 
             <div id="first"></div>
             <py-script>
-                asyncio.ensure_future(coro("first", 1));
+                asyncio.ensure_future(coro("first", 1))
             </py-script>
 
             <div id="second"></div>
             <py-script output="second">
-                asyncio.ensure_future(coro("second", 1));
+                asyncio.ensure_future(coro("second", 1))
             </py-script>
 
             <div id="third"></div>
             <py-script output="third">
-                asyncio.ensure_future(coro("third", 0));
+                asyncio.ensure_future(coro("third", 0))
             </py-script>
 
             <py-script output="third">
-                asyncio.ensure_future(coro("DONE", 3));
+                asyncio.ensure_future(coro("DONE", 3))
             </py-script>
             """
         )
@@ -168,7 +167,7 @@ class TestOutputHandling(PyScriptTest):
                 asyncio.ensure_future(coro_bad("badtwo.", 0.2))
                 print("three.")
                 asyncio.ensure_future(coro_bad("badthree.", 0))
-                asyncio.ensure_future(coro_bad("DONE", 1));
+                asyncio.ensure_future(coro_bad("DONE", 1))
             </py-script>
             """
         )

--- a/pyscriptjs/tests/integration/test_stdio_handling.py
+++ b/pyscriptjs/tests/integration/test_stdio_handling.py
@@ -110,7 +110,7 @@ class TestOutputHandling(PyScriptTest):
                     print(value)
                     await asyncio.sleep(delay)
                     js.console.log(f"DONE {value}")
-                None 
+                None
             </py-script>
 
             <div id="first"></div>

--- a/pyscriptjs/tests/integration/test_stdio_handling.py
+++ b/pyscriptjs/tests/integration/test_stdio_handling.py
@@ -4,7 +4,7 @@ from .support import PyScriptTest
 class TestOutputHandling(PyScriptTest):
     # Source of a script to test the TargetedStdio functionality
 
-    def test_targeted_stdio(self):
+    def test_targeted_stdio_solo(self):
         self.pyscript_run(
             """
             <py-config>
@@ -16,11 +16,11 @@ class TestOutputHandling(PyScriptTest):
                 <div id="second"></div>
                 <div id="third"></div>
             </div>
-            <py-script output="first">print("first 1.")</py-script>
-            <py-script output="second">print("second.")</py-script>
-            <py-script output="third">print("third.")</py-script>
-            <py-script output="first">print("first 2.")</py-script>
-            <py-script>print("no output.")</py-script>
+            <py-script output="first">print("first 1.");</py-script>
+            <py-script output="second">print("second.");</py-script>
+            <py-script output="third">print("third.");</py-script>
+            <py-script output="first">print("first 2.");</py-script>
+            <py-script>print("no output.");</py-script>
             """
         )
 
@@ -110,25 +110,26 @@ class TestOutputHandling(PyScriptTest):
                     print(value)
                     await asyncio.sleep(delay)
                     js.console.log(f"DONE {value}")
+                None 
             </py-script>
 
             <div id="first"></div>
             <py-script>
-                asyncio.ensure_future(coro("first", 1))
+                asyncio.ensure_future(coro("first", 1));
             </py-script>
 
             <div id="second"></div>
             <py-script output="second">
-                asyncio.ensure_future(coro("second", 1))
+                asyncio.ensure_future(coro("second", 1));
             </py-script>
 
             <div id="third"></div>
             <py-script output="third">
-                asyncio.ensure_future(coro("third", 0))
+                asyncio.ensure_future(coro("third", 0));
             </py-script>
 
             <py-script output="third">
-                asyncio.ensure_future(coro("DONE", 3))
+                asyncio.ensure_future(coro("DONE", 3));
             </py-script>
             """
         )
@@ -167,7 +168,7 @@ class TestOutputHandling(PyScriptTest):
                 asyncio.ensure_future(coro_bad("badtwo.", 0.2))
                 print("three.")
                 asyncio.ensure_future(coro_bad("badthree.", 0))
-                asyncio.ensure_future(coro_bad("DONE", 1))
+                asyncio.ensure_future(coro_bad("DONE", 1));
             </py-script>
             """
         )

--- a/pyscriptjs/tests/unit/pyodide.test.ts
+++ b/pyscriptjs/tests/unit/pyodide.test.ts
@@ -51,19 +51,19 @@ describe('PyodideInterpreter', () => {
     });
 
     it('should check if interpreter can run python code asynchronously', async () => {
-        expect(interpreter.run('2+3')).toBe(5);
+        expect((await interpreter.run('2+3')).result).toBe(5);
     });
 
     it('should capture stdout', async () => {
         stdio.reset();
-        interpreter.run("print('hello')");
+        await interpreter.run("print('hello')");
         expect(stdio.captured_stdout).toBe('hello\n');
     });
 
     it('should check if interpreter is able to load a package', async () => {
         await interpreter.loadPackage('numpy');
-        interpreter.run('import numpy as np');
-        interpreter.run('x = np.ones((10,))');
+        await interpreter.run('import numpy as np');
+        await interpreter.run('x = np.ones((10,))');
         expect(interpreter.globals.get('x').toJs()).toBeInstanceOf(Float64Array);
     });
 });


### PR DESCRIPTION
CC: @JeffersGlass @antocuni @hoodmane 

TODO comments still required at two places.

Thing to consider: In `pyrepl.ts` -- should the call to `pyExec` be inside a mutex lock? Just the way it was done for the `pyExec` call in `pyscript.ts`