### PR TITLE
Fix test reporter again

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -80,8 +80,8 @@ jobs:
             if: success() || failure()
             with:
                 name: test_results
-                path: test_results
-
+                path: pyscriptjs/test_results
+                if-no-files-found: error
 
     Deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -1,7 +1,7 @@
 name: Test Report
 on:
     workflow_run:
-        workflows: ['[CI] Build Unstable']
+        workflows: ['\[CI\] Build Unstable']
         types:
         -   completed
 jobs:


### PR DESCRIPTION
Test reporter take 3. The problem in the previous case was that `upload-artifacts` is not sensitive to the `working-directory: pyscriptjs` setting, so we have to give the path relative to the **original** working directory. I also added `if-no-files-found: error` so this would fail the ci if it was wrong in the future.