### PR TITLE
Fix `test_asyncio_gather`

### DIFF
--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -43,7 +43,7 @@ class TestAsync(PyScriptTest):
 
             async def get_results():
                 results = await asyncio.gather(*[coro(d) for d in range(3,0,-1)])
-                js.console.log(to_js(results))
+                js.console.log(str(results)) #Compare to string representation, not Proxy
                 js.console.log("DONE")
 
             asyncio.ensure_future(get_results())
@@ -51,7 +51,7 @@ class TestAsync(PyScriptTest):
             """
         )
         self.wait_for_console("DONE")
-        assert self.console.log.lines[-2:] == ["[3,2,1]", "DONE"]
+        assert self.console.log.lines[-2:] == ["[3, 2, 1]", "DONE"]
 
     def test_multiple_async(self):
         self.pyscript_run(


### PR DESCRIPTION
This fixes an issue with the `test_asyncio_gather` test. The test should be comparing the test string against the list of results `[3, 2, 1]`, but it was being compared with the string representation of the PyProxy of the list of results `[3,2,1]`, with different spacing. By specifying that we want to compare directly with the string representation, instead of the `to-js()` version (which did essentially nothing), this issue is resolved. 