### PR TITLE
Slightly imporved pyrepl

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -21,7 +21,6 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
 
            this             <py-repl>
            boxDiv               <div class='py-repl-box'>
-           editorLabel              <label>...</label>
            editorDiv                <div class="py-repl-editor"></div>
            outDiv                   <div class="py-repl-output"></div>
                                 </div>
@@ -35,6 +34,7 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
 
         connectedCallback() {
             ensureUniqueId(this);
+
             if (!this.hasAttribute('exec-id')) {
                 this.setAttribute('exec-id', '0');
             }
@@ -86,10 +86,8 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
             boxDiv.className = 'py-repl-box';
 
             const editorDiv = this.makeEditorDiv();
-            const editorLabel = this.makeLabel('Python Script Area', editorDiv);
             this.outDiv = this.makeOutDiv();
 
-            boxDiv.append(editorLabel);
             boxDiv.appendChild(editorDiv);
             boxDiv.appendChild(this.outDiv);
 
@@ -98,35 +96,21 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
 
         makeEditorDiv(): HTMLElement {
             const editorDiv = document.createElement('div');
-            editorDiv.id = 'code-editor';
             editorDiv.className = 'py-repl-editor';
+            editorDiv.setAttribute('aria-label', 'Python Script Area');
             editorDiv.appendChild(this.editor.dom);
 
             const runButton = this.makeRunButton();
-            const runLabel = this.makeLabel('Python Script Run Button', runButton);
-            editorDiv.appendChild(runLabel);
             editorDiv.appendChild(runButton);
 
             return editorDiv;
         }
 
-        makeLabel(text: string, elementFor: HTMLElement): HTMLElement {
-            ensureUniqueId(elementFor);
-            const lbl = document.createElement('label');
-            lbl.innerHTML = text;
-            lbl.htmlFor = elementFor.id;
-            // XXX this should be a CSS class
-            // Styles that we use to hide the labels whilst also keeping it accessible for screen readers
-            const labelStyle = 'overflow:hidden; display:block; width:1px; height:1px';
-            lbl.setAttribute('style', labelStyle);
-            return lbl;
-        }
-
         makeRunButton(): HTMLElement {
             const runButton = document.createElement('button');
-            runButton.id = 'runButton';
             runButton.className = 'absolute py-repl-run-button';
             runButton.innerHTML = RUNBUTTON;
+            runButton.setAttribute('aria-label', 'Python Script Run Button');
             runButton.addEventListener('click', this.execute.bind(this) as (e: MouseEvent) => void);
             return runButton;
         }
@@ -170,15 +154,8 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
         // should be the default.
         autogenerateMaybe(): void {
             if (this.hasAttribute('auto-generate')) {
-                const root = this.getAttribute('root');
-                const allPyRepls = document.querySelectorAll(`py-repl[root='${root}'][exec-id]`);
+                const allPyRepls = document.querySelectorAll(`py-repl[root='${this.getAttribute('root')}'][exec-id]`);
                 const lastRepl = allPyRepls[allPyRepls.length - 1];
-
-                // get out if no Repl is found instead of throwing an error
-                if (lastRepl === null) return;
-
-                this.removeAttribute('auto-generate');
-
                 const lastExecId = lastRepl.getAttribute('exec-id');
                 const nextExecId = parseInt(lastExecId) + 1;
 

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -24,9 +24,8 @@ class TestPyRepl(PyScriptTest):
             <py-repl></py-repl>
             """
         )
-        py_repl = self.page.query_selector("py-repl")
+        py_repl = self.page.query_selector("py-repl .py-repl-box")
         assert py_repl
-        assert "Python" in py_repl.inner_text()
 
     def test_execute_preloaded_source(self):
         """
@@ -69,7 +68,7 @@ class TestPyRepl(PyScriptTest):
             </py-repl>
             """
         )
-        self.page.wait_for_selector("#runButton")
+        self.page.wait_for_selector("py-repl .py-repl-run-button")
         self.page.keyboard.press("Shift+Enter")
         wait_for_render(self.page, "*", "hello world")
 

--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -299,7 +299,7 @@ class TestExamples(PyScriptTest):
         wait_for_render(self.page, "*", "<py-repl.*?>")
 
         self.page.locator("py-repl").type("display('Hello, World!')")
-        self.page.locator("#runButton").click()
+        self.page.locator("py-repl .py-repl-run-button").click()
 
         assert (
             self.page.locator("#my-repl-repl-output").text_content() == "Hello, World!"
@@ -322,7 +322,7 @@ class TestExamples(PyScriptTest):
         wait_for_render(self.page, "*", "<py-repl.*?>")
         # confirm we can import utils and run one command
         self.page.locator("py-repl").type("import utils\ndisplay(utils.now())")
-        self.page.wait_for_selector("#runButton").click()
+        self.page.wait_for_selector("py-repl .py-repl-run-button").click()
         # Make sure the output is in the page
         self.page.wait_for_selector("#my-repl-1")
         # utils.now returns current date time


### PR DESCRIPTION
## Description

This PR slightly simplifies some dance around *py-repl* component without tackling other concerns we still need to discuss. The code has been cleaned up a bit, simplified, and it should be less error prone.

### Changes

  * removed unnecessary `getAttribute`
  * removed unnecessary *shadow* and ShadowDOM in general, as it was never used
  * dropped redundant constructor
  * reused `addReplAttribute` for both attributes
  * removed unnecessary usage of the label element + fixed redundant always-same buttons IDs

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
