### PR TITLE
Fix #1326 - Allow `<script type="py">` tag to work as `<py-script>`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ Features
 - The `py-mount` attribute on HTML elements has been deprecated, and will be removed in a future release.
 
 
+### &lt;script type="py"&gt;
+- Added the ability to optionally use `<script type="py">`, `<script type="pyscript">` or `<script type="py-script">` instead of a `<py-script>` custom element, in order to tackle cases where the content of the `<py-script>` tag, inevitably parsed by browsers, could accidentally contain *HTML* able to break the surrounding page layout. ([#1396](https://github.com/pyscript/pyscript/pull/1396))
+
 ### &lt;py-terminal&gt;
 - Added a `docked` field and attribute for the `<py-terminal>` custom element, enabled by default when the terminal is in `auto` mode, and able to dock the terminal at the bottom of the page with auto scroll on new code execution.
 

--- a/docs/reference/elements/py-script.md
+++ b/docs/reference/elements/py-script.md
@@ -1,6 +1,6 @@
 # &lt;py-script&gt;
 
-The `<py-script>` element lets you execute multi-line Python scripts both inline and via a src attribute.
+The `<py-script>` element, also available as `<script type="py-script">`, lets you execute multi-line Python scripts both inline and via a src attribute.
 
 ## Attributes
 
@@ -12,13 +12,13 @@ The `<py-script>` element lets you execute multi-line Python scripts both inline
 
 ### output
 
-If the `output` attribute is provided, any output to [sys.stdout](https://docs.python.org/3/library/sys.html#sys.stdout) or [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr) is written to the DOM element with the ID matching the attribute. If no DOM element is found with a matching ID, a warning is shown. The msg is output to the `innerHTML` of the HTML Element, with newlines (`\n'`) converted to breaks (`<br\>`).
+If the `output` attribute is provided, any output to [sys.stdout](https://docs.python.org/3/library/sys.html#sys.stdout) or [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr) is written to the DOM element with the ID matching the attribute. If no DOM element is found with a matching ID, a warning is shown. The msg is output to the `innerHTML` of the HTML Element, with newlines (`\n'`) converted to breaks (`<br/>`).
 
 This output is in addition to the output being written to the developer console and the `<py-terminal>` if it is being used.
 
 ### stderr
 
-If the `stderr` attribute is provided, any output to [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr) is written to the DOM element with the ID matching the attribute. If no DOM element is found with a matching ID, a warning is shown. The msg is output to the `innerHTML` of the HTML Element, with newlines (`\n'`) converted to breaks (`<br\>`).
+If the `stderr` attribute is provided, any output to [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr) is written to the DOM element with the ID matching the attribute. If no DOM element is found with a matching ID, a warning is shown. The msg is output to the `innerHTML` of the HTML Element, with newlines (`\n'`) converted to breaks (`<br/>`).
 
 This output is in addition to the output being written to the developer console and the `<py-terminal>` if it is being used.
 

--- a/pyscriptjs/.eslintrc.js
+++ b/pyscriptjs/.eslintrc.js
@@ -37,4 +37,12 @@ module.exports = {
         '@typescript-eslint/no-empty-function': 'error',
         '@typescript-eslint/restrict-template-expressions': ['error', { allowBoolean: true }],
     },
+    overrides: [
+        {
+            files: ['src/components/pyscript.ts'],
+            rules: {
+                '@typescript-eslint/unbound-method': 'off',
+            },
+        },
+    ],
 };

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -1,4 +1,4 @@
-import { htmlDecode, ensureUniqueId, createDeprecationWarning } from '../utils';
+import { ltrim, htmlDecode, ensureUniqueId, createDeprecationWarning } from '../utils';
 import { getLogger } from '../logger';
 import { pyExec, displayPyException } from '../pyexec';
 import { _createAlertBanner } from '../exceptions';
@@ -10,61 +10,125 @@ import { InterpreterClient } from '../interpreter_client';
 const logger = getLogger('py-script');
 
 export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) {
+    /**
+     * A common <py-script> VS <script type="py"> initializator.
+     */
+    const init = async (pyScriptTag: PyScript, fallback: () => string) => {
+        /**
+         * Since connectedCallback is async, multiple py-script tags can be executed in
+         * an order which is not particularly sequential. The locking mechanism here ensures
+         * a sequential execution of multiple py-script tags present in one page.
+         *
+         * Concurrent access to the multiple py-script tags is thus avoided.
+         */
+        app.incrementPendingTags();
+        let releaseLock: () => void;
+        try {
+            releaseLock = await app.tagExecutionLock();
+            ensureUniqueId(pyScriptTag);
+            const src = await fetchSource(pyScriptTag, fallback);
+            await app.plugins.beforePyScriptExec({ interpreter, src, pyScriptTag });
+            const { result } = await pyExec(interpreter, src, pyScriptTag);
+            await app.plugins.afterPyScriptExec({ interpreter, src, pyScriptTag, result });
+        } finally {
+            releaseLock();
+            app.decrementPendingTags();
+        }
+    };
+
+    /**
+     * Given a generic DOM Element, tries to fetch the 'src' attribute, if present.
+     * It either throws an error if the 'src' can't be fetched or it returns a fallback
+     * content as source.
+     */
+    const fetchSource = async (tag: Element, fallback: () => string): Promise<string> => {
+        if (tag.hasAttribute('src')) {
+            try {
+                const response = await robustFetch(tag.getAttribute('src'));
+                return await response.text();
+            } catch (err) {
+                const e = err as Error;
+                _createAlertBanner(e.message);
+                throw e;
+            }
+        }
+        return fallback();
+    };
+
     class PyScript extends HTMLElement {
         srcCode: string;
         stdout_manager: Stdio | null;
         stderr_manager: Stdio | null;
+        _fetchSourceFallback = () => htmlDecode(this.srcCode);
 
         async connectedCallback() {
-            /**
-             * Since connectedCallback is async, multiple py-script tags can be executed in
-             * an order which is not particularly sequential. The locking mechanism here ensures
-             * a sequential execution of multiple py-script tags present in one page.
-             *
-             * Concurrent access to the multiple py-script tags is thus avoided.
-             */
-            app.incrementPendingTags();
-            let releaseLock: () => void;
-            try {
-                releaseLock = await app.tagExecutionLock();
-                ensureUniqueId(this);
-                // Save innerHTML information in srcCode so we can access it later
-                // once we clean innerHTML (which is required since we don't want
-                // source code to be rendered on the screen)
-                this.srcCode = this.innerHTML;
-                const pySrc = await this.getPySrc();
-                this.innerHTML = '';
-
-                await app.plugins.beforePyScriptExec({ interpreter: interpreter, src: pySrc, pyScriptTag: this });
-                const result = (await pyExec(interpreter, pySrc, this)).result;
-                await app.plugins.afterPyScriptExec({
-                    interpreter: interpreter,
-                    src: pySrc,
-                    pyScriptTag: this,
-                    result: result,
-                });
-            } finally {
-                releaseLock();
-                app.decrementPendingTags();
-            }
+            // Save innerHTML information in srcCode so we can access it later
+            // once we clean innerHTML (which is required since we don't want
+            // source code to be rendered on the screen)
+            this.srcCode = this.innerHTML;
+            this.innerHTML = '';
+            await init(this, this._fetchSourceFallback);
         }
+    }
 
-        async getPySrc(): Promise<string> {
-            if (this.hasAttribute('src')) {
-                const url = this.getAttribute('src');
-                try {
-                    const response = await robustFetch(url);
-                    return await response.text();
-                } catch (err) {
-                    const e = err as Error;
-                    _createAlertBanner(e.message);
-                    this.innerHTML = '';
-                    throw e;
+    // bootstrap the <script> tag fallback only if needed (once per definition)
+    if (!customElements.get('py-script')) {
+        // allow any HTMLScriptElement to behave like a PyScript custom-elelement
+        type PyScriptElement = HTMLScriptElement & PyScript;
+
+        // the <script> tags to look for, acting like a <py-script> one
+        // both py, pyscript, and py-script, are valid types to help reducing typo cases
+        const pyScriptCSS = 'script[type="py"],script[type="pyscript"],script[type="py-script"]';
+
+        // bootstrap with the same connectedCallback logic any <script>
+        const bootstrap = (script: PyScriptElement) => {
+            const pyScriptTag = document.createElement('py-script-tag') as PyScript;
+            script.after(pyScriptTag);
+
+            // remove the first empty line to preserve line numbers/counting
+            init(pyScriptTag, () => ltrim(script.textContent.replace(/^[\r\n]+/, ''))).catch(() =>
+                pyScriptTag.remove(),
+            );
+        };
+
+        // callback used to bootstrap already known <script> tags
+        const callback: MutationCallback = records => {
+            for (const { addedNodes } of records) {
+                for (const node of addedNodes) {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        if ((node as PyScriptElement).matches(pyScriptCSS)) {
+                            bootstrap(node as PyScriptElement);
+                        }
+                        for (const child of (node as PyScriptElement).querySelectorAll(pyScriptCSS)) {
+                            bootstrap(child as PyScriptElement);
+                        }
+                    }
                 }
-            } else {
-                return htmlDecode(this.srcCode);
             }
-        }
+        };
+
+        // globally shared MutationObserver for <script> special cases
+        const pyScriptMO = new MutationObserver(callback);
+
+        // simplifies observing any root node (document/shadowRoot)
+        const observe = (root: Document | ShadowRoot) => {
+            pyScriptMO.observe(root, { childList: true, subtree: true });
+            return root;
+        };
+
+        // patch attachShadow once to bootstrap <script> special cases in there too
+        const { attachShadow } = Element.prototype;
+        Object.assign(Element.prototype, {
+            attachShadow(init: ShadowRootInit) {
+                return observe(attachShadow.call(this as Element, init));
+            },
+        });
+
+        // observe the current document and retrieve all already live py <script> tags
+        const addedNodes = observe(document).querySelectorAll(pyScriptCSS);
+
+        // bootstrap retrieved py <script> tags
+        callback([{ addedNodes } as unknown] as MutationRecord[], null);
     }
 
     return PyScript;

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -9,10 +9,10 @@ class TestBasic(PyScriptTest):
     def test_pyscript_hello(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 import js
                 js.console.log('hello pyscript')
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines == ["hello pyscript"]


### PR DESCRIPTION
## Description

This MR would like to gracefully explore the possibility to use a `<script>` tag to define Python content, as opposite of using a generic Custom Element that gets inevitably parsed by browsers.

See https://github.com/pyscript/pyscript/discussions/1326

### Changes

No relevant changes to current logic, just an added feature.

### Feature / Behavior

  * a unique *MutationObserver* is used to intercept new scripts with `type="py"`, `type="pyscript"` or `type="py-script"` on the page
  * the same *MutationObserver* is used to observe *ShadowRoot* elements attached on the fly to catch those scripts within their content too
  * beside `ltrim(...)` utility, no extra parsing is ever needed for `<script>` content
  * because a `<script>` can't really show or have children, a `<py-script-tag>` companion element (name suggested by current API, happy to revisit) is inserted right after the script, so that the *Python* content is preserved (for debug reasons) and the related `<py-script-tag>`  element is used to show results when `display(...)` function is invoked (if ever)
  * because those companion tags don't exist in the first place, there's no need to have a dedicated *CSS* rule such as `py-script-tag:not(:defined) { display: none; }` so our companion tags will never cause FOUC in the layout and no 3rd party library should ever mess with our content
  * because the `<script>` tag is executed only once it gets live, we don't need `connectedCallback` machinery as that's provided out of the box by the *MutationObserver*
  * the rest of the logic is preserved/identical to the current `<py-script>` custom element, nothing has changed in that regard ....

... on "*that regard*" though, I've noticed we don't flag our custom elements as already initialized and we use an async `connectedCallback` that will re-trigger if the node is moved around (disconnected and re-connected) and that looks like a bug we should fix, otherwise the moved node will try, eventually, to evaluate as *Python* whatever `display(...)` injected in the element. This is some potential security/generic shenanigan we should probably tackle beside the result of this MR, happy to discuss this bit aside this MR though.

## Checklist

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
