### PR TITLE
Deprecate `py-mount` Attribute

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@
 Features
 --------
 
+- The `py-mount` attribute on HTML elements has been deprecated, and will be removed in a future release.
+
 
 ### &lt;py-terminal&gt;
 - Added a `docked` field and attribute for the `<py-terminal>` custom element, enabled by default when the terminal is in `auto` mode, and able to dock the terminal at the bottom of the page with auto scroll on new code execution.

--- a/docs/development/deprecation-cycle.md
+++ b/docs/development/deprecation-cycle.md
@@ -28,3 +28,11 @@ showWarning(`
     </p>
 `, "html")
 ```
+
+## Deprecation History
+
+This section tracks deprecations of specific features, both for historical record and to help the development team remember to actually remove deprecated features in future releases.
+
+|Attribute/Object/Functionality|Deprecated In|Removed In|
+|-|-|-|
+|`py-mount` attribute | (Release following 2023.03.1) | -|

--- a/examples/handtrack/say_hello.html
+++ b/examples/handtrack/say_hello.html
@@ -11,16 +11,19 @@
             rel="stylesheet"
             href="https://pyscript.net/latest/pyscript.css"
         />
-
-        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
+        <script defer src="../../pyscriptjs/build/pyscript.js"></script>
+        <!-- <script defer src="https://pyscript.net/latest/pyscript.js"></script> -->
     </head>
 
     <body>
         <py-script>
-            from js import handTrack, requestAnimationFrame
+            from js import handTrack, requestAnimationFrame, console
             from pyodide import create_once_callable
             import asyncio
 
+            update_note = Element("update-note")
+            canvas = Element("canvas")
+            video = Element("myvideo")
             context = canvas.element.getContext("2d")
 
             isVideo = False
@@ -33,7 +36,7 @@
               "scoreThreshold": 0.6, # confidence threshold for predictions.
             }
 
-            def toggle_video(evt):
+            def toggle_video():
               global isVideo
               if (not isVideo):
                 update_note.write("Starting video")
@@ -124,13 +127,11 @@
             >
                 Next Image
             </button>
-            <div id="update-note" py-mount class="updatenote mt10">
-                loading model ..
-            </div>
+            <div id="update-note" class="updatenote mt10">loading model ..</div>
         </div>
         <div>
             <video autoplay="autoplay" id="myvideo" py-mount="video"></video>
-            <canvas id="canvas" py-mount class="border canvasbox"></canvas>
+            <canvas id="canvas" class="border canvasbox"></canvas>
         </div>
         <script src="lib/handtrack.min.js"></script>
     </body>

--- a/examples/mario/play_mario.html
+++ b/examples/mario/play_mario.html
@@ -46,6 +46,9 @@
             from pyodide import create_once_callable
             import asyncio
 
+            update_note = Element("update-note")
+            canvas = Element("canvas")
+            video = Element("myvideo")
             context = canvas.element.getContext("2d")
 
             isVideo = False
@@ -60,7 +63,7 @@
               "scoreThreshold": 0.6, # confidence threshold for predictions.
             }
 
-            def toggle_video(evt):
+            def toggle_video():
               global isVideo
               player.jump()
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -238,6 +238,7 @@ export async function mountElements(interpreter: InterpreterClient) {
     logger.info(`py-mount: found ${matches.length} elements`);
 
     if (matches.length > 0) {
+        //last non-deprecated version: 2023.03.1
         const deprecationMessage =
             'The "py-mount" attribute is deprecated. Please add references to HTML Elements manually in your script.';
         createDeprecationWarning(deprecationMessage, 'py-mount');

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -237,6 +237,12 @@ export async function mountElements(interpreter: InterpreterClient) {
     const matches: NodeListOf<HTMLElement> = document.querySelectorAll('[py-mount]');
     logger.info(`py-mount: found ${matches.length} elements`);
 
+    if (matches.length > 0) {
+        const deprecationMessage =
+            'The "py-mount" attribute is deprecated. Please add references to HTML Elements manually in your script.';
+        createDeprecationWarning(deprecationMessage, 'py-mount');
+    }
+
     let source = '';
     for (const el of matches) {
         const mountName = el.getAttribute('py-mount') || el.id.split('-').join('_');

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -345,3 +345,16 @@ class TestBasic(PyScriptTest):
         btn.click()
         assert self.console.log.lines[-1] == "hello world!"
         assert self.console.error.lines == []
+
+    def test_py_mount_shows_deprecation_warning(self):
+        self.pyscript_run(
+            """
+            <div id="foo" py-mount></div>
+            """
+        )
+        banner = self.page.locator(".alert-banner")
+        expected_message = (
+            'The "py-mount" attribute is deprecated.'
+            + "Please add references to HTML Elements manually in your script."
+        )
+        assert banner.inner_text() == expected_message

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -355,7 +355,7 @@ class TestBasic(PyScriptTest):
         )
         banner = self.page.locator(".alert-banner")
         expected_message = (
-            'The "py-mount" attribute is deprecated.'
+            'The "py-mount" attribute is deprecated. '
             + "Please add references to HTML Elements manually in your script."
         )
         assert banner.inner_text() == expected_message

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -347,6 +347,7 @@ class TestBasic(PyScriptTest):
         assert self.console.error.lines == []
 
     def test_py_mount_shows_deprecation_warning(self):
+        # last non-deprecated version: 2023.03.1
         self.pyscript_run(
             """
             <div id="foo" py-mount></div>


### PR DESCRIPTION
As described in #1220, the `py-mount` attribute isn't a feature we really advertise, nor make use of anywhere else in the codebase. It was meant to mount HTML elements directly as pyscript `Element`s, but that's nor really a part of the API we're suggesting at this point.

Also added a section of the deprecation docs for **tracking what's currently being deprecated** so that we actually remember to remove deprecated things in a future release. 😅

Fixes #1220