### PR TITLE
Docked auto py-terminal

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+2023.XX.X
+=========
+
+Features
+--------
+
+- Added a `docked` field and attribute for the `<py-terminal>` custom element, enabled by default when the terminal is in `auto` mode, and able to dock the terminal at the bottom of the page with auto scroll on new code execution.
+
+
 2023.01.1
 =========
 

--- a/docs/reference/plugins/py-terminal.md
+++ b/docs/reference/plugins/py-terminal.md
@@ -4,7 +4,9 @@ This is one of the core plugins in PyScript, which is active by default. With it
 
 ## Configuration
 
-You can control how `<py-terminal>` behaves by setting the value of the  `terminal` configuration in your `<py-config>`.
+You can control how `<py-terminal>` behaves by setting the value of the `terminal` configuration in your `<py-config>`, together with the `docked` one.
+
+For the **terminal** field, these are the values:
 
 | value | description |
 |-------|-------------|
@@ -12,11 +14,25 @@ You can control how `<py-terminal>` behaves by setting the value of the  `termin
 | `true` | Automatically add a `<py-terminal>` to the page |
 | `"auto"` | This is the default. Automatically add a `<py-terminal auto>`, to the page. The terminal is initially hidden and automatically shown as soon as something writes to `stdout` and/or `stderr` |
 
+For the **docked** field, these are the values:
+
+| value | description |
+|-------|-------------|
+| `false` | Don't dock `<py-terminal>` to the page |
+| `true` | Automatically dock a `<py-terminal>` to the page |
+| `"docked"` | This is the default. Automatically add a `<py-terminal docked>`, to the page. The terminal, once visible, is automatically shown at the bottom of the page, covering the width of such page |
+
+Please note that **docked** mode is currently used as default only when `terminal="auto"`, or *terminal* default, is used.
+
+In all other cases it's up to the user decide if a terminal should be docked or not.
+
+
 ### Examples
 
 ```html
 <py-config>
     terminal = true
+    docked = false
 </py-config>
 
 <py-script>

--- a/pyscriptjs/src/styles/pyscript_base.css
+++ b/pyscriptjs/src/styles/pyscript_base.css
@@ -330,3 +330,20 @@ textarea {
 .py-terminal-hidden {
     display: none;
 }
+
+/* avoid changing the page layout when the terminal is docked and hidden */
+html:has(py-terminal[docked]:not(py-terminal[docked].py-terminal-hidden)) {
+    padding-bottom: 40vh;
+}
+
+py-terminal[docked] {
+    position: fixed;
+    bottom: 0;
+    width: 100vw;
+    max-height: 40vh;
+    overflow: auto;
+}
+
+py-terminal[docked] .py-terminal {
+    margin: 0;
+}

--- a/pyscriptjs/tests/integration/test_py_terminal.py
+++ b/pyscriptjs/tests/integration/test_py_terminal.py
@@ -131,3 +131,18 @@ class TestPyTerminal(PyScriptTest):
         )
         term = self.page.locator("py-terminal")
         assert term.count() == 0
+
+    def test_config_docked(self):
+        """
+        config.docked == "docked" is also the default: a <py-terminal auto docked> is
+        automatically added to the page
+        """
+        self.pyscript_run(
+            """
+            <button id="my-button" py-onClick="print('hello world')">Click me</button>
+            """
+        )
+        term = self.page.locator("py-terminal")
+        self.page.locator("button").click()
+        expect(term).to_be_visible()
+        assert term.get_attribute("docked") == ""


### PR DESCRIPTION
## Description

Make the default auto terminal docked at the bottom of the document.

### Changes

As discussed with Antonio, this MR does the following:

  * it accepts an optional `docked` configuration option, which is `"docked"` by default
  * the attribute behaves just like the `auto` one
  * the *py-terminal* is fixed at the bottom of the page, keeping the underlying page scrollable

Accidentally this PR also fixes an issue with `terminal = true` not being treated like `terminal = "auto"`.

## Checklist

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)

There is some TODO/TO-DISCUSS here around extra possible features or behavior so this is some sort of PoC.