### PR TITLE
Improve `validate()` function for plugin options

### DIFF
--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -267,43 +267,49 @@ export function define_custom_element(tag: string, pyElementClass: PyElementClas
     customElements.define(tag, ProxyCustomElement);
 }
 
-// Members of py-config in plug that we want to validate must be one of these types; 
+// Members of py-config in plug that we want to validate must be one of these types;
 // see next comment for more detail
-type BaseConfigObject = string | boolean | number | object
+type BaseConfigObject = string | boolean | number | object;
 
 /* The following interface (ConfigOption) and function (checkedConfigOption)
  * work together to ensure that the default value for ConfigOptions objects
  * settings objects must be one of the members of the array of possible values.
- * 
+ *
  * checkedConfigOption allows us to create the configuration options objects with
  * correct typing without having to duplicate all the parameters.
  * I.e, the following would also work, from a types perspective, but all the values
  * have to be entered twice for each type:
- * 
- * const terminal_settings: ConfigOption<[true, false, 'auto'][number], 'auto'> 
+ *
+ * const terminal_settings: ConfigOption<[true, false, 'auto'][number], 'auto'>
  *      = {possible_values: [true, false, 'auto'], default:'auto'}
- * 
+ *
  * The possible values are constained to be of type BaseConfigObject (above),
  * i.e. if we want to validate more types of things, BaseConfigObject
  * will need to be extended
  */
 
-interface ConfigOption<F extends BaseConfigObject, D extends F>{
-    possible_values: ReadonlyArray<F>
-    default: D
+interface ConfigOption<F extends BaseConfigObject, D extends F> {
+    possible_values: ReadonlyArray<F>;
+    default: D;
 }
 
-export function checkedConfigOption<F extends BaseConfigObject, D extends F>(value: ConfigOption<F, D>){return value}
+export function checkedConfigOption<F extends BaseConfigObject, D extends F>(value: ConfigOption<F, D>) {
+    return value;
+}
 
 /**
- * Validate that parameter the user provided to py-config is one of the acceptable values; 
+ * Validate that parameter the user provided to py-config is one of the acceptable values;
  * if not, throw an error explaining the bad value
  * @param config - The (extended) AppConfig object from py-config
  * @param {string} name - The name of the key in py-config to be checked
  * @param {possible_vlaues: Array.<BaseConfigObject>, default: BaseConfigObject} options - An object of the specified type, enumerating the acceptable values for this configuration object and the default value
  */
-export function validateConfigParameter<AppConfig> (config: AppConfig, name: string, options: ReturnType<typeof checkedConfigOption>) {
-    const value = config[name]
+export function validateConfigParameter<AppConfig>(
+    config: AppConfig,
+    name: string,
+    options: ReturnType<typeof checkedConfigOption>,
+) {
+    const value = config[name];
     if (value !== undefined && !options.possible_values.includes(value)) {
         const got = JSON.stringify(value);
         throw new UserError(
@@ -315,4 +321,4 @@ export function validateConfigParameter<AppConfig> (config: AppConfig, name: str
     if (value === undefined) {
         config[name] = options.default;
     }
-};
+}

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -314,8 +314,8 @@ export function validateConfigParameter<AppConfig>(
         const got = JSON.stringify(value);
         throw new UserError(
             ErrorCode.BAD_CONFIG,
-            `Invalid value for config.${name}: the only accepted` +
-                `values are: [${options.possible_values.join(',')}], got "${got}".`,
+            `Invalid value for config.${name}: the only accepted ` +
+                `values are: [${options.possible_values.map(item => JSON.stringify(item)).join(', ')}], got: ${got}.`,
         );
     }
     if (value === undefined) {

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -272,11 +272,13 @@ export function define_custom_element(tag: string, pyElementClass: PyElementClas
 type BaseConfigObject = string | boolean | number | object;
 
 /**
- * Validate that parameter the user provided to py-config is one of the acceptable values;
+ * Validate that parameter the user provided to py-config conforms to the specified validation function;
  * if not, throw an error explaining the bad value
- * @param config - The (extended) AppConfig object from py-config
- * @param {string} name - The name of the key in py-config to be checked
- * @param {possible_vlaues: Array<BaseConfigObject>, default: BaseConfigObject} options - An object of the specified type, enumerating the acceptable values for this configuration object and the default value
+ * @param options.config - The (extended) AppConfig object from py-config
+ * @param {string} options.name - The name of the key in py-config to be checked
+ * @param {(b:BaseConfigObject) => boolean} options.validator - the validation function used to test the user-supplied value
+ * @param {BaseConfigObject} options.defaultValue - The default value for this parameter, if none is provided
+ * @param {string} [options.hintMessage] - The message to show in a user error if the supplied value isn't valid
  */
 export function validateConfigParameter<AppConfig>(options: {
     config: AppConfig;
@@ -307,6 +309,14 @@ export function validateConfigParameter<AppConfig>(options: {
     }
 }
 
+/**
+ * Validate that parameter the user provided to py-config is one of the acceptable values;
+ * if not, throw an error explaining the bad value
+ * @param options.config - The (extended) AppConfig object from py-config
+ * @param {string} options.name - The name of the key in py-config to be checked
+ * @param {Array<BaseConfigObject>} options.possibleValues: The acceptable values for this parameter
+ * @param {BaseConfigObject} options.defaultValue: The default value for this parameter, if none is provided
+ */
 export function validateConfigParameterFromArray(options: {
     config: AppConfig;
     name: string;

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -297,6 +297,34 @@ export function checkedConfigOption<F extends BaseConfigObject, D extends F>(val
     return value;
 }
 
+// //////////////////
+// Working on making an interface for a user to pass their own validation function here;
+// this work is not yet complete
+
+interface FunctionConfigOption<F extends (B: BaseConfigObject) => boolean, D extends Parameters<F>[number]> {
+    validator: F;
+    hint: string;
+    default: D;
+}
+
+export function FunctionCheckedConfigOption<
+    F extends (B: BaseConfigObject) => boolean,
+    D extends Parameters<F>[number],
+>(value: FunctionConfigOption<F, D>) {
+    return value;
+}
+
+export function member_of(values: Array<BaseConfigObject>) {
+    return {
+        validator: (valueFromConfig: BaseConfigObject) => values.includes(valueFromConfig),
+        hint: `The only accepted values are: ${values.map(item => JSON.stringify(item)).join(', ')}]`,
+    };
+}
+
+//const test_options = FunctionCheckedConfigOption({ validator: (s: string) => false, hint: 'foo', default: 'foo' });
+
+////////
+
 /**
  * Validate that parameter the user provided to py-config is one of the acceptable values;
  * if not, throw an error explaining the bad value

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -268,11 +268,12 @@ export function define_custom_element(tag: string, pyElementClass: PyElementClas
 }
 
 // Members of py-config in plug that we want to validate must be one of these types
-type BaseConfigObject = string | boolean | number;
+type BaseConfigObject = string | boolean | number | undefined;
 
 /**
  * Validate that parameter the user provided to py-config conforms to the specified validation function;
- * if not, throw an error explaining the bad value.
+ * if not, throw an error explaining the bad value. If no value is provided, set the parameter
+ * to the provided default value
  * This is the most generic validation function; other validation functions for common situations follow
  * @param options.config - The (extended) AppConfig object from py-config
  * @param {string} options.name - The name of the key in py-config to be checked
@@ -310,7 +311,8 @@ export function validateConfigParameter(options: {
 
 /**
  * Validate that parameter the user provided to py-config is one of the acceptable values in
- * the given Array; if not, throw an error explaining the bad value
+ * the given Array; if not, throw an error explaining the bad value. If no value is provided,
+ * set the parameter to the provided default value
  * @param options.config - The (extended) AppConfig object from py-config
  * @param {string} options.name - The name of the key in py-config to be checked
  * @param {Array<BaseConfigObject>} options.possibleValues: The acceptable values for this parameter

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -309,13 +309,13 @@ export function validateConfigParameter<AppConfig>(
     name: string,
     options: ReturnType<typeof checkedConfigOption>,
 ) {
-    const value = config[name];
+    const value = config[name] as BaseConfigObject;
     if (value !== undefined && !options.possible_values.includes(value)) {
         const got = JSON.stringify(value);
         throw new UserError(
             ErrorCode.BAD_CONFIG,
             `Invalid value for config.${name}: the only accepted` +
-                `values are: ${options.possible_values}, got "${got}".`,
+                `values are: [${options.possible_values.join(',')}], got "${got}".`,
         );
     }
     if (value === undefined) {

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -267,26 +267,25 @@ export function define_custom_element(tag: string, pyElementClass: PyElementClas
     customElements.define(tag, ProxyCustomElement);
 }
 
-// Members of py-config in plug that we want to validate must be one of these types;
-// see next comment for more detail
-type BaseConfigObject = string | boolean | number | object;
+// Members of py-config in plug that we want to validate must be one of these types
+type BaseConfigObject = string | boolean | number;
 
 /**
  * Validate that parameter the user provided to py-config conforms to the specified validation function;
- * if not, throw an error explaining the bad value
+ * if not, throw an error explaining the bad value.
+ * This is the most generic validation function; other validation functions for common situations follow
  * @param options.config - The (extended) AppConfig object from py-config
  * @param {string} options.name - The name of the key in py-config to be checked
  * @param {(b:BaseConfigObject) => boolean} options.validator - the validation function used to test the user-supplied value
  * @param {BaseConfigObject} options.defaultValue - The default value for this parameter, if none is provided
  * @param {string} [options.hintMessage] - The message to show in a user error if the supplied value isn't valid
  */
-export function validateConfigParameter<AppConfig>(options: {
+export function validateConfigParameter(options: {
     config: AppConfig;
     name: string;
     validator: (b: BaseConfigObject) => boolean;
     defaultValue: BaseConfigObject;
     hintMessage?: string;
-    //options: ReturnType<typeof checkedConfigOption>,
 }) {
     //Validate that the default value is acceptable, at runtime
     if (!options.validator(options.defaultValue)) {
@@ -310,8 +309,8 @@ export function validateConfigParameter<AppConfig>(options: {
 }
 
 /**
- * Validate that parameter the user provided to py-config is one of the acceptable values;
- * if not, throw an error explaining the bad value
+ * Validate that parameter the user provided to py-config is one of the acceptable values in
+ * the given Array; if not, throw an error explaining the bad value
  * @param options.config - The (extended) AppConfig object from py-config
  * @param {string} options.name - The name of the key in py-config to be checked
  * @param {Array<BaseConfigObject>} options.possibleValues: The acceptable values for this parameter

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -283,7 +283,7 @@ type BaseConfigObject = string | boolean | number | object;
  * const terminal_settings: ConfigOption<[true, false, 'auto'][number], 'auto'>
  *      = {possible_values: [true, false, 'auto'], default:'auto'}
  *
- * The possible values are constained to be of type BaseConfigObject (above),
+ * The possible values are constrained to be of type BaseConfigObject (above),
  * i.e. if we want to validate more types of things, BaseConfigObject
  * will need to be extended
  */

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -1,6 +1,6 @@
 import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
-import { Plugin, checkedConfigOption, validateConfigParameter} from '../plugin';
+import { Plugin, checkedConfigOption, validateConfigParameter } from '../plugin';
 import { UserError, ErrorCode } from '../exceptions';
 import { getLogger } from '../logger';
 import { type Stdio } from '../stdio';
@@ -9,13 +9,13 @@ import { InterpreterClient } from '../interpreter_client';
 const logger = getLogger('py-terminal');
 
 // Configuration options for this plugin go here:
-const terminal_settings = checkedConfigOption({possible_values: [true, false, 'auto'], default: 'auto'})
-const docked_settings = checkedConfigOption({possible_values: [true, false, 'docked'], default: 'docked'})
+const terminal_settings = checkedConfigOption({ possible_values: [true, false, 'auto'], default: 'auto' });
+const docked_settings = checkedConfigOption({ possible_values: [true, false, 'docked'], default: 'docked' });
 
-type AppConfigStyle = AppConfig & { 
-    terminal?: typeof terminal_settings.possible_values[number],
-    docked?: typeof docked_settings.possible_values[number]
-    };
+type AppConfigStyle = AppConfig & {
+    terminal?: (typeof terminal_settings.possible_values)[number];
+    docked?: (typeof docked_settings.possible_values)[number];
+};
 
 export class PyTerminalPlugin extends Plugin {
     app: PyScriptApp;

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -1,7 +1,6 @@
 import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
-import { Plugin, checkedConfigOption, validateConfigParameter } from '../plugin';
-import { UserError, ErrorCode } from '../exceptions';
+import { Plugin, checkedConfigOption, validateConfigParameter} from '../plugin';
 import { getLogger } from '../logger';
 import { type Stdio } from '../stdio';
 import { InterpreterClient } from '../interpreter_client';

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -1,6 +1,6 @@
 import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
-import { Plugin, checkedConfigOption, validateConfigParameter} from '../plugin';
+import { Plugin, checkedConfigOption, validateConfigParameter } from '../plugin';
 import { getLogger } from '../logger';
 import { type Stdio } from '../stdio';
 import { InterpreterClient } from '../interpreter_client';

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -1,6 +1,6 @@
 import type { PyScriptApp } from '../main';
 import type { AppConfig } from '../pyconfig';
-import { Plugin, checkedConfigOption, validateConfigParameter } from '../plugin';
+import { Plugin, validateConfigParameterFromArray } from '../plugin';
 import { getLogger } from '../logger';
 import { type Stdio } from '../stdio';
 import { InterpreterClient } from '../interpreter_client';
@@ -8,12 +8,12 @@ import { InterpreterClient } from '../interpreter_client';
 const logger = getLogger('py-terminal');
 
 // Configuration options for this plugin go here:
-const terminal_settings = checkedConfigOption({ possible_values: [true, false, 'auto'], default: 'auto' });
-const docked_settings = checkedConfigOption({ possible_values: [true, false, 'docked'], default: 'docked' });
+//const terminal_settings = checkedConfigOption({ possible_values: [true, false, 'auto'], default: 'auto' });
+//const docked_settings = checkedConfigOption({ possible_values: [true, false, 'docked'], default: 'docked' });
 
 type AppConfigStyle = AppConfig & {
-    terminal?: (typeof terminal_settings.possible_values)[number];
-    docked?: (typeof docked_settings.possible_values)[number];
+    terminal?: string | boolean; //(typeof terminal_settings.possible_values)[number];
+    docked?: string | boolean; //(typeof docked_settings.possible_values)[number];
 };
 
 export class PyTerminalPlugin extends Plugin {
@@ -26,8 +26,18 @@ export class PyTerminalPlugin extends Plugin {
 
     configure(config: AppConfigStyle) {
         // validate the terminal config and handle default values
-        validateConfigParameter(config, 'terminal', terminal_settings);
-        validateConfigParameter(config, 'docked', docked_settings);
+        validateConfigParameterFromArray({
+            config: config,
+            name: 'terminal',
+            possibleValues: [true, false, 'auto'],
+            defaultValue: 'auto',
+        });
+        validateConfigParameterFromArray({
+            config: config,
+            name: 'docked',
+            possibleValues: [true, false, 'docked'],
+            defaultValue: 'docked',
+        });
     }
 
     beforeLaunch(config: AppConfigStyle) {

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -8,8 +8,8 @@ import { InterpreterClient } from '../interpreter_client';
 const logger = getLogger('py-terminal');
 
 type AppConfigStyle = AppConfig & {
-    terminal?: string | boolean; //(typeof terminal_settings.possible_values)[number];
-    docked?: string | boolean; //(typeof docked_settings.possible_values)[number];
+    terminal?: string | boolean;
+    docked?: string | boolean;
 };
 
 export class PyTerminalPlugin extends Plugin {

--- a/pyscriptjs/src/plugins/pyterminal.ts
+++ b/pyscriptjs/src/plugins/pyterminal.ts
@@ -7,10 +7,6 @@ import { InterpreterClient } from '../interpreter_client';
 
 const logger = getLogger('py-terminal');
 
-// Configuration options for this plugin go here:
-//const terminal_settings = checkedConfigOption({ possible_values: [true, false, 'auto'], default: 'auto' });
-//const docked_settings = checkedConfigOption({ possible_values: [true, false, 'docked'], default: 'docked' });
-
 type AppConfigStyle = AppConfig & {
     terminal?: string | boolean; //(typeof terminal_settings.possible_values)[number];
     docked?: string | boolean; //(typeof docked_settings.possible_values)[number];

--- a/pyscriptjs/tests/unit/plugin.test.ts
+++ b/pyscriptjs/tests/unit/plugin.test.ts
@@ -1,0 +1,28 @@
+import { checkedConfigOption, validateConfigParameter } from '../../src/plugin';
+import { UserError } from '../../src/exceptions';
+
+describe('validateConfigParamters', () => {
+    const a_options = checkedConfigOption({ possible_values: ['a1', 100, false], default: 'a1' });
+
+    it('should not change a matching config option', () => {
+        //const a_opti
+        const config = { a: 'a1', dummy: 'dummy' };
+        validateConfigParameter(config, 'a', a_options);
+        expect(config).toStrictEqual({ a: 'a1', dummy: 'dummy' });
+    });
+
+    it('should set the default value if no value is present', () => {
+        const config = { dummy: 'dummy' };
+        validateConfigParameter(config, 'a', a_options);
+        expect(config).toStrictEqual({ a: 'a1', dummy: 'dummy' });
+    });
+
+    it('should error if the provided value is not in possible_values', () => {
+        const config = { a: 'NotValidValue', dummy: 'dummy' };
+        const func = () => validateConfigParameter(config, 'a', a_options);
+        expect(func).toThrow(UserError);
+        expect(func).toThrow(
+            '(PY1000): Invalid value for config.a: the only accepted values are: ["a1", 100, false], got: "NotValidValue".',
+        );
+    });
+});

--- a/pyscriptjs/tests/unit/plugin.test.ts
+++ b/pyscriptjs/tests/unit/plugin.test.ts
@@ -1,28 +1,116 @@
-import { checkedConfigOption, validateConfigParameter } from '../../src/plugin';
+import { validateConfigParameter, validateConfigParameterFromArray } from '../../src/plugin';
 import { UserError } from '../../src/exceptions';
 
-describe('validateConfigParamters', () => {
-    const a_options = checkedConfigOption({ possible_values: ['a1', 100, false], default: 'a1' });
+describe('validateConfigParameter', () => {
+    const validator = a => a.charAt(0) === 'a';
 
     it('should not change a matching config option', () => {
-        //const a_opti
-        const config = { a: 'a1', dummy: 'dummy' };
-        validateConfigParameter(config, 'a', a_options);
-        expect(config).toStrictEqual({ a: 'a1', dummy: 'dummy' });
+        const pyconfig = { a: 'a1', dummy: 'dummy' };
+        validateConfigParameter({
+            config: pyconfig,
+            name: 'a',
+            validator: validator,
+            defaultValue: 'a_default',
+            hintMessage: "Should start with 'a'",
+        });
+        expect(pyconfig).toStrictEqual({ a: 'a1', dummy: 'dummy' });
     });
 
     it('should set the default value if no value is present', () => {
-        const config = { dummy: 'dummy' };
-        validateConfigParameter(config, 'a', a_options);
-        expect(config).toStrictEqual({ a: 'a1', dummy: 'dummy' });
+        const pyconfig = { dummy: 'dummy' };
+        validateConfigParameter({
+            config: pyconfig,
+            name: 'a',
+            validator: validator,
+            defaultValue: 'a_default',
+            hintMessage: "Should start with 'a'",
+        });
+        expect(pyconfig).toStrictEqual({ a: 'a_default', dummy: 'dummy' });
+    });
+
+    it('should error if the provided value is not valid', () => {
+        const pyconfig = { a: 'NotValidValue', dummy: 'dummy' };
+        const func = () =>
+            validateConfigParameter({
+                config: pyconfig,
+                name: 'a',
+                validator: validator,
+                defaultValue: 'a_default',
+                hintMessage: "Should start with 'a'",
+            });
+        expect(func).toThrow(UserError);
+        expect(func).toThrow('(PY1000): Invalid value "NotValidValue" for config.a. Should start with \'a\'');
+    });
+
+    it('should error if the provided default is not valid', () => {
+        const pyconfig = { a: 'a1', dummy: 'dummy' };
+        const func = () =>
+            validateConfigParameter({
+                config: pyconfig,
+                name: 'a',
+                validator: validator,
+                defaultValue: 'NotValidDefault',
+                hintMessage: "Should start with 'a'",
+            });
+        expect(func).toThrow(Error);
+        expect(func).toThrow(
+            'Default value "NotValidDefault" for a is not a valid argument, according to the provided validator function. Should start with \'a\'',
+        );
+    });
+});
+
+describe('validateConfigParameterFromArray', () => {
+    const possibilities = ['a1', 'a2', true, 42, 'a_default'];
+
+    it('should not change a matching config option', () => {
+        const pyconfig = { a: 'a1', dummy: 'dummy' };
+        validateConfigParameterFromArray({
+            config: pyconfig,
+            name: 'a',
+            possibleValues: possibilities,
+            defaultValue: 'a_default',
+        });
+        expect(pyconfig).toStrictEqual({ a: 'a1', dummy: 'dummy' });
+    });
+
+    it('should set the default value if no value is present', () => {
+        const pyconfig = { dummy: 'dummy' };
+        validateConfigParameterFromArray({
+            config: pyconfig,
+            name: 'a',
+            possibleValues: possibilities,
+            defaultValue: 'a_default',
+        });
+        expect(pyconfig).toStrictEqual({ a: 'a_default', dummy: 'dummy' });
     });
 
     it('should error if the provided value is not in possible_values', () => {
-        const config = { a: 'NotValidValue', dummy: 'dummy' };
-        const func = () => validateConfigParameter(config, 'a', a_options);
-        expect(func).toThrow(UserError);
+        const pyconfig = { a: 'NotValidValue', dummy: 'dummy' };
+        const func = () =>
+            validateConfigParameterFromArray({
+                config: pyconfig,
+                name: 'a',
+                possibleValues: possibilities,
+                defaultValue: 'a_default',
+            });
+        expect(func).toThrow(Error);
         expect(func).toThrow(
-            '(PY1000): Invalid value for config.a: the only accepted values are: ["a1", 100, false], got: "NotValidValue".',
+            '(PY1000): Invalid value "NotValidValue" for config.a. The only accepted values are: ["a1", "a2", true, 42, "a_default"]',
+        );
+    });
+
+    it('should error if the provided default is not in possible_values', () => {
+        const pyconfig = { a: 'a1', dummy: 'dummy' };
+        const func = () =>
+            validateConfigParameterFromArray({
+                config: pyconfig,
+                name: 'a',
+                possibleValues: possibilities,
+                defaultValue: 'NotValidDefault',
+            });
+        expect(func).toThrow(Error);
+        expect(func).toThrow(
+            'Default value "NotValidDefault" for a is not a valid argument, according to the provided validator function. The only accepted values are: ["a1", "a2", true, 42, "a_default"]',
         );
     });
 });


### PR DESCRIPTION
This improves the previous `validate()` function in pyterminal.ts to be more flexible in how it handles potential values and default values. Previously, configuration options could only be booleans or strings, and the default *had* to be a string. 

Now, the options can be any of the non-array types (string, boolean, number or Object) that could be present in the TOML/JSON from py-config, any of them can be the default, ~~*and* the type system will catch whether the listed default value is indeed part of the array.~~

I've moved `validate()` - now renamed to `validateConfigParameter()` - from pyterminal.ts to plugin.ts, but only used it to improve pyterminal.ts for now to make it easier to see what's changed. We can use it to validate parameters for the other plugins in follow-up PRs. I've also added `validateConfigParameterFromArray()`, which handles the (currently) common situation where the valid values are drawn from a small list known ahead of time.

~~This could probably now use a test or two, hence the WIP~~. ~~Tests written; this is ready for review.~~ ~~Following Antonio's thoughts about broadening what this could do, I'm reverting this to draft for now.~~ This is ready for review again.

I also want to use this functionality in #1317 (xterm.js), so I'm prioritizing this at this moment.
