### PR TITLE
Add prettier to pre-commit

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
     categories:
-    -   title: New Features
-    -   title: Breaking Changes
-    -   title: Known Issues
+        - title: New Features
+        - title: Breaking Changes
+        - title: Known Issues

--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -1,21 +1,21 @@
-name: '[CI] Build Unstable'
+name: "[CI] Build Unstable"
 
 on:
     push: # Only run on merges into main that modify files under pyscriptjs/ and examples/
         branches:
-        -   main
+            - main
         paths:
-        -   pyscriptjs/**
-        -   examples/**
-        -   .github/workflows/build-latest.yml   # Test that workflow works when changed
+            - pyscriptjs/**
+            - examples/**
+            - .github/workflows/build-latest.yml # Test that workflow works when changed
 
     pull_request: # Run on any PR that modifies files under pyscriptjs/ and examples/
         branches:
-        -   main
+            - main
         paths:
-        -   pyscriptjs/**
-        -   examples/**
-        -   .github/workflows/build-unstable.yml   # Test that workflow works when changed
+            - pyscriptjs/**
+            - examples/**
+            - .github/workflows/build-unstable.yml # Test that workflow works when changed
     workflow_dispatch:
 
 jobs:
@@ -28,59 +28,59 @@ jobs:
             MINICONDA_PYTHON_VERSION: py38
             MINICONDA_VERSION: 4.11.0
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
 
-        -   name: Install node
-            uses: actions/setup-node@v3
-            with:
-                node-version: 18.x
+            - name: Install node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
 
-        -   name: Cache node modules
-            uses: actions/cache@v3
-            env:
-                cache-name: cache-node-modules
-            with:
+            - name: Cache node modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
-                path: ~/.npm
-                key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                    ${{ runner.os }}-build-${{ env.cache-name }}-
-                    ${{ runner.os }}-build-
-                    ${{ runner.os }}-
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-build-${{ env.cache-name }}-
+                      ${{ runner.os }}-build-
+                      ${{ runner.os }}-
 
-        -   name: setup Miniconda
-            uses: conda-incubator/setup-miniconda@v2
+            - name: setup Miniconda
+              uses: conda-incubator/setup-miniconda@v2
 
-        -   name: Setup Environment
-            run: make setup
+            - name: Setup Environment
+              run: make setup
 
-        -   name: Build
-            run: make build
+            - name: Build
+              run: make build
 
-        -   name: TypeScript Tests
-            run: make test-ts
+            - name: TypeScript Tests
+              run: make test-ts
 
-        -   name: Python Tests
-            run: make test-py
+            - name: Python Tests
+              run: make test-py
 
-        -   name: Integration Tests
-            run: make test-integration-parallel
+            - name: Integration Tests
+              run: make test-integration-parallel
 
-        -   uses: actions/upload-artifact@v3
-            with:
-                name: pyscript
-                path: |
-                    pyscriptjs/build/
-                if-no-files-found: error
-                retention-days: 7
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: pyscript
+                  path: |
+                      pyscriptjs/build/
+                  if-no-files-found: error
+                  retention-days: 7
 
-        -   uses: actions/upload-artifact@v3
-            if: success() || failure()
-            with:
-                name: test_results
-                path: pyscriptjs/test_results
-                if-no-files-found: error
+            - uses: actions/upload-artifact@v3
+              if: success() || failure()
+              with:
+                  name: test_results
+                  path: pyscriptjs/test_results
+                  if-no-files-found: error
 
     Deploy:
         runs-on: ubuntu-latest
@@ -91,17 +91,17 @@ jobs:
             id-token: write
 
         steps:
-        -   uses: actions/download-artifact@v3
-            with:
-                name: pyscript
-                path: ./build/
+            - uses: actions/download-artifact@v3
+              with:
+                  name: pyscript
+                  path: ./build/
 
-            # Deploy to S3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+              # Deploy to S3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-        -   name: Sync to S3
-            run: aws s3 sync --quiet ./build/ s3://pyscript.net/unstable/
+            - name: Sync to S3
+              run: aws s3 sync --quiet ./build/ s3://pyscript.net/unstable/

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,4 +1,4 @@
-name: '[Docs] Build Release'
+name: "[Docs] Build Release"
 
 on:
     release:
@@ -13,50 +13,50 @@ jobs:
         env:
             SPHINX_HTML_BASE_URL: https://docs.pyscript.net/
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
-            with:
-                persist-credentials: false   # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-                fetch-depth: 0   # otherwise, there would be errors pushing refs to the destination repository.
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+                  fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
-        -   name: Setup
-            uses: conda-incubator/setup-miniconda@v2
-            with:
-                auto-update-conda: true
-                activate-environment: docs
-                environment-file: docs/environment.yml
-                python-version: '3.9'
+            - name: Setup
+              uses: conda-incubator/setup-miniconda@v2
+              with:
+                  auto-update-conda: true
+                  activate-environment: docs
+                  environment-file: docs/environment.yml
+                  python-version: "3.9"
 
-        -   name: Build
-            shell: bash -l {0}
-            run: |
-                cd docs/
-                make html
+            - name: Build
+              shell: bash -l {0}
+              run: |
+                  cd docs/
+                  make html
 
-        -   name: Upload artifacts
-            uses: actions/upload-artifact@v3
-            with:
-                name: pyscript-docs-${{ github.ref_name }}
-                path: docs/_build/html/
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: pyscript-docs-${{ github.ref_name }}
+                  path: docs/_build/html/
 
-            # Deploy to S3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+              # Deploy to S3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-        -   name: Copy redirect file
-            run: aws s3 cp --quiet ./docs/_build/html/_static/redirect.html s3://docs.pyscript.net/index.html
+            - name: Copy redirect file
+              run: aws s3 cp --quiet ./docs/_build/html/_static/redirect.html s3://docs.pyscript.net/index.html
 
-        -   name: Sync to S3
-            run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/${{ github.ref_name }}/
+            - name: Sync to S3
+              run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/${{ github.ref_name }}/
 
-            # Make sure to remove the latest folder so we sync the full docs upon release
-        -   name: Delete latest directory
-            run: aws s3 rm --recursive s3://docs.pyscript.net/latest/
+              # Make sure to remove the latest folder so we sync the full docs upon release
+            - name: Delete latest directory
+              run: aws s3 rm --recursive s3://docs.pyscript.net/latest/
 
-            # Note that the files are the same as above, but we want to have folders with
-            # /<tag name>/ AND /latest/ which latest will always point to the latest release
-        -   name: Sync to /latest
-            run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/latest/
+              # Note that the files are the same as above, but we want to have folders with
+              # /<tag name>/ AND /latest/ which latest will always point to the latest release
+            - name: Sync to /latest
+              run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/latest/

--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -1,11 +1,11 @@
-name: '[Docs] Build Review'
+name: "[Docs] Build Review"
 
 on:
     pull_request:
         branches:
-        -   '*'
+            - "*"
         paths:
-        -   docs/**
+            - docs/**
 
 concurrency:
     # Concurrency group that uses the workflow name and PR number if available
@@ -26,48 +26,48 @@ jobs:
         env:
             SPHINX_HTML_BASE_URL: https://docs.pyscript.net/
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
-            with:
-                persist-credentials: false   # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-                fetch-depth: 0   # otherwise, there would be errors pushing refs to the destination repository.
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+                  fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
-        -   name: Setup
-            uses: conda-incubator/setup-miniconda@v2
-            with:
-                auto-update-conda: true
-                activate-environment: docs
-                environment-file: docs/environment.yml
-                python-version: '3.9'
+            - name: Setup
+              uses: conda-incubator/setup-miniconda@v2
+              with:
+                  auto-update-conda: true
+                  activate-environment: docs
+                  environment-file: docs/environment.yml
+                  python-version: "3.9"
 
-        -   name: Build
-            shell: bash -l {0}
-            run: |
-                cd docs/
-                make html
+            - name: Build
+              shell: bash -l {0}
+              run: |
+                  cd docs/
+                  make html
 
-        -   name: Upload artifacts
-            uses: actions/upload-artifact@v3
-            with:
-                name: pyscript-docs-review-${{ github.event.number }}
-                path: docs/_build/html/
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: pyscript-docs-review-${{ github.event.number }}
+                  path: docs/_build/html/
 
-            # Deploy to S3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+              # Deploy to S3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-        -   name: Copy redirect file
-            run: aws s3 cp --quiet ./docs/_build/html/_static/redirect.html s3://docs.pyscript.net/index.html
+            - name: Copy redirect file
+              run: aws s3 cp --quiet ./docs/_build/html/_static/redirect.html s3://docs.pyscript.net/index.html
 
-        -   name: Sync to S3
-            run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/review/${{ github.event.number }}/
+            - name: Sync to S3
+              run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/review/${{ github.event.number }}/
 
-        -   name: Adding step summary
-            run: |
-                echo "### Review documentation" >> $GITHUB_STEP_SUMMARY
-                echo "As with any pull request, you can find the rendered documentation version for pull request ${{ github.event.number }} here:"
-                echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
-                echo "https://docs.pyscript.net/review/${{ github.event.number }}/" >> $GITHUB_STEP_SUMMARY
+            - name: Adding step summary
+              run: |
+                  echo "### Review documentation" >> $GITHUB_STEP_SUMMARY
+                  echo "As with any pull request, you can find the rendered documentation version for pull request ${{ github.event.number }} here:"
+                  echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+                  echo "https://docs.pyscript.net/review/${{ github.event.number }}/" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs-unstable.yml
+++ b/.github/workflows/docs-unstable.yml
@@ -1,11 +1,11 @@
-name: '[Docs] Build Latest'
+name: "[Docs] Build Latest"
 
 on:
     push:
         branches:
-        -   main
+            - main
         paths:
-        -   docs/**
+            - docs/**
 
 jobs:
     build:
@@ -16,39 +16,39 @@ jobs:
         env:
             SPHINX_HTML_BASE_URL: https://docs.pyscript.net/
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
-            with:
-                persist-credentials: false   # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-                fetch-depth: 0   # otherwise, there would be errors pushing refs to the destination repository.
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+                  fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
-        -   name: Setup
-            uses: conda-incubator/setup-miniconda@v2
-            with:
-                auto-update-conda: true
-                activate-environment: docs
-                environment-file: docs/environment.yml
-                python-version: '3.9'
+            - name: Setup
+              uses: conda-incubator/setup-miniconda@v2
+              with:
+                  auto-update-conda: true
+                  activate-environment: docs
+                  environment-file: docs/environment.yml
+                  python-version: "3.9"
 
-        -   name: Build
-            shell: bash -l {0}
-            run: |
-                cd docs/
-                make html
+            - name: Build
+              shell: bash -l {0}
+              run: |
+                  cd docs/
+                  make html
 
-        -   name: Upload artifacts
-            uses: actions/upload-artifact@v3
-            with:
-                name: pyscript-docs-latest
-                path: docs/_build/html/
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: pyscript-docs-latest
+                  path: docs/_build/html/
 
-            # Deploy to S3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+              # Deploy to S3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-            # Sync will only copy changed files
-        -   name: Sync to S3
-            run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/unstable/
+              # Sync will only copy changed files
+            - name: Sync to S3
+              run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/unstable/

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,9 +1,9 @@
-name: '[CI] Prepare Release'
+name: "[CI] Prepare Release"
 
 on:
     push:
         tags:
-        -   '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9]+'   # YYYY.MM.MICRO
+            - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9]+" # YYYY.MM.MICRO
 
 env:
     MINICONDA_PYTHON_VERSION: py38
@@ -17,43 +17,43 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
 
-        -   name: Install node
-            uses: actions/setup-node@v3
-            with:
-                node-version: 18.x
+            - name: Install node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
 
-        -   name: Cache node modules
-            uses: actions/cache@v3
-            env:
-                cache-name: cache-node-modules
-            with:
+            - name: Cache node modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
-                path: ~/.npm
-                key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                    ${{ runner.os }}-build-${{ env.cache-name }}-
-                    ${{ runner.os }}-build-
-                    ${{ runner.os }}-
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-build-${{ env.cache-name }}-
+                      ${{ runner.os }}-build-
+                      ${{ runner.os }}-
 
-        -   name: setup Miniconda
-            uses: conda-incubator/setup-miniconda@v2
+            - name: setup Miniconda
+              uses: conda-incubator/setup-miniconda@v2
 
-        -   name: Setup Environment
-            run: make setup
+            - name: Setup Environment
+              run: make setup
 
-        -   name: Build and Test
-            run: make test
+            - name: Build and Test
+              run: make test
 
-        -   name: Zip build folder
-            run: zip -r -q ./build.zip ./build
+            - name: Zip build folder
+              run: zip -r -q ./build.zip ./build
 
-        -   name: Prepare Release
-            uses: softprops/action-gh-release@v1
-            with:
-                draft: true
-                prerelease: true
-                generate_release_notes: true
-                files: ./build.zip
+            - name: Prepare Release
+              uses: softprops/action-gh-release@v1
+              with:
+                  draft: true
+                  prerelease: true
+                  generate_release_notes: true
+                  files: ./build.zip

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: '[CI] Publish Release'
+name: "[CI] Publish Release"
 
 on:
     release:
@@ -19,44 +19,45 @@ jobs:
             contents: read
             id-token: write
         steps:
-        -   name: Checkout
-            uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
 
-        -   name: Install node
-            uses: actions/setup-node@v3
-            with:
-                node-version: 18.x
+            - name: Install node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
 
-        -   name: Cache node modules
-            uses: actions/cache@v3
-            env:
-                cache-name: cache-node-modules
-            with:
+            - name: Cache node modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
-                path: ~/.npm
-                key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                    ${{ runner.os }}-build-${{ env.cache-name }}-
-                    ${{ runner.os }}-build-
-                    ${{ runner.os }}-
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-build-${{ env.cache-name }}-
+                      ${{ runner.os }}-build-
+                      ${{ runner.os }}-
 
-        -   name: setup Miniconda
-            uses: conda-incubator/setup-miniconda@v2
+            - name: setup Miniconda
+              uses: conda-incubator/setup-miniconda@v2
 
-        -   name: Setup Environment
-            run: make setup
+            - name: Setup Environment
+              run: make setup
 
-        -   name: Build and Test
-            run: make test
+            - name: Build and Test
+              run: make test
 
-            # Upload to S3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+              # Upload to S3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
 
-        -   name: Sync to S3
-            run: | # Update /latest and create an explicitly versioned directory under releases/YYYY.MM.MICRO/
-                aws s3 sync --quiet ./build/ s3://pyscript.net/latest/
-                aws s3 sync --quiet ./build/ s3://pyscript.net/releases/${{ github.ref_name }}/
+            - name: Sync to S3
+              run:
+                  | # Update /latest and create an explicitly versioned directory under releases/YYYY.MM.MICRO/
+                  aws s3 sync --quiet ./build/ s3://pyscript.net/latest/
+                  aws s3 sync --quiet ./build/ s3://pyscript.net/releases/${{ github.ref_name }}/

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,11 +1,11 @@
-name: '[CI] Publish Snapshot'
+name: "[CI] Publish Snapshot"
 # Copy /unstable/ to /snapshots/2022.09.1.RC1/
 
 on:
     workflow_dispatch:
         inputs:
             snapshot_version:
-                description: 'The calver version of this snapshot: 2022.09.1 or 2022.09.1.RC1'
+                description: "The calver version of this snapshot: 2022.09.1 or 2022.09.1.RC1"
                 type: string
                 required: true
 
@@ -16,11 +16,11 @@ jobs:
             contents: read
             id-token: write
         steps:
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
-        -   name: Sync to S3
-            run: >
-                aws s3 sync s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+            - name: Sync to S3
+              run: >
+                  aws s3 sync s3://pyscript.net/unstable/ s3://pyscript.net/snapshots/${{ inputs.snapshot_version }}/

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -1,4 +1,4 @@
-name: '[CI] Sync Examples'
+name: "[CI] Sync Examples"
 
 on:
     release:
@@ -16,13 +16,14 @@ jobs:
 
         steps:
             # Deploy to S3
-        -   name: Checkout
-            uses: actions/checkout@v3
-        -   name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1.6.1
-            with:
-                aws-region: ${{ secrets.AWS_REGION }}
-                role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
-        -   name: Sync to S3
-              # Sync outdated or new files, delete ones no longer in source
-            run: aws s3 sync --quiet --delete . s3://pyscript.net/examples/   # Sync directory, delete what is not in source
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1.6.1
+              with:
+                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
+            - name:
+                  Sync to S3
+                  # Sync outdated or new files, delete ones no longer in source
+              run: aws s3 sync --quiet --delete . s3://pyscript.net/examples/ # Sync directory, delete what is not in source

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -3,14 +3,14 @@ on:
     workflow_run:
         workflows: ['\[CI\] Build Unstable']
         types:
-        -   completed
+            - completed
 jobs:
     report:
         runs-on: ubuntu-latest
         steps:
-        -   uses: dorny/test-reporter@v1.6.0
-            with:
-                artifact: test_results
-                name: Test reports
-                path: '*.xml'
-                reporter: java-junit
+            - uses: dorny/test-reporter@v1.6.0
+              with:
+                  artifact: test_results
+                  name: Test reports
+                  path: "*.xml"
+                  reporter: java-junit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
         additional_dependencies:
         -   tomli
 
--   repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.7.0
+-   repo: https://github.com/hoodmane/pyscript-prettier-precommit
+    rev: "v3.0.0-alpha.6"
     hooks:
-    -   id: pretty-format-yaml
-        args: [--autofix, --indent, '4']
-        exclude: .github/ISSUE_TEMPLATE/.*\.yml$
+    -   id: prettier
+        args: [--tab-width, "4"]
+
 
 -   repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.35.0
@@ -55,14 +55,3 @@ repos:
         -   typescript@4.8.4
         -   '@typescript-eslint/eslint-plugin@5.39.0'
         -   '@typescript-eslint/parser@5.39.0'
-
-# Commented out until mdformat-myst supports custom extensions
-# See https://github.com/executablebooks/mdformat-myst/pull/9
-# -   repo: https://github.com/executablebooks/mdformat
-#     rev: 0.7.14 # Use the ref you want to point at
-#     hooks:
-#     -   id: mdformat
-#         additional_dependencies:
-#         -   mdformat-gfm
-#         -   mdformat-myst
-#         -   mdformat-black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,55 +3,54 @@
 
 default_stages: [commit]
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: check-builtin-literals
-    -   id: check-case-conflict
-    -   id: check-docstring-first
-    -   id: check-executables-have-shebangs
-    -   id: check-json
-        exclude: tsconfig.json
-    -   id: check-toml
-    -   id: check-xml
-    -   id: check-yaml
-    -   id: detect-private-key
-    -   id: end-of-file-fixer
-        exclude: \.min\.js$
-    -   id: trailing-whitespace
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.4.0
+      hooks:
+          - id: check-builtin-literals
+          - id: check-case-conflict
+          - id: check-docstring-first
+          - id: check-executables-have-shebangs
+          - id: check-json
+            exclude: tsconfig.json
+          - id: check-toml
+          - id: check-xml
+          - id: check-yaml
+          - id: detect-private-key
+          - id: end-of-file-fixer
+            exclude: \.min\.js$
+          - id: trailing-whitespace
 
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.247
-    hooks:
-    -   id: ruff
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.247
+      hooks:
+          - id: ruff
 
--   repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    -   id: black
+    - repo: https://github.com/psf/black
+      rev: 23.1.0
+      hooks:
+          - id: black
 
--   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
-    hooks:
-    -   id: codespell  # See 'pyproject.toml' for args
-        additional_dependencies:
-        -   tomli
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.2.2
+      hooks:
+          - id: codespell # See 'pyproject.toml' for args
+            additional_dependencies:
+                - tomli
 
--   repo: https://github.com/hoodmane/pyscript-prettier-precommit
-    rev: "v3.0.0-alpha.6"
-    hooks:
-    -   id: prettier
-        args: [--tab-width, "4"]
+    - repo: https://github.com/hoodmane/pyscript-prettier-precommit
+      rev: "v3.0.0-alpha.6"
+      hooks:
+          - id: prettier
+            args: [--tab-width, "4"]
 
-
--   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.35.0
-    hooks:
-    -   id: eslint
-        files: pyscriptjs/src/.*\.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
-        types: [file]
-        additional_dependencies:
-        -   eslint@8.25.0
-        -   typescript@4.8.4
-        -   '@typescript-eslint/eslint-plugin@5.39.0'
-        -   '@typescript-eslint/parser@5.39.0'
+    - repo: https://github.com/pre-commit/mirrors-eslint
+      rev: v8.35.0
+      hooks:
+          - id: eslint
+            files: pyscriptjs/src/.*\.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+            types: [file]
+            additional_dependencies:
+                - eslint@8.25.0
+                - typescript@4.8.4
+                - "@typescript-eslint/eslint-plugin@5.39.0"
+                - "@typescript-eslint/parser@5.39.0"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+ISSUE_TEMPLATE
+*.min.*
+package-lock.json
+docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,4 +25,4 @@ conda:
 # Optionally declare the Python requirements required to build your docs
 python:
     install:
-    -   requirements: docs/requirements.txt
+        - requirements: docs/requirements.txt

--- a/examples/handtrack/say_hello.html
+++ b/examples/handtrack/say_hello.html
@@ -1,123 +1,137 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <title>Say Hello</title>
+        <title>Say Hello</title>
 
-    <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
+        <link rel="icon" type="image/png" href="../favicon.png" />
+        <link
+            rel="stylesheet"
+            href="https://pyscript.net/latest/pyscript.css"
+        />
 
-    <script defer src="https://pyscript.net/latest/pyscript.js"></script>
-  </head>
+        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
+    </head>
 
-  <body>
-    <py-script>
-from js import handTrack, requestAnimationFrame
-from pyodide import create_once_callable
-import asyncio
+    <body>
+        <py-script>
+            from js import handTrack, requestAnimationFrame
+            from pyodide import create_once_callable
+            import asyncio
 
-context = canvas.element.getContext("2d")
+            context = canvas.element.getContext("2d")
 
-isVideo = False
-model = None
+            isVideo = False
+            model = None
 
-modelParams = {
-  "flipHorizontal": True, # flip e.g for video
-  "maxNumBoxes": 20, # maximum number of boxes to detect
-  "iouThreshold": 0.5, # ioU threshold for non-max suppression
-  "scoreThreshold": 0.6, # confidence threshold for predictions.
-}
+            modelParams = {
+              "flipHorizontal": True, # flip e.g for video
+              "maxNumBoxes": 20, # maximum number of boxes to detect
+              "iouThreshold": 0.5, # ioU threshold for non-max suppression
+              "scoreThreshold": 0.6, # confidence threshold for predictions.
+            }
 
-def toggle_video(evt):
-  global isVideo
-  if (not isVideo):
-    update_note.write("Starting video")
-    pyscript.run_until_complete(start_video())
-  else:
-    update_note.write("Stopping video")
-    handTrack.stopVideo(video.element)
-    isVideo = False
-    update_note.write("Video stopped")
+            def toggle_video(evt):
+              global isVideo
+              if (not isVideo):
+                update_note.write("Starting video")
+                pyscript.run_until_complete(start_video())
+              else:
+                update_note.write("Stopping video")
+                handTrack.stopVideo(video.element)
+                isVideo = False
+                update_note.write("Video stopped")
 
-async def start_video():
-  global isVideo
-  update_note.write("Inside sstart video")
-  status = await handTrack.startVideo(video.element)
-  console.log("video started", status)
-  if status:
-    update_note.write("Video started. Now tracking")
-    isVideo = True
-    console.log( "Calling RUN DETECTION")
-    y = await run_detection()
-  else:
-    update_note.write( "Please enable video")
+            async def start_video():
+              global isVideo
+              update_note.write("Inside sstart video")
+              status = await handTrack.startVideo(video.element)
+              console.log("video started", status)
+              if status:
+                update_note.write("Video started. Now tracking")
+                isVideo = True
+                console.log( "Calling RUN DETECTION")
+                y = await run_detection()
+              else:
+                update_note.write( "Please enable video")
 
-def sync_run_detection(evt):
-  pyscript.run_until_complete(run_detection())
+            def sync_run_detection(evt):
+              pyscript.run_until_complete(run_detection())
 
-async def run_detection():
-  console.log("in RUN DETECTION: ");
-  global model
-  global isVideo
+            async def run_detection():
+              console.log("in RUN DETECTION: ");
+              global model
+              global isVideo
 
-  console.log("...1")
+              console.log("...1")
 
-  predictions = await model.detect(video.element)
-  console.log("done...1")
-  console.log("Predictions: ", predictions);
-  model.renderPredictions(predictions, canvas.element, context, video.element);
-  console.log("is Video?", isVideo)
-  if (isVideo):
-    console.log("requestingAnimation!")
-    await requestAnimationFrame(create_once_callable(sync_run_detection));
-  console.log("...2")
+              predictions = await model.detect(video.element)
+              console.log("done...1")
+              console.log("Predictions: ", predictions);
+              model.renderPredictions(predictions, canvas.element, context, video.element);
+              console.log("is Video?", isVideo)
+              if (isVideo):
+                console.log("requestingAnimation!")
+                await requestAnimationFrame(create_once_callable(sync_run_detection));
+              console.log("...2")
 
-def run_detection_image(img):
-  console.log("in RUN DETECTION IMAGE", predictions);
-  global model
-  def detect(predition):
-    console.log("Predictions: ", predictions);
-    model.renderPredictions(predictions, canvas, context, img);
-  console.log("...3")
-  model.detect(img).then(detect)
-  console.log("...4")
+            def run_detection_image(img):
+              console.log("in RUN DETECTION IMAGE", predictions);
+              global model
+              def detect(predition):
+                console.log("Predictions: ", predictions);
+                model.renderPredictions(predictions, canvas, context, img);
+              console.log("...3")
+              model.detect(img).then(detect)
+              console.log("...4")
 
-def handle_model(lmodel):
-  global model
-  model = lmodel
-  update_note.write("Loaded Model!")
+            def handle_model(lmodel):
+              global model
+              model = lmodel
+              update_note.write("Loaded Model!")
 
-async def start():
-  console.log("creating x")
-  console.log("calling x")
-  model = await handTrack.load(modelParams)#.then(handle_model)
-  console.log("loaded model!")
-  console.log(model)
-  handle_model(model)
-  print(dir(x))
-  print(x)
+            async def start():
+              console.log("creating x")
+              console.log("calling x")
+              model = await handTrack.load(modelParams)#.then(handle_model)
+              console.log("loaded model!")
+              console.log(model)
+              handle_model(model)
+              print(dir(x))
+              print(x)
 
-pyscript.run_until_complete(start())
+            pyscript.run_until_complete(start())
 
-#});
+            #});
+        </py-script>
 
-    </py-script>
-
-    <div class="mb10">
-      <button  id="trackbutton" class="bx--btn bx--btn--secondary" type="button" py-onClick="toggle_video()">
-        Toggle Video
-      </button>
-      <button id="nextimagebutton" class="mt10 bx--btn bx--btn--secondary" type="button" disabled>
-        Next Image
-      </button>
-      <div id="update-note" py-mount class="updatenote mt10">loading model ..</div>
-    </div>
-    <div>
-      <video autoplay="autoplay" id="myvideo" py-mount="video"></video>
-      <canvas id="canvas" py-mount class="border canvasbox"></canvas>
-    </div>
-    <script src="lib/handtrack.min.js"> </script>
-  </body>
+        <div class="mb10">
+            <button
+                id="trackbutton"
+                class="bx--btn bx--btn--secondary"
+                type="button"
+                py-onClick="toggle_video()"
+            >
+                Toggle Video
+            </button>
+            <button
+                id="nextimagebutton"
+                class="mt10 bx--btn bx--btn--secondary"
+                type="button"
+                disabled
+            >
+                Next Image
+            </button>
+            <div id="update-note" py-mount class="updatenote mt10">
+                loading model ..
+            </div>
+        </div>
+        <div>
+            <video autoplay="autoplay" id="myvideo" py-mount="video"></video>
+            <canvas id="canvas" py-mount class="border canvasbox"></canvas>
+        </div>
+        <script src="lib/handtrack.min.js"></script>
+    </body>
 </html>

--- a/examples/mario/play_mario.html
+++ b/examples/mario/play_mario.html
@@ -1,145 +1,157 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <title>Mario</title>
+        <title>Mario</title>
 
-    <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
+        <link rel="icon" type="image/png" href="../favicon.png" />
+        <link
+            rel="stylesheet"
+            href="https://pyscript.net/latest/pyscript.css"
+        />
 
-    <script defer src="https://pyscript.net/latest/pyscript.js"></script>
-  </head>
+        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
+    </head>
 
-  <body>
-    <script type="text/javascript" src="js/util.js"></script>
-    <script type="text/javascript" src="js/input.js"></script>
-    <script type="text/javascript" src="js/resources.js"></script>
-    <script type="text/javascript" src="js/sprite.js"></script>
-    <script type="text/javascript" src="js/entity.js"></script>
-    <script type="text/javascript" src="js/pipe.js"></script>
-    <script type="text/javascript" src="js/mushroom.js"></script>
-    <script type="text/javascript" src="js/fireflower.js"></script>
-    <script type="text/javascript" src="js/star.js"></script>
-    <script type="text/javascript" src="js/fireball.js"></script>
-    <script type="text/javascript" src="js/coin.js"></script>
-    <script type="text/javascript" src="js/bcoin.js"></script>
-    <script type="text/javascript" src="js/goomba.js"></script>
-    <script type="text/javascript" src="js/koopa.js"></script>
-    <script type="text/javascript" src="js/floor.js"></script>
-    <script type="text/javascript" src="js/block.js"></script>
-    <script type="text/javascript" src="js/rubble.js"></script>
-    <script type="text/javascript" src="js/prop.js"></script>
-    <script type="text/javascript" src="js/player.js"></script>
-    <script type="text/javascript" src="js/flag.js"></script>
-    <script type="text/javascript" src="js/levels/level.js"></script>
-    <script type="text/javascript" src="js/levels/11.js"></script>
-    <script type="text/javascript" src="js/levels/11tunnel.js"></script>
-    <script type="text/javascript" src="js/game.js"></script>
+    <body>
+        <script type="text/javascript" src="js/util.js"></script>
+        <script type="text/javascript" src="js/input.js"></script>
+        <script type="text/javascript" src="js/resources.js"></script>
+        <script type="text/javascript" src="js/sprite.js"></script>
+        <script type="text/javascript" src="js/entity.js"></script>
+        <script type="text/javascript" src="js/pipe.js"></script>
+        <script type="text/javascript" src="js/mushroom.js"></script>
+        <script type="text/javascript" src="js/fireflower.js"></script>
+        <script type="text/javascript" src="js/star.js"></script>
+        <script type="text/javascript" src="js/fireball.js"></script>
+        <script type="text/javascript" src="js/coin.js"></script>
+        <script type="text/javascript" src="js/bcoin.js"></script>
+        <script type="text/javascript" src="js/goomba.js"></script>
+        <script type="text/javascript" src="js/koopa.js"></script>
+        <script type="text/javascript" src="js/floor.js"></script>
+        <script type="text/javascript" src="js/block.js"></script>
+        <script type="text/javascript" src="js/rubble.js"></script>
+        <script type="text/javascript" src="js/prop.js"></script>
+        <script type="text/javascript" src="js/player.js"></script>
+        <script type="text/javascript" src="js/flag.js"></script>
+        <script type="text/javascript" src="js/levels/level.js"></script>
+        <script type="text/javascript" src="js/levels/11.js"></script>
+        <script type="text/javascript" src="js/levels/11tunnel.js"></script>
+        <script type="text/javascript" src="js/game.js"></script>
 
-    <py-script>
-from js import handTrack, setTimeout, requestAnimationFrame, player
-from pyodide import create_once_callable
-import asyncio
+        <py-script>
+            from js import handTrack, setTimeout, requestAnimationFrame, player
+            from pyodide import create_once_callable
+            import asyncio
 
-context = canvas.element.getContext("2d")
+            context = canvas.element.getContext("2d")
 
-isVideo = False
-model = None
-last_position = 0
-direction = "stop"
+            isVideo = False
+            model = None
+            last_position = 0
+            direction = "stop"
 
-modelParams = {
-  "flipHorizontal": True, # flip e.g for video
-  "maxNumBoxes": 20, # maximum number of boxes to detect
-  "iouThreshold": 0.5, # ioU threshold for non-max suppression
-  "scoreThreshold": 0.6, # confidence threshold for predictions.
-}
+            modelParams = {
+              "flipHorizontal": True, # flip e.g for video
+              "maxNumBoxes": 20, # maximum number of boxes to detect
+              "iouThreshold": 0.5, # ioU threshold for non-max suppression
+              "scoreThreshold": 0.6, # confidence threshold for predictions.
+            }
 
-def toggle_video(evt):
-  global isVideo
-  player.jump()
+            def toggle_video(evt):
+              global isVideo
+              player.jump()
 
-  if (not isVideo):
-    update_note.write("Starting video")
-    pyscript.run_until_complete(start_video())
-  else:
-    update_note.write("Stopping video")
-    handTrack.stopVideo(video.element)
-    isVideo = False
-    update_note.write("Video stopped")
+              if (not isVideo):
+                update_note.write("Starting video")
+                pyscript.run_until_complete(start_video())
+              else:
+                update_note.write("Stopping video")
+                handTrack.stopVideo(video.element)
+                isVideo = False
+                update_note.write("Video stopped")
 
-async def start_video():
-  global isVideo
-  update_note.write("Inside start video")
-  status = await handTrack.startVideo(video.element)
-  console.log("video started", status)
-  if status:
-    update_note.write("Video started. Now tracking")
-    isVideo = True
-    console.log( "Calling RUN DETECTION")
-    y = await run_detection()
-  else:
-    update_note.write( "Please enable video")
+            async def start_video():
+              global isVideo
+              update_note.write("Inside start video")
+              status = await handTrack.startVideo(video.element)
+              console.log("video started", status)
+              if status:
+                update_note.write("Video started. Now tracking")
+                isVideo = True
+                console.log( "Calling RUN DETECTION")
+                y = await run_detection()
+              else:
+                update_note.write( "Please enable video")
 
-def sync_run_detection(evt):
-  pyscript.run_until_complete(run_detection())
+            def sync_run_detection(evt):
+              pyscript.run_until_complete(run_detection())
 
-async def run_detection():
-  global model
-  global isVideo
-  global last_position
-  global direction
+            async def run_detection():
+              global model
+              global isVideo
+              global last_position
+              global direction
 
-  predictions = await model.detect(video.element)
-  model.renderPredictions(predictions, canvas.element, context, video.element);
+              predictions = await model.detect(video.element)
+              model.renderPredictions(predictions, canvas.element, context, video.element);
 
-  if predictions:
-    curr_position = predictions[0].bbox[0] + (predictions[0].bbox[2] / 2)
-    delta = last_position - curr_position
-    last_position = curr_position
-    #console.log(delta, curr_position, last_position)
-    if abs(delta) < 2:
-      direction = "stop"
-    elif delta > 0:
-      direction = "left"
-    else:
-      direction = "right"
+              if predictions:
+                curr_position = predictions[0].bbox[0] + (predictions[0].bbox[2] / 2)
+                delta = last_position - curr_position
+                last_position = curr_position
+                #console.log(delta, curr_position, last_position)
+                if abs(delta) < 2:
+                  direction = "stop"
+                elif delta > 0:
+                  direction = "left"
+                else:
+                  direction = "right"
 
-    for prediction in predictions:
-      if prediction.label == 'open':
-        player.jump()
-      elif prediction.label == 'close':
-        player.crouch()
+                for prediction in predictions:
+                  if prediction.label == 'open':
+                    player.jump()
+                  elif prediction.label == 'close':
+                    player.crouch()
 
-  if (isVideo):
-    await requestAnimationFrame(create_once_callable(sync_run_detection));
+              if (isVideo):
+                await requestAnimationFrame(create_once_callable(sync_run_detection));
 
-def handle_model(lmodel):
-  global model
-  model = lmodel
-  update_note.write("Loaded Model!")
+            def handle_model(lmodel):
+              global model
+              model = lmodel
+              update_note.write("Loaded Model!")
 
-async def start():
-  model = await handTrack.load(modelParams)#.then(handle_model)
-  handle_model(model)
+            async def start():
+              model = await handTrack.load(modelParams)#.then(handle_model)
+              handle_model(model)
 
-pyscript.run_until_complete(start())
+            pyscript.run_until_complete(start())
+        </py-script>
 
-    </py-script>
-
-    <div class="mb10">
-      <p>Use < > to move, ↓ to crouch and x to jump. If video is enabled, say hi to jump as well! </p>
-      <button  id="trackbutton" class="bx--btn bx--btn--secondary" type="button" py-onClick="toggle_video()">
-        Start Video
-      </button>
-      <div id="update-note" py-mount class="updatenote mt10">loading model ..</div>
-    </div>
-    <div>
-      <video autoplay="autoplay" id="myvideo" py-mount="video"></video>
-      <canvas id="canvas" py-mount class="border canvasbox"></canvas>
-    </div>
-    <script src="../handtrack/lib/handtrack.min.js"> </script>
-  </body>
+        <div class="mb10">
+            <p>
+                Use < > to move, ↓ to crouch and x to jump. If video is enabled,
+                say hi to jump as well!
+            </p>
+            <button
+                id="trackbutton"
+                class="bx--btn bx--btn--secondary"
+                type="button"
+                py-onClick="toggle_video()"
+            >
+                Start Video
+            </button>
+            <div id="update-note" py-mount class="updatenote mt10">
+                loading model ..
+            </div>
+        </div>
+        <div>
+            <video autoplay="autoplay" id="myvideo" py-mount="video"></video>
+            <canvas id="canvas" py-mount class="border canvasbox"></canvas>
+        </div>
+        <script src="../handtrack/lib/handtrack.min.js"></script>
+    </body>
 </html>

--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -1,20 +1,20 @@
 channels:
--   defaults
--   conda-forge
--   microsoft
+    - defaults
+    - conda-forge
+    - microsoft
 dependencies:
--   python=3.9
--   pip
--   pytest=7
--   nodejs=16
--   black
--   isort
--   codespell
--   pre-commit
--   pillow
--   numpy
--   markdown
--   pip:
-    -   playwright
-    -   pytest-playwright
-    -   pytest-xdist
+    - python=3.9
+    - pip
+    - pytest=7
+    - nodejs=16
+    - black
+    - isort
+    - codespell
+    - pre-commit
+    - pillow
+    - numpy
+    - markdown
+    - pip:
+          - playwright
+          - pytest-playwright
+          - pytest-xdist


### PR DESCRIPTION
This uses my forked version of prettier. Prettier has no API to ask it to leave `py-script` and `py-config` alone, but it does have an internal method.
See my precommit hook here: https://github.com/hoodmane/pyscript-prettier-precommit

@FabioRosado It would be better to rebase-merge / merge-merge this and not to squash merge, since commit 2 is 378 lines of automated changes (another option would be to split into two prs and temporarily disable pre-commit.ci between them, but that's more annoying)