### PR TITLE
doc: remove duplicated link

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -35,5 +35,4 @@ glob:
 ---
 py-config-fetch
 py-config-interpreter
-writing-to-page
 ```


### PR DESCRIPTION
"How to write content to the page" appeared twice in the index.
