### PR TITLE
Fix <script src> + test all py-script attributes

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -89,7 +89,7 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
             const pyScriptTag = document.createElement('py-script-tag') as PyScript;
 
             // move attributes to the live resulting pyScriptTag reference
-            for (const name of ['output', 'stderr']) {
+            for (const name of ['output', 'src', 'stderr']) {
                 const value = script.getAttribute(name);
                 if (value) {
                     pyScriptTag.setAttribute(name, value);

--- a/pyscriptjs/tests/integration/test_script_type.py
+++ b/pyscriptjs/tests/integration/test_script_type.py
@@ -1,8 +1,8 @@
 from .support import PyScriptTest, skip_worker
 
 
-class TestDisplayLineBreak(PyScriptTest):
-    @skip_worker("FIXME: there is no document in a worker")
+class TestScriptTypePyScript(PyScriptTest):
+    @skip_worker("FIXME: js.document")
     def test_display_line_break(self):
         self.pyscript_run(
             r"""
@@ -14,7 +14,7 @@ class TestDisplayLineBreak(PyScriptTest):
         text_content = self.page.locator("py-script-tag").text_content()
         assert "hello\nworld" == text_content
 
-    @skip_worker("FIXME: there is no document in a worker")
+    @skip_worker("FIXME: js.document")
     def test_amp(self):
         self.pyscript_run(
             r"""
@@ -26,7 +26,7 @@ class TestDisplayLineBreak(PyScriptTest):
         text_content = self.page.locator("py-script-tag").text_content()
         assert "a &amp; b" == text_content
 
-    @skip_worker("FIXME: there is no document in a worker")
+    @skip_worker("FIXME: js.document")
     def test_quot(self):
         self.pyscript_run(
             r"""
@@ -38,7 +38,7 @@ class TestDisplayLineBreak(PyScriptTest):
         text_content = self.page.locator("py-script-tag").text_content()
         assert "a &quot; b" == text_content
 
-    @skip_worker("FIXME: there is no document in a worker")
+    @skip_worker("FIXME: js.document")
     def test_lt_gt(self):
         self.pyscript_run(
             r"""
@@ -49,3 +49,62 @@ class TestDisplayLineBreak(PyScriptTest):
         )
         text_content = self.page.locator("py-script-tag").text_content()
         assert "< &lt; &gt; >" == text_content
+
+    @skip_worker("FIXME: js.document")
+    def test_dynamically_add_script_type_py_tag(self):
+        self.pyscript_run(
+            """
+            <script>
+                function addPyScriptTag() {
+                    let tag = document.createElement('script');
+                    tag.type = 'py-script';
+                    tag.textContent = "print('hello world')";
+                    document.body.appendChild(tag);
+                }
+            </script>
+            <button onclick="addPyScriptTag()">Click me</button>
+            """
+        )
+        self.page.locator("button").click()
+
+        self.page.wait_for_selector("py-terminal")
+        assert self.console.log.lines[-1] == "hello world"
+
+    @skip_worker("FIXME: js.document")
+    def test_script_type_py_src_attribute(self):
+        self.writefile("foo.py", "print('hello from foo')")
+        self.pyscript_run(
+            """
+            <script type="py-script" src="foo.py"></script>
+            """
+        )
+        assert self.console.log.lines[-1] == "hello from foo"
+
+    @skip_worker("FIXME: js.document")
+    def test_script_type_py_output_attribute(self):
+        self.pyscript_run(
+            """
+            <div id="first"></div>
+            <script type="py-script" output="first">
+                print("<p>Hello</p>")
+            </script>
+            """
+        )
+        text = self.page.locator("#first").text_content()
+        assert "<p>Hello</p>" in text
+
+    @skip_worker("FIXME: js.document")
+    def test_script_type_py_stderr_attribute(self):
+        self.pyscript_run(
+            """
+            <div id="stdout-div"></div>
+            <div id="stderr-div"></div>
+            <py-script output="stdout-div" stderr="stderr-div">
+                import sys
+                print("one.", file=sys.stderr)
+                print("two.")
+            </py-script>
+            """
+        )
+        assert self.page.locator("#stdout-div").text_content() == "one.two."
+        assert self.page.locator("#stderr-div").text_content() == "one."


### PR DESCRIPTION
## Description

After addressing  @JeffersGlass comment on adding more tests for attributes, I've realized that indeed I forgot to propagate the `src` attribute to the companion element.

Everything is now tested though and the `src` works as expected.

## Changes

  * propagate the `src` attribute to the companion element to handle external sources too
  * add tests that prove all attributes work exactly like `<py-script>` does

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
