### PR TITLE
Fix #735 - Test <script type="py"> against all special cases

### DIFF
--- a/pyscriptjs/tests/integration/test_script_type.py
+++ b/pyscriptjs/tests/integration/test_script_type.py
@@ -1,0 +1,51 @@
+from .support import PyScriptTest, skip_worker
+
+
+class TestDisplayLineBreak(PyScriptTest):
+    @skip_worker("FIXME: there is no document in a worker")
+    def test_display_line_break(self):
+        self.pyscript_run(
+            r"""
+            <script type="py-script">
+                display('hello\nworld')
+            </script>
+            """
+        )
+        text_content = self.page.locator("py-script-tag").text_content()
+        assert "hello\nworld" == text_content
+
+    @skip_worker("FIXME: there is no document in a worker")
+    def test_amp(self):
+        self.pyscript_run(
+            r"""
+            <script type="py-script">
+                display('a &amp; b')
+            </script>
+            """
+        )
+        text_content = self.page.locator("py-script-tag").text_content()
+        assert "a &amp; b" == text_content
+
+    @skip_worker("FIXME: there is no document in a worker")
+    def test_quot(self):
+        self.pyscript_run(
+            r"""
+            <script type="py-script">
+                display('a &quot; b')
+            </script>
+            """
+        )
+        text_content = self.page.locator("py-script-tag").text_content()
+        assert "a &quot; b" == text_content
+
+    @skip_worker("FIXME: there is no document in a worker")
+    def test_lt_gt(self):
+        self.pyscript_run(
+            r"""
+            <script type="py-script">
+                display('< &lt; &gt; >')
+            </script>
+            """
+        )
+        text_content = self.page.locator("py-script-tag").text_content()
+        assert "< &lt; &gt; >" == text_content


### PR DESCRIPTION
## Description

Rather than a *fix* this MR showcases that when special chars are meant and needed, the `<script type="py">` solution works out of the box without any encoding/decoding indirection and without *DOMParser* on its way.

## Changes

  * added a test that proves that with a `<script type="py">` none of the issues presented in #735 exist

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
