### PR TITLE
Remove an unused dependency

### DIFF
--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -31,7 +31,6 @@
                 "pyodide": "0.22.1",
                 "synclink": "0.2.4",
                 "ts-jest": "29.0.3",
-                "tslib": "2.4.0",
                 "typescript": "5.0.4"
             }
         },
@@ -5702,12 +5701,6 @@
                 }
             }
         },
-        "node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-            "dev": true
-        },
         "node_modules/tsutils": {
             "version": "3.21.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -10237,12 +10230,6 @@
                 "semver": "7.x",
                 "yargs-parser": "^21.0.1"
             }
-        },
-        "tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-            "dev": true
         },
         "tsutils": {
             "version": "3.21.0",

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -37,7 +37,6 @@
         "pyodide": "0.22.1",
         "synclink": "0.2.4",
         "ts-jest": "29.0.3",
-        "tslib": "2.4.0",
         "typescript": "5.0.4"
     }
 }


### PR DESCRIPTION
## Description

It seems that esbuild doesn't support to import helpers for now.

### Changes

- Remove tslib

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
