### PR TITLE
Fix #1445 - Move the EditorView into ShadowDOM

### DIFF
--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -44,7 +44,7 @@ class TestPyRepl(PyScriptTest):
             """
         )
         py_repl = self.page.locator("py-repl")
-        src = py_repl.inner_text()
+        src = py_repl.locator("div.cm-content").inner_text()
         assert "print('hello from py-repl')" in src
         py_repl.locator("button").click()
         self.page.wait_for_selector("py-terminal")
@@ -601,7 +601,7 @@ class TestPyRepl(PyScriptTest):
         assert self.console.info.lines[-1] == successMsg
 
         py_repl = self.page.locator("py-repl")
-        code = py_repl.inner_text()
+        code = py_repl.locator("div.cm-content").inner_text()
         assert "print('1')" in code
 
     @skip_worker("TIMEOUT")


### PR DESCRIPTION
## Description

This MR goal is to move the codemirror's *EditorView* into a dedicated *div* through its *shadowRoot* to avoid editor style and behavior break in the wild.

## Changes

  * slightly changed the *EditorView* initialization dance
  * changed tests to address via *Playwright* "*automagic*" `shadowRoot` crawler the content of the repl
  * changed the way external *src* is injected, using the `editor.dom` as root

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

No user-facing changes.

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
