### PR TITLE
Fix #1427 - Avoid multiple initialization of the same node

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -9,6 +9,9 @@ import { InterpreterClient } from '../interpreter_client';
 
 const logger = getLogger('py-script');
 
+// used to flag already initialized nodes
+const knownPyScriptTags: WeakSet<HTMLElement> = new WeakSet();
+
 export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) {
     /**
      * A common <py-script> VS <script type="py"> initializator.
@@ -62,6 +65,10 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
         _fetchSourceFallback = () => htmlDecode(this.srcCode);
 
         async connectedCallback() {
+            // prevent multiple initialization of the same node if re-appended
+            if (knownPyScriptTags.has(this)) return;
+            knownPyScriptTags.add(this);
+
             // Save innerHTML information in srcCode so we can access it later
             // once we clean innerHTML (which is required since we don't want
             // source code to be rendered on the screen)
@@ -86,6 +93,10 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
 
         // bootstrap with the same connectedCallback logic any <script>
         const bootstrap = (script: PyScriptElement) => {
+            // prevent multiple initialization of the same node if re-appended
+            if (knownPyScriptTags.has(script)) return;
+            knownPyScriptTags.add(script);
+
             const pyScriptTag = document.createElement('py-script-tag') as PyScript;
 
             // move attributes to the live resulting pyScriptTag reference


### PR DESCRIPTION
## Description

This MR would like to provide option No. 1 of the related issue https://github.com/pyscript/pyscript/issues/1427

## Changes

  * use a *WeakSet* to flag already initialized PyScript nodes (either custom element or script)

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
