### PR TITLE
Remove redundant `.shadow` property as that is defined at the CE level

### DIFF
--- a/pyscriptjs/src/components/pywidget.ts
+++ b/pyscriptjs/src/components/pywidget.ts
@@ -8,7 +8,6 @@ const logger = getLogger('py-register-widget');
 
 function createWidget(interpreter: InterpreterClient, name: string, code: string, klass: string) {
     class CustomWidget extends HTMLElement {
-        shadow: ShadowRoot;
         wrapper: HTMLElement;
 
         name: string = name;
@@ -20,11 +19,8 @@ function createWidget(interpreter: InterpreterClient, name: string, code: string
         constructor() {
             super();
 
-            // attach shadow so we can preserve the element original innerHtml content
-            this.shadow = this.attachShadow({ mode: 'open' });
-
             this.wrapper = document.createElement('slot');
-            this.shadow.appendChild(this.wrapper);
+            this.attachShadow({ mode: 'open' }).appendChild(this.wrapper);
         }
 
         async connectedCallback() {
@@ -45,7 +41,6 @@ function createWidget(interpreter: InterpreterClient, name: string, code: string
 
 export function make_PyWidget(interpreter: InterpreterClient) {
     class PyWidget extends HTMLElement {
-        shadow: ShadowRoot;
         name: string;
         klass: string;
         outputElement: HTMLElement;
@@ -58,11 +53,8 @@ export function make_PyWidget(interpreter: InterpreterClient) {
         constructor() {
             super();
 
-            // attach shadow so we can preserve the element original innerHtml content
-            this.shadow = this.attachShadow({ mode: 'open' });
-
             this.wrapper = document.createElement('slot');
-            this.shadow.appendChild(this.wrapper);
+            this.attachShadow({ mode: 'open' }).appendChild(this.wrapper);
 
             this.addAttributes('src', 'name', 'klass');
         }

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -242,7 +242,6 @@ type PyElementClass = (htmlElement: HTMLElement) => PyElementInstance;
 export function define_custom_element(tag: string, pyElementClass: PyElementClass): any {
     logger.info(`creating plugin: ${tag}`);
     class ProxyCustomElement extends HTMLElement {
-        shadow: ShadowRoot;
         wrapper: HTMLElement;
         pyElementInstance: PyElementInstance;
         originalInnerHTML: string;
@@ -251,9 +250,8 @@ export function define_custom_element(tag: string, pyElementClass: PyElementClas
             logger.debug(`creating ${tag} plugin instance`);
             super();
 
-            this.shadow = this.attachShadow({ mode: 'open' });
             this.wrapper = document.createElement('slot');
-            this.shadow.appendChild(this.wrapper);
+            this.attachShadow({ mode: 'open' }).appendChild(this.wrapper);
             this.originalInnerHTML = this.innerHTML;
             this.pyElementInstance = pyElementClass(this);
         }


### PR DESCRIPTION
## Description

This MR would like to cleanup a tiny redundant property we type and set at the Custom Element level, likely ignoring the fact a `shadowRoot` field is attached to the element already when `attachShadow({mode: 'open'})` is used.

### Changes

Remove the unused and unnecessary `shadow` property/field from our Custom Elements.

## Checklist

-   [ ] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
