### PR TITLE
re-enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Feature Proposals
     url: https://github.com/pyscript/pyscript/discussions/new?category=proposals


### PR DESCRIPTION
 They were disabled by PR #1157 but without any discussion or consensus, so I guess it was a mistake. Personally I found them very useful and AFAIK we never had a problem of people abusing them, so I don't see why they should be disabled

