### PR TITLE
Make repl hooks optional

### DIFF
--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -189,13 +189,13 @@ export class PluginManager {
     }
 
     beforePyReplExec(options: { interpreter: InterpreterClient; src: string; outEl: HTMLElement; pyReplTag: any }) {
-        for (const p of this._plugins) p.beforePyReplExec(options);
+        for (const p of this._plugins) p.beforePyReplExec?.(options);
 
         for (const p of this._pythonPlugins) p.beforePyReplExec?.callKwargs(options);
     }
 
     afterPyReplExec(options: { interpreter: InterpreterClient; src: string; outEl; pyReplTag; result }) {
-        for (const p of this._plugins) p.afterPyReplExec(options);
+        for (const p of this._plugins) p.afterPyReplExec?.(options);
 
         for (const p of this._pythonPlugins) p.afterPyReplExec?.callKwargs(options);
     }


### PR DESCRIPTION
## Description

Makes the new methods `beforePyReplExec` and `afterPyReplExec` from #1106 optional for plugin classes, just like I did for all the other methods in #1134.  An oversight of mine, working on both of those PRs at once.

