### PR TITLE
Fix an error message when loading local modules failed

### DIFF
--- a/pyscriptjs/src/fetch.ts
+++ b/pyscriptjs/src/fetch.ts
@@ -25,7 +25,7 @@ export async function robustFetch(url: string, options?: RequestInit): Promise<R
                 `'${error.message}'. Are your filename and path correct?`;
         } else {
             errMsg = `PyScript: Access to local files
-        (using "Paths:" in &lt;py-config&gt;)
+        (using "files" in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files.
         See <a style="text-decoration: underline;" href="https://github.com/pyscript/pyscript/issues/257#issuecomment-1119595062">this reference</a>

--- a/pyscriptjs/src/fetch.ts
+++ b/pyscriptjs/src/fetch.ts
@@ -25,7 +25,7 @@ export async function robustFetch(url: string, options?: RequestInit): Promise<R
                 `'${error.message}'. Are your filename and path correct?`;
         } else {
             errMsg = `PyScript: Access to local files
-        (using "files" in &lt;py-config&gt;)
+        (using [[fetch]] configurations in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files.
         See <a style="text-decoration: underline;" href="https://github.com/pyscript/pyscript/issues/257#issuecomment-1119595062">this reference</a>

--- a/pyscriptjs/tests/unit/fetch.test.ts
+++ b/pyscriptjs/tests/unit/fetch.test.ts
@@ -94,7 +94,7 @@ describe('robustFetch', () => {
         const expectedError = new FetchError(
             ErrorCode.FETCH_ERROR,
             `PyScript: Access to local files
-        (using "files" in &lt;py-config&gt;)
+        (using [[fetch]] configurations in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files.
         See <a style="text-decoration: underline;" href="https://github.com/pyscript/pyscript/issues/257#issuecomment-1119595062">this reference</a>

--- a/pyscriptjs/tests/unit/fetch.test.ts
+++ b/pyscriptjs/tests/unit/fetch.test.ts
@@ -94,7 +94,7 @@ describe('robustFetch', () => {
         const expectedError = new FetchError(
             ErrorCode.FETCH_ERROR,
             `PyScript: Access to local files
-        (using "Paths:" in &lt;py-config&gt;)
+        (using "files" in &lt;py-config&gt;)
         is not available when directly opening a HTML file;
         you must use a webserver to serve the additional files.
         See <a style="text-decoration: underline;" href="https://github.com/pyscript/pyscript/issues/257#issuecomment-1119595062">this reference</a>


### PR DESCRIPTION
## Description

The key for loading local modules seems to be different now.
https://docs.pyscript.net/latest/reference/elements/py-config.html#local-modules

### Changes

- Fix an error message when loading local modules failed

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
