### PR TITLE
Ruff: Add pylint

### DIFF
--- a/examples/micrograd_ai.py
+++ b/examples/micrograd_ai.py
@@ -26,7 +26,7 @@ def print_div(o):
 
 # All code is wrapped in this run_all function so it optionally executed (called)
 # from pyscript when a button is pressed.
-def micrograd_demo(*args, **kwargs):
+def micrograd_demo(*args, **kwargs):  # noqa: PLR0915
     """
     Runs the micrograd demo.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ builtins = [
     "pyscript",
 ]
 ignore = [
+    "PLR2004",
     "S101",
     "S113",
 ]
@@ -26,6 +27,7 @@ select = [
     "E",
     "F",
     "I",
+    "PL",
     "S",
     "UP",
     "W",

--- a/pyscriptjs/src/python/pyscript/__init__.py
+++ b/pyscriptjs/src/python/pyscript/__init__.py
@@ -79,8 +79,8 @@ def _set_version_info(version_from_interpreter: str):
             YYYY.MM.m(m).releaselevel
             Year, Month, and Minor should be integers; releaselevel can be any string
     """
-    global __version__
-    global version_info
+    global __version__  # noqa: PLW0603
+    global version_info  # noqa: PLW0603
 
     __version__ = version_from_interpreter
 

--- a/pyscriptjs/tests/integration/conftest.py
+++ b/pyscriptjs/tests/integration/conftest.py
@@ -78,10 +78,9 @@ def pytest_configure(config):
             - cd tests/integration; pytest
         """
         pytest.fail(msg)
-    else:
-        if config.option.dev:
-            config.option.headed = True
-            config.option.no_fake_server = True
+    elif config.option.dev:
+        config.option.headed = True
+        config.option.no_fake_server = True
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Add [pylint rules](https://beta.ruff.rs/docs/rules/#pylint-pl) for convention, errors, refactoring, and warning.

__Ignore__:
% `ruff rule PLR2004`
# magic-value-comparison (PLR2004)

Derived from the **Pylint** linter.

Message formats:
* Magic value used in comparison, consider replacing {value} with a constant variable