### PR TITLE
use mkdirTree in emscripten FS

### DIFF
--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -248,6 +248,7 @@ export class PyScriptApp {
         // initialized. But we could easily do it in JS in parallel with the
         // download/startup of pyodide.
         const [paths, fetchPaths] = calculatePaths(this.config.fetch);
+        logger.info('Paths to write: ', paths);
         logger.info('Paths to fetch: ', fetchPaths);
         for (let i = 0; i < paths.length; i++) {
             logger.info(`  fetching path: ${fetchPaths[i]}`);
@@ -332,8 +333,7 @@ export class PyScriptApp {
         const pathArr = filePath.split('/');
         const filename = pathArr.pop();
         // TODO: Would be probably be better to store plugins somewhere like /plugins/python/ or similar
-        const destPath = `./${filename}`;
-        await interpreter._remote.loadFromFile(destPath, filePath);
+        await interpreter._remote.loadFromFile(filename, filePath);
 
         //refresh module cache before trying to import module files into interpreter
         interpreter._remote.invalidate_module_path_cache();

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -212,8 +212,10 @@ export class RemoteInterpreter extends Object {
      * and `/a/b.py` will be placed into `/a/b.py`.
      */
     async loadFromFile(path: string, fetch_path: string): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         path = this.interface._module.PATH_FS.resolve(path);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const dir = this.interface._module.PATH.dirname(path);
         this.interface.FS.mkdirTree(dir);

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -200,54 +200,26 @@ export class RemoteInterpreter extends Object {
      * Example usage:
      * await loadFromFile(`a/b/c/foo.py`, `http://dummy.com/hi.py`)
      *
-     * Nested paths are iteratively analysed and each part is created
-     * if it doesn't exist.
-     *
-     * The analysis returns if the part exists and if it's parent directory exists
-     * Due to the manner in which we proceed, the parent will ALWAYS exist.
-     *
-     * The iteration proceeds in the following manner for `a/b/c/foo.py`:
-     *
-     * - `a` doesn't exist but it's parent i.e. `root` exists --> create `a`
-     * - `a/b` doesn't exist but it's parent i.e. `a` exists --> create `a/b`
-     * - `a/b/c` doesn't exist but it's parent i.e. `a/b` exists --> create `a/b/c`
-     *
-     * Finally, write content of `http://dummy.com/hi.py` to `a/b/c/foo.py`
+     * Write content of `http://dummy.com/hi.py` to `a/b/c/foo.py`
      *
      * NOTE: The `path` parameter expects to have the `filename` in it i.e.
      * `a/b/c/foo.py` is valid while `a/b/c` (i.e. only the folders) are incorrect.
+     *
+     * Also, the path shouldn't be relative i.e. cannot be like './a/b/c'
      */
     async loadFromFile(path: string, fetch_path: string): Promise<void> {
         const pathArr = path.split('/');
-        const filename = pathArr.pop();
-        for (let i = 0; i < pathArr.length; i++) {
-            // iteratively calculates parts of the path i.e. `a`, `a/b`, `a/b/c` for `a/b/c/foo.py`
-            const eachPath = pathArr.slice(0, i + 1).join('/');
-
-            // analyses `eachPath` and returns if it exists along with if its parent directory exists or not
-            const { exists, parentExists } = this.interface.FS.analyzePath(eachPath);
-
-            // due to the iterative manner in which we proceed, the parent directory should ALWAYS exist
-            if (!parentExists) {
-                throw new Error(`'INTERNAL ERROR! cannot create ${path}, this should never happen'`);
-            }
-
-            // creates `eachPath` if it doesn't exist
-            if (!exists) {
-                this.interface.FS.mkdir(eachPath);
-            }
-        }
+        // pop out the filename
+        pathArr.pop();
+        const dirTree = pathArr.join('/');
+        this.interface.FS.mkdirTree(dirTree);
 
         // `robustFetch` checks for failures in getting a response
         const response = await robustFetch(fetch_path);
         const buffer = await response.arrayBuffer();
         const data = new Uint8Array(buffer);
 
-        pathArr.push(filename);
-        // opens a file descriptor for the file at `path`
-        const stream = this.interface.FS.open(pathArr.join('/'), 'w');
-        this.interface.FS.write(stream, data, 0, data.length, 0);
-        this.interface.FS.close(stream);
+        this.interface.FS.writeFile(path, data, {canOwn: true});
     }
 
     /**


### PR DESCRIPTION
Suggested by @hoodmane, the undocumented API for `FS.mkdirTree` can be used to avoid creating nested paths by iteration.

The PR is marked WIP since some tests fail.

For example, one of the tests fail due to:

`this.interface.FS.writeFile(path, data, {canOwn: true})` resulting in an error i.e.
```
{node: undefined, errno: 44, message: 'FS error', stack: '<generic error, no stack>', setErrno: ƒ}
```