### PR TITLE
Fix what is pyscript example h1 color

### DIFF
--- a/docs/_static/examples/what-is-pyscript.html
+++ b/docs/_static/examples/what-is-pyscript.html
@@ -3,6 +3,10 @@
       <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
       <script defer src="https://pyscript.net/latest/pyscript.js"></script>
       <style>
+        h1 {
+          color: #459db9;
+        }
+
         .pulse {
             animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
         }


### PR DESCRIPTION
## Description

This is a small PR to fix the pyscript example on dark mode. I decided to use he blue that we use on the docs.

## Changes

Fixes: #1404

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
