### PR TITLE
Un-break Docs CI

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -51,23 +51,3 @@ jobs:
               with:
                   name: pyscript-docs-review-${{ github.event.number }}
                   path: docs/_build/html/
-
-              # Deploy to S3
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1.6.1
-              with:
-                  aws-region: ${{ secrets.AWS_REGION }}
-                  role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
-
-            - name: Copy redirect file
-              run: aws s3 cp --quiet ./docs/_build/html/_static/redirect.html s3://docs.pyscript.net/index.html
-
-            - name: Sync to S3
-              run: aws s3 sync --quiet ./docs/_build/html/ s3://docs.pyscript.net/review/${{ github.event.number }}/
-
-            - name: Adding step summary
-              run: |
-                  echo "### Review documentation" >> $GITHUB_STEP_SUMMARY
-                  echo "As with any pull request, you can find the rendered documentation version for pull request ${{ github.event.number }} here:"
-                  echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
-                  echo "https://docs.pyscript.net/review/${{ github.event.number }}/" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The `docs-review` action breaks on every PR that includes changes to the docs. The action tries to upload a copy of the built docs to AWS, presumably for easier review. However, as I understand it, actions triggered by PR's not from the repo's owner are run with the credentials of the *contributor* for security reasons. So the AWS secrets are not accessible, and the action fails.

This just removes the attempted AWS upload step from the PR tests. Since we've never had it working in the first place, I don't think we'll miss it. The docs still get built on merge/release.

Fixes #1294 
