### PR TITLE
Fix deprecation warning for `pyodide.create_proxy`

### DIFF
--- a/pyscriptjs/src/python/pyscript.py
+++ b/pyscriptjs/src/python/pyscript.py
@@ -11,9 +11,9 @@ from textwrap import dedent
 import js
 
 try:
-    from pyodide import create_proxy
-except ImportError:
     from pyodide.ffi import create_proxy
+except ImportError:
+    from pyodide import create_proxy
 
 loop = asyncio.get_event_loop()
 


### PR DESCRIPTION
Try new import path first then fall back to old one