### PR TITLE
Fix tests running on osx + remove auto-gen where doesnt make sense

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,22 @@
 # Release Notes
 
 2023.XX.X
-=========
+========= 
 
 Features
 --------
 
 - Added a `docked` field and attribute for the `<py-terminal>` custom element, enabled by default when the terminal is in `auto` mode, and able to dock the terminal at the bottom of the page with auto scroll on new code execution.
 
+Bug fixes
+---------
+
+- Fixes [#1280](https://github.com/pyscript/pyscript/issues/1280), which describes the errors on the PyRepl tests related to having auto-gen tags that shouldn't be there.
+
+Enhancements
+------------
+
+- Py-REPL tests now run on both osx and non osx OSs
 
 2023.01.1
 =========

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 2023.XX.X
-========= 
+=========
 
 Features
 --------

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -10,7 +10,7 @@ class TestPyRepl(PyScriptTest):
         WARNING: this assumes that the textbox has already the focus
         """
         # clear the editor, write new code
-        if 'macOS' in platform.platform():
+        if "macOS" in platform.platform():
             self.page.keyboard.press("Meta+A")
         else:
             self.page.keyboard.press("Control+A")

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -1,3 +1,5 @@
+import platform
+
 from .support import PyScriptTest, wait_for_render
 
 
@@ -8,7 +10,11 @@ class TestPyRepl(PyScriptTest):
         WARNING: this assumes that the textbox has already the focus
         """
         # clear the editor, write new code
-        self.page.keyboard.press("Control+A")
+        if 'macOS' in platform.platform():
+            self.page.keyboard.press("Meta+A")
+        else:
+            self.page.keyboard.press("Control+A")
+
         self.page.keyboard.press("Backspace")
         self.page.keyboard.type(newcode)
 
@@ -110,7 +116,7 @@ class TestPyRepl(PyScriptTest):
         """
         self.pyscript_run(
             """
-            <py-repl  auto-generate="true">
+            <py-repl>
                 display('hello world')
             </py-repl>
             """
@@ -124,7 +130,7 @@ class TestPyRepl(PyScriptTest):
         self._replace(py_repl, "display('another output')")
         self.page.keyboard.press("Shift+Enter")
         print
-        assert out_div.all_inner_texts()[1] == "another output"
+        assert out_div.all_inner_texts()[0] == "another output"
 
     def test_python_exception(self):
         """
@@ -175,7 +181,7 @@ class TestPyRepl(PyScriptTest):
     def test_python_exception_after_previous_output(self):
         self.pyscript_run(
             """
-            <py-repl auto-generate="true">
+            <py-repl>
                 display('hello world')
             </py-repl>
             """
@@ -188,8 +194,8 @@ class TestPyRepl(PyScriptTest):
         # clear the editor, write new code, execute
         self._replace(py_repl, "0/0")
         self.page.keyboard.press("Shift+Enter")
-        assert "hello world" not in out_div.all_inner_texts()[1]
-        assert "ZeroDivisionError" in out_div.all_inner_texts()[1]
+        assert "hello world" not in out_div.all_inner_texts()[0]
+        assert "ZeroDivisionError" in out_div.all_inner_texts()[0]
 
     def test_hide_previous_error_after_successful_run(self):
         """
@@ -199,7 +205,7 @@ class TestPyRepl(PyScriptTest):
         """
         self.pyscript_run(
             """
-            <py-repl  auto-generate="true">
+            <py-repl>
                 raise Exception('this is an error')
             </py-repl>
             """
@@ -211,7 +217,7 @@ class TestPyRepl(PyScriptTest):
         #
         self._replace(py_repl, "display('hello')")
         self.page.keyboard.press("Shift+Enter")
-        assert out_div.all_inner_texts()[1] == "hello"
+        assert out_div.all_inner_texts()[0] == "hello"
 
     def test_output_attribute(self):
         self.pyscript_run(


### PR DESCRIPTION
## Description

In the end the problem was simply a osx vs other os problem.
The `autogen` fix comes from me not paying attention in the past while changing the autogen functionality. Sorry for that!

fixes #1280

## Checklist

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
