### PR TITLE
Fix #1341 - Use <script type="py"> instead to avoid entities

### DIFF
--- a/examples/matplotlib.html
+++ b/examples/matplotlib.html
@@ -32,7 +32,7 @@
                     ]
                 </py-config>
 
-                <py-script>
+                <script type="py">
                     import matplotlib.pyplot as plt
                     import matplotlib.tri as tri
                     import numpy as np
@@ -66,7 +66,7 @@
                     ax1.set_title('tripcolor of Delaunay triangulation, flat shading')
 
                     display(fig1, target="mpl")
-                </py-script>
+                </script>
             </py-tutor>
         </section>
     </body>


### PR DESCRIPTION
## Description

As `<script type="py">` alternative landed, and it doesn't suffer any entities related issue, it's likely to be more suitable to show examples with python code that contains entities such as `&lt;` and others.

## Changes

  * use `<script type="py">` instead of `<py-script>` to completely avoid dealing with entities

## Checklist

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
