### PR TITLE
Fix Failing `test_multiple_async` Test

### DIFF
--- a/pyscriptjs/tests/integration/test_async.py
+++ b/pyscriptjs/tests/integration/test_async.py
@@ -80,9 +80,7 @@ class TestAsync(PyScriptTest):
         )
         self.wait_for_console("b func done")
         assert self.console.log.lines[0] == self.PY_COMPLETE
-        # We are getting some deprecation warnings from pyodide, so we
-        # need to skip the first 2 lines
-        assert self.console.log.lines[3:] == [
+        assert self.console.log.lines[1:] == [
             "A 0",
             "B 0",
             "A 1",


### PR DESCRIPTION
The integration test `test_multiple_async` had accounted for the deprecation warnings caused by `from pyodide import ffi`; now that those are fixed by #1223, the test has been adjusted to correctly pick out the lines that have the test's output.