### PR TITLE
Add `@when` decorator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 Features
 --------
 
+- Added the `@when` decorator for attaching Python functions as event handlers
 - The `py-mount` attribute on HTML elements has been deprecated, and will be removed in a future release.
 
 

--- a/docs/reference/API/when.md
+++ b/docs/reference/API/when.md
@@ -1,0 +1,13 @@
+# `@when`
+
+`@when(event:str = None, selector:str = None)`
+
+The `@when` decorator attaches the decorated function or Callable as an event handler for selected objects on the page. That is, when the named event is emitted by the selected DOM elements, the decorated Python function will be called.
+
+If the decorated function takes a single (non-self) argument, it will be passed the [Event object](https://developer.mozilla.org/en-US/docs/Web/API/Event) corresponding to the triggered event. If the function takes no (non-self) argument, it will be called with no arguments.
+
+## Parameters
+
+`event` - A string representing the event type to match against. This can be any of the [https://developer.mozilla.org/en-US/docs/Web/Events#event_listing](https://developer.mozilla.org/en-US/docs/Web/Events) that HTML elements may emit, as appropriate to their type.
+
+`selector` = A string containing one or more [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors). The selected DOM elements will have the decorated function attacehed as an event handler.

--- a/docs/reference/API/when.md
+++ b/docs/reference/API/when.md
@@ -1,6 +1,6 @@
 # `@when`
 
-`@when(event:str = None, selector:str = None)`
+`@when(event_type:str = None, selector:str = None)`
 
 The `@when` decorator attaches the decorated function or Callable as an event handler for selected objects on the page. That is, when the named event is emitted by the selected DOM elements, the decorated Python function will be called.
 
@@ -8,7 +8,7 @@ If the decorated function takes a single (non-self) argument, it will be passed 
 
 ## Parameters
 
-`event` - A string representing the event type to match against. This can be any of the [https://developer.mozilla.org/en-US/docs/Web/Events#event_listing](https://developer.mozilla.org/en-US/docs/Web/Events) that HTML elements may emit, as appropriate to their type.
+`event_type` - A string representing the event type to match against. This can be any of the [https://developer.mozilla.org/en-US/docs/Web/Events#event_listing](https://developer.mozilla.org/en-US/docs/Web/Events) that HTML elements may emit, as appropriate to their element type.
 
 `selector` = A string containing one or more [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors). The selected DOM elements will have the decorated function attacehed as an event handler.
 

--- a/docs/reference/API/when.md
+++ b/docs/reference/API/when.md
@@ -11,3 +11,41 @@ If the decorated function takes a single (non-self) argument, it will be passed 
 `event` - A string representing the event type to match against. This can be any of the [https://developer.mozilla.org/en-US/docs/Web/Events#event_listing](https://developer.mozilla.org/en-US/docs/Web/Events) that HTML elements may emit, as appropriate to their type.
 
 `selector` = A string containing one or more [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors). The selected DOM elements will have the decorated function attacehed as an event handler.
+
+## Examples:
+
+The following example prints "Hello, world!" whenever the button is clicked. It demonstrates using the `@when` decorator on a Callable which takes no arguments:
+
+```html
+<button id="my_btn">Click Me to Say Hi</button>
+<py-script>
+    from pyscript import when
+    @when("click", selector="#my_btn")
+    def say_hello():
+        print(f"Hello, world!")
+</py-script>
+```
+
+The following example includes three buttons - when any of the buttons is clicked, that button turns green, and the remaining two buttons turn red. This demonstrates using the `@when` decorator on a Callable which takes one argument, which is then passed the Event object from the associated event. When combined with the ability to look at other elements in on the page, this is quite a powerful feature.
+
+```html
+<div id="container">
+    <button>First</button>
+    <button>Second</button>
+    <button>Third</button>
+</div>
+<py-script>
+    from pyscript import when
+    import js
+
+    @when("click", selector="#container button")
+    def highlight(evt):
+        #Set the clicked button's background to green
+        evt.target.style.backgroundColor = 'green'
+
+        #Set the background of all buttons to red
+        other_buttons = (button for button in js.document.querySelectorAll('button') if button != evt.target)
+        for button in other_buttons:
+            button.style.backgroundColor = 'red'
+</py-script>
+```

--- a/pyscriptjs/src/python/pyscript/__init__.py
+++ b/pyscriptjs/src/python/pyscript/__init__.py
@@ -1,5 +1,6 @@
 from _pyscript_js import showWarning
 
+from ._event_handling import when
 from ._event_loop import LOOP as loop
 from ._event_loop import run_until_complete
 from ._html import (
@@ -51,4 +52,5 @@ __all__ = [
     "__version__",
     "version_info",
     "showWarning",
+    "when",
 ]

--- a/pyscriptjs/src/python/pyscript/_event_handling.py
+++ b/pyscriptjs/src/python/pyscript/_event_handling.py
@@ -1,0 +1,27 @@
+import inspect
+
+import js
+from pyodide.ffi.wrappers import add_event_listener
+
+
+def when(event=None, id=None):
+    """
+    Decorates a function and passes py-* events to the decorated function
+    The events might or not be an argument of the decorated function
+    """
+
+    def decorator(func):
+        element = js.document.getElementById(id)
+        sig = inspect.signature(func)
+        # Function doesn't receive events
+        if not sig.parameters:
+
+            def wrapper(*args, **kwargs):
+                func()
+
+            add_event_listener(element, event, wrapper)
+        else:
+            add_event_listener(element, event, func)
+        return func
+
+    return decorator

--- a/pyscriptjs/src/python/pyscript/_event_handling.py
+++ b/pyscriptjs/src/python/pyscript/_event_handling.py
@@ -4,7 +4,7 @@ import js
 from pyodide.ffi.wrappers import add_event_listener
 
 
-def when(event=None, selector=None):
+def when(event_type=None, selector=None):
     """
     Decorates a function and passes py-* events to the decorated function
     The events might or not be an argument of the decorated function
@@ -20,10 +20,10 @@ def when(event=None, selector=None):
                 func()
 
             for el in elements:
-                add_event_listener(el, event, wrapper)
+                add_event_listener(el, event_type, wrapper)
         else:
             for el in elements:
-                add_event_listener(el, event, func)
+                add_event_listener(el, event_type, func)
         return func
 
     return decorator

--- a/pyscriptjs/src/python/pyscript/_event_handling.py
+++ b/pyscriptjs/src/python/pyscript/_event_handling.py
@@ -4,14 +4,14 @@ import js
 from pyodide.ffi.wrappers import add_event_listener
 
 
-def when(event=None, id=None):
+def when(event=None, selector=None):
     """
     Decorates a function and passes py-* events to the decorated function
     The events might or not be an argument of the decorated function
     """
 
     def decorator(func):
-        element = js.document.getElementById(id)
+        elements = js.document.querySelectorAll(selector)
         sig = inspect.signature(func)
         # Function doesn't receive events
         if not sig.parameters:
@@ -19,9 +19,11 @@ def when(event=None, id=None):
             def wrapper(*args, **kwargs):
                 func()
 
-            add_event_listener(element, event, wrapper)
+            for el in elements:
+                add_event_listener(el, event, wrapper)
         else:
-            add_event_listener(element, event, func)
+            for el in elements:
+                add_event_listener(el, event, func)
         return func
 
     return decorator

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -316,6 +316,7 @@ class TestBasic(PyScriptTest):
         )
         btn = self.page.wait_for_selector("button")
         btn.click()
+        self.wait_for_console("hello world!")
         assert self.console.log.lines[-1] == "hello world!"
         assert self.console.error.lines == []
 

--- a/pyscriptjs/tests/integration/test_event_handling.py
+++ b/pyscriptjs/tests/integration/test_event_handling.py
@@ -12,7 +12,7 @@ class TestEventHandler(PyScriptTest):
             <button id="foo_id">foo_button</button>
             <py-script>
                 from pyscript import when
-                @when("click", id="foo_id")
+                @when("click", selector="#foo_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
             </py-script>
@@ -34,7 +34,7 @@ class TestEventHandler(PyScriptTest):
             <button id="foo_id">foo_button</button>
             <py-script>
                 from pyscript import when
-                @when("click", id="foo_id")
+                @when("click", selector="#foo_id")
                 def foo():
                     print("The button was clicked")
             </py-script>
@@ -53,10 +53,10 @@ class TestEventHandler(PyScriptTest):
             <button id="bar_id">bar_button</button>
             <py-script>
                 from pyscript import when
-                @when("click", id="foo_id")
+                @when("click", selector="#foo_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
-                @when("click", id="bar_id")
+                @when("click", selector="#bar_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
             </py-script>

--- a/pyscriptjs/tests/integration/test_event_handling.py
+++ b/pyscriptjs/tests/integration/test_event_handling.py
@@ -97,6 +97,28 @@ class TestEventHandler(PyScriptTest):
         self.assert_no_banners()
 
     @skip_worker(reason="FIXME: js.document (@when decorator)")
+    def test_two_when_decorators_same_element(self):
+        """When decorating a function twice *on the same DOM element*, both should function"""
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", selector="#foo_id")
+                @when("mouseover", selector="#foo_id")
+                def foo(evt):
+                    print(f"An event of type {evt.type} happened")
+            </py-script>
+        """
+        )
+        self.page.locator("text=foo_button").hover()
+        self.page.locator("text=foo_button").click()
+        self.wait_for_console("An event of type click happened")
+        assert "An event of type mouseover happened" in self.console.log.lines
+        assert "An event of type click happened" in self.console.log.lines
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
     def test_when_decorator_multiple_elements(self):
         """The @when decorator's selector should successfully select multiple
         DOM elements

--- a/pyscriptjs/tests/integration/test_event_handling.py
+++ b/pyscriptjs/tests/integration/test_event_handling.py
@@ -1,0 +1,74 @@
+from .support import PyScriptTest, skip_worker
+
+
+class TestEventHandler(PyScriptTest):
+    @skip_worker(reason="FIXME: js.document")
+    def test_when_decorator_with_event(self):
+        """When the decorated function takes a single parameter,
+        it should be passed the event object
+        """
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", id="foo_id")
+                def foo(evt):
+                    print(f"I've clicked {evt.target} with id {evt.target.id}")
+            </py-script>
+        """
+        )
+        self.page.locator("text=foo_button").click()
+        console_text = self.console.all.lines
+        self.wait_for_console("I've clicked [object HTMLButtonElement] with id foo_id")
+        assert "I've clicked [object HTMLButtonElement] with id foo_id" in console_text
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document")
+    def test_when_decorator_without_event(self):
+        """When the decorated function takes no parameters (not including 'self'),
+        it should be called without the event object
+        """
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", id="foo_id")
+                def foo():
+                    print("The button was clicked")
+            </py-script>
+        """
+        )
+        self.page.locator("text=foo_button").click()
+        self.wait_for_console("The button was clicked")
+        assert "The button was clicked" in self.console.log.lines
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document")
+    def test_multiple_when_decorators_with_event(self):
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <button id="bar_id">bar_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", id="foo_id")
+                def foo(evt):
+                    print(f"I've clicked {evt.target} with id {evt.target.id}")
+                @when("click", id="bar_id")
+                def foo(evt):
+                    print(f"I've clicked {evt.target} with id {evt.target.id}")
+            </py-script>
+        """
+        )
+        self.page.locator("text=foo_button").click()
+        console_text = self.console.all.lines
+        self.wait_for_console("I've clicked [object HTMLButtonElement] with id foo_id")
+        assert "I've clicked [object HTMLButtonElement] with id foo_id" in console_text
+
+        self.page.locator("text=bar_button").click()
+        console_text = self.console.all.lines
+        self.wait_for_console("I've clicked [object HTMLButtonElement] with id bar_id")
+        assert "I've clicked [object HTMLButtonElement] with id bar_id" in console_text
+        self.assert_no_banners()

--- a/pyscriptjs/tests/integration/test_event_handling.py
+++ b/pyscriptjs/tests/integration/test_event_handling.py
@@ -2,7 +2,7 @@ from .support import PyScriptTest, skip_worker
 
 
 class TestEventHandler(PyScriptTest):
-    @skip_worker(reason="FIXME: js.document")
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
     def test_when_decorator_with_event(self):
         """When the decorated function takes a single parameter,
         it should be passed the event object
@@ -24,7 +24,7 @@ class TestEventHandler(PyScriptTest):
         assert "I've clicked [object HTMLButtonElement] with id foo_id" in console_text
         self.assert_no_banners()
 
-    @skip_worker(reason="FIXME: js.document")
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
     def test_when_decorator_without_event(self):
         """When the decorated function takes no parameters (not including 'self'),
         it should be called without the event object
@@ -45,7 +45,7 @@ class TestEventHandler(PyScriptTest):
         assert "The button was clicked" in self.console.log.lines
         self.assert_no_banners()
 
-    @skip_worker(reason="FIXME: js.document")
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
     def test_multiple_when_decorators_with_event(self):
         self.pyscript_run(
             """
@@ -73,7 +73,54 @@ class TestEventHandler(PyScriptTest):
         assert "I've clicked [object HTMLButtonElement] with id bar_id" in console_text
         self.assert_no_banners()
 
-    @skip_worker(reason="FIXME: js.document")
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
+    def test_two_when_decorators(self):
+        """When decorating a function twice, both should function"""
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <button class="bar_class">bar_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", selector="#foo_id")
+                @when("mouseover", selector=".bar_class")
+                def foo(evt):
+                    print(f"An event of type {evt.type} happened")
+            </py-script>
+        """
+        )
+        self.page.locator("text=bar_button").hover()
+        self.page.locator("text=foo_button").click()
+        self.wait_for_console("An event of type click happened")
+        assert "An event of type mouseover happened" in self.console.log.lines
+        assert "An event of type click happened" in self.console.log.lines
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
+    def test_when_decorator_multiple_elements(self):
+        """The @when decorator's selector should successfully select multiple
+        DOM elements
+        """
+        self.pyscript_run(
+            """
+            <button class="bar_class">button1</button>
+            <button class="bar_class">button2</button>
+            <py-script>
+                from pyscript import when
+                @when("click", selector=".bar_class")
+                def foo(evt):
+                    print(f"{evt.target.innerText} was clicked")
+            </py-script>
+        """
+        )
+        self.page.locator("text=button1").click()
+        self.page.locator("text=button2").click()
+        self.wait_for_console("button2 was clicked")
+        assert "button1 was clicked" in self.console.log.lines
+        assert "button2 was clicked" in self.console.log.lines
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
     def test_invalid_selector(self):
         """When the selector parameter of @when is invalid, it should show an error"""
         self.pyscript_run(

--- a/pyscriptjs/tests/integration/test_event_handling.py
+++ b/pyscriptjs/tests/integration/test_event_handling.py
@@ -143,7 +143,31 @@ class TestEventHandler(PyScriptTest):
         self.assert_no_banners()
 
     @skip_worker(reason="FIXME: js.document (@when decorator)")
-    def test_invalid_selector(self):
+    def test_when_decorator_duplicate_selectors(self):
+        """ """
+        self.pyscript_run(
+            """
+            <button id="foo_id">foo_button</button>
+            <py-script>
+                from pyscript import when
+                @when("click", selector="#foo_id")
+                @when("click", selector="#foo_id")
+                def foo(evt):
+                    print(f"I've clicked {evt.target} with id {evt.target.id}")
+            </py-script>
+        """
+        )
+        self.page.locator("text=foo_button").click()
+        console_text = self.console.all.lines
+        self.wait_for_console("I've clicked [object HTMLButtonElement] with id foo_id")
+        assert (
+            console_text.count("I've clicked [object HTMLButtonElement] with id foo_id")
+            == 2
+        )
+        self.assert_no_banners()
+
+    @skip_worker(reason="FIXME: js.document (@when decorator)")
+    def test_when_decorator_invalid_selector(self):
         """When the selector parameter of @when is invalid, it should show an error"""
         self.pyscript_run(
             """


### PR DESCRIPTION
## Description

This adds the `@when` decorator to the PyScript API. It is largely the work of @marimeireles in #1240, with a little reshaping around the newer Pyodide FFI and some test cleanup.

The `when` decorator takes two arguments, `event` and `selector`. It attaches the decorated function as an event handler for the named event to all elements in the DOM that match the selector. If the wrapped function takes a single (non-self) argument, the function will be passed the event object when it is called; otherwise, it is called with no arguments.

## Changes

- Adds the `@when` decorator in a new module `_event_handling.py`
- Adds tests for the same in new file `test_event_handling.py`

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
