### PR TITLE
Clarify PR Template - Doc Changes Don't Need Changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
 ## Description
 
-Please describe the changes in your pull request in few words here.
+<!--Please describe the changes in your pull request in few words here. -->
 
-### Changes
+## Changes
 
-List the changes done to fix a bug or introducing a new feature.
+<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->
 
 ## Checklist
+
+<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->
 
 -   [ ] All tests pass locally
 -   [ ] I have updated `docs/changelog.md`


### PR DESCRIPTION
## Description

Adds some clarifications to the Pull Request template, specifically around what does and does not require a changelog entry, since that's been something that's needed clarification in several recent PR's.
