### PR TITLE
Add `nodejs=16` to docs conda environment

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,6 +10,7 @@ dependencies:
 -   sphinx-copybutton
 -   sphinx-design
 -   sphinx-togglebutton
+-   nodejs=16
 
 -   pip:
     -   sphinxemoji


### PR DESCRIPTION
## Description

PR #1255 added prettier to the pre-commit hooks for PyScript, which is awesome. Prettier requires NodeJS 14+, so to ensure that we have the appropriate version available when commit from within the `docs/_env` conda environment, this PR makes a single-line change to `docs/environment.yml`.
