### PR TITLE
Fix #1059 - Observe py-* attributes changes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ Features
 - The `py-mount` attribute on HTML elements has been deprecated, and will be removed in a future release.
 
 
+### Runtime py- attributes
+
+- Added logic to react to `py-*` attributes changes, removal, `py-*` attributes added to already live nodes but also `py-*` attributes added or defined via injected nodes (either appended or via `innerHTML` operations). ([#1435](https://github.com/pyscript/pyscript/pull/1435))
+
 ### &lt;script type="py"&gt;
 - Added the ability to optionally use `<script type="py">`, `<script type="pyscript">` or `<script type="py-script">` instead of a `<py-script>` custom element, in order to tackle cases where the content of the `<py-script>` tag, inevitably parsed by browsers, could accidentally contain *HTML* able to break the surrounding page layout. ([#1396](https://github.com/pyscript/pyscript/pull/1396))
 

--- a/pyscriptjs/tests/integration/test_runtime_attributes.py
+++ b/pyscriptjs/tests/integration/test_runtime_attributes.py
@@ -1,0 +1,62 @@
+from .support import PyScriptTest, skip_worker
+
+
+class TestPyScriptRuntimeAttributes(PyScriptTest):
+    @skip_worker("FIXME: js.document")
+    def test_injected_html_with_py_event(self):
+        self.pyscript_run(
+            r"""
+            <div id="py-button-container"></div>
+            <py-script>
+              import js
+
+              py_button = Element("py-button-container")
+              py_button.element.innerHTML = '<button py-click="print_hello()"></button>'
+
+              def print_hello():
+                js.console.log("hello pyscript")
+            </py-script>
+            """
+        )
+        self.page.locator("button").click()
+        assert self.console.log.lines == ["hello pyscript"]
+
+    @skip_worker("FIXME: js.document")
+    def test_added_py_event(self):
+        self.pyscript_run(
+            r"""
+            <button id="py-button"></button>
+            <py-script>
+              import js
+
+              py_button = Element("py-button")
+              py_button.element.setAttribute("py-click", "print_hello()")
+
+              def print_hello():
+                js.console.log("hello pyscript")
+            </py-script>
+            """
+        )
+        self.page.locator("button").click()
+        assert self.console.log.lines == ["hello pyscript"]
+
+    @skip_worker("FIXME: js.document")
+    def test_added_then_removed_py_event(self):
+        self.pyscript_run(
+            r"""
+            <button id="py-button">live content</button>
+            <py-script>
+              import js
+
+              py_button = Element("py-button")
+              py_button.element.setAttribute("py-click", "print_hello()")
+
+              def print_hello():
+                js.console.log("hello pyscript")
+                py_button.element.removeAttribute("py-click")
+            </py-script>
+            """
+        )
+        self.page.locator("button").click()
+        self.page.locator("button").click()
+        assert self.console.log.lines == ["hello pyscript"]


### PR DESCRIPTION
## Description

This MR addresses various long-standing issues around `py-*` events added at runtime, injected via `innerHTML`, changed or removed from both already live components and new nodes added during long sessions.

## Changes

  * recycled the same MutationObserver used to observe only scripts so that attributes nodes are also observed in both the `document` and any `shadowRoot` attached in the wild
  * simplified the bootstrap of `<script type="py">` nodes without needing to reuse the MO logic
  * simplified with previous point the bootstrap of *scripts* also within added nodes
  * improved the XPath selector to start from a specific context node and reused the same logic for both initial PyScript bootstrap and all runtime added nodes so that all attributes are addressed
  * added logic to remove or add same listener to any node that mutates attributes once live on the page
  * introduced a memoized `lastInterpreter` reference as it's otherwise impossible to have an interpreter when runtime nodes or attributes are added or created (will follow up with [an architecture question](https://github.com/pyscript/pyscript/discussions/1436))

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)