### PR TITLE
Update to the latest TypeScript

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,6 @@ repos:
             types: [file]
             additional_dependencies:
                 - eslint@8.25.0
-                - typescript@4.8.4
-                - "@typescript-eslint/eslint-plugin@5.39.0"
-                - "@typescript-eslint/parser@5.39.0"
+                - typescript@5.0.4
+                - "@typescript-eslint/eslint-plugin@5.58.0"
+                - "@typescript-eslint/parser@5.58.0"

--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -19,8 +19,8 @@
                 "@types/codemirror": "^5.60.5",
                 "@types/jest": "29.1.2",
                 "@types/node": "18.8.3",
-                "@typescript-eslint/eslint-plugin": "5.39.0",
-                "@typescript-eslint/parser": "5.39.0",
+                "@typescript-eslint/eslint-plugin": "5.58.0",
+                "@typescript-eslint/parser": "5.58.0",
                 "codemirror": "6.0.1",
                 "cross-env": "7.0.3",
                 "esbuild": "0.17.12",
@@ -29,10 +29,10 @@
                 "jest-environment-jsdom": "29.1.2",
                 "prettier": "2.7.1",
                 "pyodide": "0.22.1",
-                "synclink": "^0.2.4",
+                "synclink": "0.2.4",
                 "ts-jest": "29.0.3",
                 "tslib": "2.4.0",
-                "typescript": "4.8.4"
+                "typescript": "5.0.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1106,6 +1106,30 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -1831,6 +1855,12 @@
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
             "dev": true
         },
+        "node_modules/@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -1868,17 +1898,19 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-            "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
+            "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/type-utils": "5.39.0",
-                "@typescript-eslint/utils": "5.39.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/type-utils": "5.58.0",
+                "@typescript-eslint/utils": "5.58.0",
                 "debug": "^4.3.4",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
-                "regexpp": "^3.2.0",
+                "natural-compare-lite": "^1.4.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -1900,14 +1932,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-            "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
+            "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/typescript-estree": "5.39.0",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1927,13 +1959,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-            "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
+            "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/visitor-keys": "5.39.0"
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/visitor-keys": "5.58.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1944,13 +1976,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-            "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
+            "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.39.0",
-                "@typescript-eslint/utils": "5.39.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
+                "@typescript-eslint/utils": "5.58.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -1971,9 +2003,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-            "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
+            "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1984,13 +2016,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-            "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
+            "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/visitor-keys": "5.39.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/visitor-keys": "5.58.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -2011,17 +2043,19 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-            "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
+            "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/typescript-estree": "5.39.0",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
+                "semver": "^7.3.7"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2035,12 +2069,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-            "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
+            "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.39.0",
+                "@typescript-eslint/types": "5.58.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -4692,6 +4726,12 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "node_modules/natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+            "dev": true
+        },
         "node_modules/node-fetch": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -5723,16 +5763,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=12.20"
             }
         },
         "node_modules/universalify": {
@@ -6751,6 +6791,21 @@
             "dev": true,
             "optional": true
         },
+        "@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^3.3.0"
+            }
+        },
+        "@eslint-community/regexpp": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+            "dev": true
+        },
         "@eslint/eslintrc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -7356,6 +7411,12 @@
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
             "dev": true
         },
+        "@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
         "@types/stack-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -7393,69 +7454,71 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-            "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
+            "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/type-utils": "5.39.0",
-                "@typescript-eslint/utils": "5.39.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/type-utils": "5.58.0",
+                "@typescript-eslint/utils": "5.58.0",
                 "debug": "^4.3.4",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
-                "regexpp": "^3.2.0",
+                "natural-compare-lite": "^1.4.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-            "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
+            "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/typescript-estree": "5.39.0",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-            "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
+            "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/visitor-keys": "5.39.0"
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/visitor-keys": "5.58.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-            "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
+            "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "5.39.0",
-                "@typescript-eslint/utils": "5.39.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
+                "@typescript-eslint/utils": "5.58.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-            "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
+            "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-            "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
+            "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/visitor-keys": "5.39.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/visitor-keys": "5.58.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -7464,26 +7527,28 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-            "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
+            "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
             "dev": true,
             "requires": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.39.0",
-                "@typescript-eslint/types": "5.39.0",
-                "@typescript-eslint/typescript-estree": "5.39.0",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.58.0",
+                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/typescript-estree": "5.58.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
+                "semver": "^7.3.7"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-            "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+            "version": "5.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
+            "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.39.0",
+                "@typescript-eslint/types": "5.58.0",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -9482,6 +9547,12 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+            "dev": true
+        },
         "node-fetch": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -10212,9 +10283,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
             "dev": true
         },
         "universalify": {

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -25,8 +25,8 @@
         "@types/codemirror": "^5.60.5",
         "@types/jest": "29.1.2",
         "@types/node": "18.8.3",
-        "@typescript-eslint/eslint-plugin": "5.39.0",
-        "@typescript-eslint/parser": "5.39.0",
+        "@typescript-eslint/eslint-plugin": "5.58.0",
+        "@typescript-eslint/parser": "5.58.0",
         "codemirror": "6.0.1",
         "cross-env": "7.0.3",
         "esbuild": "0.17.12",
@@ -38,6 +38,6 @@
         "synclink": "0.2.4",
         "ts-jest": "29.0.3",
         "tslib": "2.4.0",
-        "typescript": "4.8.4"
+        "typescript": "5.0.4"
     }
 }


### PR DESCRIPTION
## Description

This PR updates TypeScript and related packages to the latest versions.

### Changes

- Update TypeScript 4.8.4 to 5.0.4
- Update @typescript-eslint/eslint-plugin 5.39.0 to 5.58.0
- Update @typescript-eslint/parse 5.39.0 to 5.58.0

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
