### PR TITLE
Fix examples broken because of a wrong link

### DIFF
--- a/examples/altair.html
+++ b/examples/altair.html
@@ -29,7 +29,7 @@
                       "vega_datasets"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
                 <py-script>

--- a/examples/antigravity.html
+++ b/examples/antigravity.html
@@ -23,7 +23,7 @@
             <section class="pyscript">
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./antigravity.py"]

--- a/examples/bokeh.html
+++ b/examples/bokeh.html
@@ -57,7 +57,7 @@
                       "xyzservices"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/bokeh_interactive.html
+++ b/examples/bokeh_interactive.html
@@ -57,7 +57,7 @@
                       "numpy",
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/d3.html
+++ b/examples/d3.html
@@ -45,7 +45,7 @@
             <py-tutor modules="d3.py">
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./d3.py"]

--- a/examples/folium.html
+++ b/examples/folium.html
@@ -29,7 +29,7 @@
                       "pandas"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/hello_world.html
+++ b/examples/hello_world.html
@@ -28,7 +28,7 @@
         <py-tutor>
             <py-config>
                 plugins = [
-                  "../build/plugins/python/py_tutor.py"
+                  "https://pyscript.net/latest/plugins/python/py_tutor.py"
                 ]
             </py-config>
 

--- a/examples/markdown-plugin.html
+++ b/examples/markdown-plugin.html
@@ -6,10 +6,13 @@
         <title>PyMarkdown</title>
 
         <link rel="icon" type="image/png" href="favicon.png" />
-        <link rel="stylesheet" href="../build/pyscript.css" />
+        <link
+            rel="stylesheet"
+            href="https://pyscript.net/latest/pyscript.css"
+        />
 
         <link rel="stylesheet" href="./assets/css/examples.css" />
-        <script defer src="../build/pyscript.js"></script>
+        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
     </head>
 
     <body>
@@ -19,8 +22,8 @@
                   "markdown"
                 ]
                 plugins = [
-                  "../build/plugins/python/py_markdown.py",
-                  "../build/plugins/python/py_tutor.py"
+                  "https://pyscript.net/latest/plugins/python/py_markdown.py",
+                  "https://pyscript.net/latest/plugins/python/py_tutor.py"
                 ]
             </py-config>
 

--- a/examples/matplotlib.html
+++ b/examples/matplotlib.html
@@ -28,7 +28,7 @@
                       "matplotlib"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/message_passing.html
+++ b/examples/message_passing.html
@@ -19,7 +19,7 @@
                 "matplotlib"
                 ]
                 plugins = [
-                  "../build/plugins/python/py_tutor.py"
+                  "https://pyscript.net/latest/plugins/python/py_tutor.py"
                 ]
             </py-config>
 

--- a/examples/numpy_canvas_fractals.html
+++ b/examples/numpy_canvas_fractals.html
@@ -170,7 +170,7 @@
                         }
                       ],
                       "plugins": [
-                        "../build/plugins/python/py_tutor.py"
+                        "https://pyscript.net/latest/plugins/python/py_tutor.py"
                       ]
                     }
                 </py-config>

--- a/examples/pandas.html
+++ b/examples/pandas.html
@@ -67,7 +67,7 @@
         <py-tutor>
             <py-config>
                 plugins = [
-                "../build/plugins/python/py_tutor.py"
+                "https://pyscript.net/latest/plugins/python/py_tutor.py"
                 ]
                 packages = ["pandas"]
             </py-config>

--- a/examples/panel.html
+++ b/examples/panel.html
@@ -48,7 +48,7 @@
                       "panel==0.14.1"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/panel_deckgl.html
+++ b/examples/panel_deckgl.html
@@ -133,7 +133,7 @@
                       "panel==0.13.1"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/panel_kmeans.html
+++ b/examples/panel_kmeans.html
@@ -129,7 +129,7 @@
                       "panel==0.13.1"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/panel_stream.html
+++ b/examples/panel_stream.html
@@ -105,7 +105,7 @@
                       "panel==0.13.1"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                 </py-config>
 

--- a/examples/repl.html
+++ b/examples/repl.html
@@ -33,7 +33,7 @@
             <py-tutor modules="antigravity.py">
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./antigravity.py"]

--- a/examples/repl2.html
+++ b/examples/repl2.html
@@ -34,7 +34,7 @@
                       "numpy"
                     ]
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
 
                     [[fetch]]

--- a/examples/simple_clock.html
+++ b/examples/simple_clock.html
@@ -35,7 +35,7 @@
             <py-tutor modules="utils.py">
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./utils.py"]

--- a/examples/todo-pylist.html
+++ b/examples/todo-pylist.html
@@ -37,7 +37,7 @@
 
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./utils.py", "./pylist.py"]

--- a/examples/todo.html
+++ b/examples/todo.html
@@ -29,7 +29,7 @@
             <py-tutor modules="./utils.py;./todo.py">
                 <py-config>
                     plugins = [
-                      "../build/plugins/python/py_tutor.py"
+                      "https://pyscript.net/latest/plugins/python/py_tutor.py"
                     ]
                     [[fetch]]
                     files = ["./utils.py", "./todo.py"]


### PR DESCRIPTION
At the moment of writing, pyscript.net/examples/* are broken because they try to load the plugin `../build/plugins/python/py_tutor.py`.
This is wrong, they should reference `pyscript.net/latest/plugins/python/py_tutor.py` instead.

This is what happened:

1. the git pyscript/examples directory is the one which goes straight to pyscript.net: it is supposed to contain absolute links to e.g. pyscript.net/latest/pyscript.js etc.

2. when you do make examples, the makefile replaces links to pyscript.net to ../build/ so that the examples also work locally

3. in PR #1040, @fpliger changed the source code in pyscript/examples to point to a plugin in ../build/: but this is wrong! It should point to pyscript.net (and then the makefile fixes the link automatically when we do `make examples`).

