### PR TITLE
Update sync-examples CI to be run manually as well

### DIFF
--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -3,6 +3,7 @@ name: "[CI] Sync Examples"
 on:
     release:
         types: [published]
+    workflow_dispatch:
 
 jobs:
     build:


### PR DESCRIPTION
This PR adds `workflow_dispatch` to the sync examples action so we can trigger it manually from within github itself. This should allow us to publish examples and fix the issue with py_tutor without doing a full release.