### PR TITLE
Fix #1446 - Move pyscript defer after other dependencies

### DIFF
--- a/examples/panel.html
+++ b/examples/panel.html
@@ -7,7 +7,6 @@
             rel="stylesheet"
             href="https://pyscript.net/latest/pyscript.css"
         />
-        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
         <link rel="stylesheet" href="./assets/css/examples.css" />
     </head>
     <body>
@@ -29,6 +28,7 @@
                 <script defer src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
                 <script defer src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
                 <script defer src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.14.1/dist/panel.min.js"></script>
+                <script defer src="https://pyscript.net/latest/pyscript.js"></script>
                 <py-config>
                     packages = [
                       "https://cdn.holoviz.org/panel/0.14.3/dist/wheels/bokeh-2.4.3-py3-none-any.whl",


### PR DESCRIPTION
## Description

~~There's a possible regression with current panel demo, because~~ (see https://github.com/pyscript/pyscript/issues/1446#issuecomment-1534368103) we were deferring pyscript after other scripts but latest change inverted the order. Issue #1446 is likely unrelated but that's where I've noticed we moved the dance within the tutor but the pyscript was left behind.

I don't think current page is causing any issue because of *DOMContentLoaded* event triggered after deferred scripts are in, but it's worth, for clean/consistency sake, to preserve the original order.

## Changes

  * move the pyscript library *after* the rest of the dependencies

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
