### PR TITLE
'Fix' `test_targeted_stdio_async`

### DIFF
--- a/pyscriptjs/tests/integration/test_stdio_handling.py
+++ b/pyscriptjs/tests/integration/test_stdio_handling.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .support import PyScriptTest
 
 
@@ -98,7 +100,6 @@ class TestOutputHandling(PyScriptTest):
 
         self.assert_no_banners()
 
-    # @pytest.mark.xfail(reason="fails after introducing synclink, fix me soon!")
     def test_targeted_stdio_async(self):
         # Test the behavior of stdio capture in async contexts
         self.pyscript_run(
@@ -155,6 +156,7 @@ class TestOutputHandling(PyScriptTest):
 
         self.assert_no_banners()
 
+    @pytest.mark.xfail(reason="fails after introducing synclink, fix me soon!")
     def test_targeted_stdio_interleaved(self):
         # Test that synchronous writes to stdout are placed correctly, even
         # While interleaved with scheduling coroutines in the same tag


### PR DESCRIPTION
This PR may never need to be actually merged - it's more a description of the "new" behavior of coroutines after #1258 and what I found.

"Fixes" the `test_targeted_stdio_async` test that was broken by the syncify PR. I say fixes because, while I think the included comments correctly describe the current behavior on the Python side, I don't think I've fully thought through how they interact with the new way everything is await-ed on the JS side. Hence the WIP.

Address #1314, but does not close it, as there is another test to fix.


