### PR TITLE
Chore - Utils cleanup

### DIFF
--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -8,7 +8,7 @@ import { InterpreterClient } from './interpreter_client';
 import { PluginManager, Plugin, PythonPlugin } from './plugin';
 import { make_PyScript, initHandlers, mountElements } from './components/pyscript';
 import { getLogger } from './logger';
-import { showWarning, globalExport, createLock } from './utils';
+import { showWarning, createLock } from './utils';
 import { calculateFetchPaths } from './plugins/calculateFetchPaths';
 import { createCustomElements } from './components/elements';
 import { UserError, ErrorCode, _createAlertBanner } from './exceptions';
@@ -450,10 +450,7 @@ modules must contain a "plugin" attribute. For more information check the plugin
     }
 }
 
-function pyscript_get_config() {
-    return globalApp.config;
-}
-globalExport('pyscript_get_config', pyscript_get_config);
+globalThis.pyscript_get_config = () => globalApp.config;
 
 // main entry point of execution
 const globalApp = new PyScriptApp();

--- a/pyscriptjs/src/plugin.ts
+++ b/pyscriptjs/src/plugin.ts
@@ -143,7 +143,7 @@ export class PluginManager {
     }
 
     add(...plugins: Plugin[]) {
-        for (const p of plugins) this._plugins.push(p);
+        this._plugins.push(...plugins);
     }
 
     addPythonPlugin(plugin: PythonPlugin) {

--- a/pyscriptjs/src/pyconfig.ts
+++ b/pyscriptjs/src/pyconfig.ts
@@ -1,7 +1,7 @@
 import toml from '@hoodmane/toml-j0.4';
 import { getLogger } from './logger';
 import { version } from './version';
-import { getAttribute, readTextFromPath, htmlDecode, createDeprecationWarning } from './utils';
+import { readTextFromPath, htmlDecode, createDeprecationWarning } from './utils';
 import { UserError, ErrorCode } from './exceptions';
 
 const logger = getLogger('py-config');
@@ -74,7 +74,7 @@ export function loadConfigFromElement(el: Element): AppConfig {
         srcConfig = {};
         inlineConfig = {};
     } else {
-        const configType = getAttribute(el, 'type') || 'toml';
+        const configType = el.getAttribute('type') || 'toml';
         srcConfig = extractFromSrc(el, configType);
         inlineConfig = extractFromInline(el, configType);
     }
@@ -88,7 +88,7 @@ export function loadConfigFromElement(el: Element): AppConfig {
 }
 
 function extractFromSrc(el: Element, configType: string) {
-    const src = getAttribute(el, 'src');
+    const src = el.getAttribute('src');
     if (src) {
         logger.info('loading ', src);
         return validateConfig(readTextFromPath(src), configType);

--- a/pyscriptjs/src/pyexec.ts
+++ b/pyscriptjs/src/pyexec.ts
@@ -55,7 +55,6 @@ export async function pyDisplay(interpreter: InterpreterClient, obj: any, kwargs
 }
 
 export function displayPyException(err: Error, errElem: HTMLElement) {
-    //addClasses(errElem, ['py-error'])
     const pre = document.createElement('pre');
     pre.className = 'py-error';
 

--- a/pyscriptjs/src/utils.ts
+++ b/pyscriptjs/src/utils.ts
@@ -2,18 +2,6 @@ import { $$ } from 'basic-devtools';
 
 import { _createAlertBanner } from './exceptions';
 
-export function addClasses(element: HTMLElement, classes: string[]) {
-    for (const entry of classes) {
-        element.classList.add(entry);
-    }
-}
-
-export function removeClasses(element: HTMLElement, classes: string[]) {
-    for (const entry of classes) {
-        element.classList.remove(entry);
-    }
-}
-
 export function escape(str: string): string {
     return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
@@ -60,23 +48,6 @@ export function inJest(): boolean {
     return typeof process === 'object' && process.env.JEST_WORKER_ID !== undefined;
 }
 
-export function globalExport(name: string, obj: object) {
-    // attach the given object to the global object, so that it is globally
-    // visible everywhere. Should be used very sparingly!
-
-    globalThis[name] = obj;
-}
-
-export function getAttribute(el: Element, attr: string): string | null {
-    if (el.hasAttribute(attr)) {
-        const value = el.getAttribute(attr);
-        if (value) {
-            return value;
-        }
-    }
-    return null;
-}
-
 export function joinPaths(parts: string[], separator = '/') {
     const res = parts
         .map(function (part) {
@@ -102,11 +73,11 @@ export function createDeprecationWarning(msg: string, elementName: string): void
  * @param sentinelText {string} [null] The text to match against existing warning banners.
  *                     If null, the full text of 'msg' is used instead.
  */
-export function createSingularWarning(msg: string, sentinelText: string | null = null): void {
+export function createSingularWarning(msg: string, sentinelText?: string): void {
     const banners = $$('.alert-banner, .py-warning', document);
     let bannerCount = 0;
     for (const banner of banners) {
-        if (banner.innerHTML.includes(sentinelText ? sentinelText : msg)) {
+        if (banner.innerHTML.includes(sentinelText || msg)) {
             bannerCount++;
         }
     }


### PR DESCRIPTION
## Description

I am doing some investigation around the pyscript bootstrap and following "[the boyscout rule](https://levelup.gitconnected.com/the-boy-scouting-rule-a-simple-yet-effective-programming-principle-5d504c7dd993)" I've decided to push some minor cleanup.

## Changes

  * removed `getAttribute` as not-needed indirection of `anyElement.getAttribute(...)` as the check on attribute is weak and the result is always `null` even if the attribute is there but its value is an empty string
  * removed any multi class utility because `classList.add(...classes)` and `classList.remove(...classes)` already accept an array of classes
  * fixed, or better simplfied, some unnecessary type overhead
  * removed a (imho?) not useful at all `globalExport` export which does nothing different from attaching something globally
  * sneaked in a minor change in plugins too since I've just spotted that too

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
