### PR TITLE
Increase commonly failing tests timeout

### DIFF
--- a/pyscriptjs/tests/integration/test_zz_examples.py
+++ b/pyscriptjs/tests/integration/test_zz_examples.py
@@ -59,7 +59,7 @@ class TestExamples(PyScriptTest):
 
     def test_altair(self):
         self.goto("examples/altair.html")
-        self.wait_for_pyscript()
+        self.wait_for_pyscript(timeout=90 * 1000)
         assert self.page.title() == "Altair"
         wait_for_render(self.page, "*", '<canvas.*?class=\\"marks\\".*?>')
         save_as_png_link = self.page.locator("text=Save as PNG")
@@ -137,7 +137,7 @@ class TestExamples(PyScriptTest):
 
     def test_folium(self):
         self.goto("examples/folium.html")
-        self.wait_for_pyscript()
+        self.wait_for_pyscript(timeout=90 * 1000)
         assert self.page.title() == "Folium"
         wait_for_render(self.page, "*", "<iframe srcdoc=")
 
@@ -173,7 +173,7 @@ class TestExamples(PyScriptTest):
 
     def test_matplotlib(self):
         self.goto("examples/matplotlib.html")
-        self.wait_for_pyscript()
+        self.wait_for_pyscript(timeout=90 * 1000)
         assert self.page.title() == "Matplotlib"
         wait_for_render(self.page, "*", "<img src=['\"]data:image")
         # The image is being rended using base64, lets fetch its source
@@ -201,7 +201,7 @@ class TestExamples(PyScriptTest):
 
     def test_numpy_canvas_fractals(self):
         self.goto("examples/numpy_canvas_fractals.html")
-        self.wait_for_pyscript()
+        self.wait_for_pyscript(timeout=90 * 1000)
         assert (
             self.page.title()
             == "Visualization of Mandelbrot, Julia and Newton sets with NumPy and HTML5 canvas"


### PR DESCRIPTION
## Description

There are 4 randomly failing tests that often give me a timeout issue (on my machine).

I'd like to propose a timeout for these too.

## Changes

Use the higher timeout other tests use for:

  * test_folium
  * test_numpy_canvas_fractals
  * test_altair
  * test_matplotlib

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
