### PR TITLE
Reduce default test timeout back to 30 seconds

### DIFF
--- a/pyscriptjs/tests/integration/support.py
+++ b/pyscriptjs/tests/integration/support.py
@@ -118,9 +118,6 @@ class PyScriptTest:
     def init_page(self, page):
         self.page = page
 
-        # set default timeout to 60000 millliseconds from 30000
-        page.set_default_timeout(60000)
-
         self.console = ConsoleMessageCollection(self.logger)
         self._js_errors = []
         page.on("console", self._on_console)


### PR DESCRIPTION
A minute is too long IMO. If some particular test requires more time, we should try to fix it. If we have to, we can increase timeout for a specific test.
