### PR TITLE
Adds missing dependency description (anaconda) to docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,7 @@ Docs
 ----
 
 - Add docs for event handlers
+- Updates requirements in dev setup guide
 
 2023.01.1
 =========

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,7 +46,6 @@ Docs
 ----
 
 - Add docs for event handlers
-- Updates requirements in dev setup guide
 
 2023.01.1
 =========

--- a/docs/development/setting-up-environment.md
+++ b/docs/development/setting-up-environment.md
@@ -20,7 +20,7 @@ git remote add upstream git@github.com:pyscript/pyscript.git
 cd pyscript/pyscriptjs
 ```
 
-* Install the dependencies with the command below (you must have `nodejs` >=16 and `make`)
+* Install the dependencies with the command below (you must have `anaconda`, `nodejs` >=16 and `make`)
 
 ```
 make setup


### PR DESCRIPTION
## Description
Following the development setup docs, running make setup will fail if you don't have anaconda installed. This should be documented.

### Changes

Documents anaconda requirement higher up in the dev setup guide.

## Checklist

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
