### PR TITLE
Run eslint in github actions, skip it in precommit.ci

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -81,6 +81,38 @@ jobs:
                   name: test_results
                   path: pyscriptjs/test_results
                   if-no-files-found: error
+    eslint:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: pyscriptjs
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Install node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+
+            - name: Cache node modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-build-${{ env.cache-name }}-
+                      ${{ runner.os }}-build-
+                      ${{ runner.os }}-
+
+            - name: npm install
+              run: npm install
+
+            - name: Eslint
+              run: npx eslint src -c .eslintrc.js
 
     Deploy:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # This is the configuration for pre-commit, a local framework for managing pre-commit hooks
 #   Check out the docs at: https://pre-commit.com/
+ci:
+    skip: [eslint]
 
 default_stages: [commit]
 repos:


### PR DESCRIPTION
precommit.ci seems to have different results than when I run eslint locally. 
At least at first glance, github seems to behave the same as local. So this
turns off eslint in pre-commit.ci and turns it on in gha.