### PR TITLE
WIP: Make sure that tests fail in case there is an unhandled Python error

### DIFF
--- a/pyscriptjs/tests/integration/test_00_support.py
+++ b/pyscriptjs/tests/integration/test_00_support.py
@@ -3,7 +3,12 @@ import textwrap
 
 import pytest
 
-from .support import JsErrors, JsErrorsDidNotRaise, PyScriptTest, with_execution_thread
+from .support import (
+    PageErrors,
+    PageErrorsDidNotRaise,
+    PyScriptTest,
+    with_execution_thread,
+)
 
 
 @with_execution_thread(None)
@@ -104,7 +109,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.check_js_errors()
         # check that the exception message contains the error message and the
         # stack trace
@@ -147,7 +152,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrorsDidNotRaise) as exc:
+        with pytest.raises(PageErrorsDidNotRaise) as exc:
             self.check_js_errors(
                 "this is an error 1",
                 "this is an error 2",
@@ -176,7 +181,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.check_js_errors()
         #
         msg = str(exc.value)
@@ -207,7 +212,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.check_js_errors("expected 1", "expected 3")
         #
         msg = str(exc.value)
@@ -233,7 +238,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrorsDidNotRaise) as exc:
+        with pytest.raises(PageErrorsDidNotRaise) as exc:
             self.check_js_errors("this is not going to be found")
         #
         msg = str(exc.value)
@@ -348,7 +353,7 @@ class TestSupport(PyScriptTest):
         self.writefile("mytest.html", doc)
         # "Page loaded!" will never appear, of course.
         self.goto("mytest.html")
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.wait_for_console("Page loaded!", timeout=200)
         assert "this is an error" in str(exc.value)
         assert isinstance(exc.value.__context__, TimeoutError)
@@ -358,7 +363,7 @@ class TestSupport(PyScriptTest):
         self.goto("mytest.html")
         with pytest.raises(TimeoutError):
             self.wait_for_console("Page loaded!", timeout=200, check_js_errors=False)
-        # we still got a JsErrors, so we need to manually clear it, else the
+        # we still got a PageErrors, so we need to manually clear it, else the
         # test fails at teardown
         self.clear_js_errors()
 
@@ -381,7 +386,7 @@ class TestSupport(PyScriptTest):
         """
         self.writefile("mytest.html", doc)
         self.goto("mytest.html")
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.wait_for_console("Page loaded!", timeout=200)
         assert "this is an error" in str(exc.value)
         #

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from .support import JsErrors, PyScriptTest, skip_worker
+from .support import PageErrors, PyScriptTest, skip_worker
 
 
 class TestBasic(PyScriptTest):
@@ -76,6 +76,8 @@ class TestBasic(PyScriptTest):
         """
         )
         assert "hello pyscript" in self.console.log.lines
+        self.check_py_errors("Exception: this is an error")
+        #
         # check that we sent the traceback to the console
         tb_lines = self.console.error.lines[-1].splitlines()
         assert tb_lines[0] == "[pyexec] Python exception:"
@@ -106,6 +108,8 @@ class TestBasic(PyScriptTest):
         self.wait_for_console(
             "Exception: this is an error inside handler", match_substring=True
         )
+
+        self.check_py_errors("Exception: this is an error inside handler")
 
         ## error in console
         tb_lines = self.console.error.lines[-1].splitlines()
@@ -240,7 +244,7 @@ class TestBasic(PyScriptTest):
         assert self.console.log.lines[-1] == "hello from foo"
 
     def test_py_script_src_not_found(self):
-        with pytest.raises(JsErrors) as exc:
+        with pytest.raises(PageErrors) as exc:
             self.pyscript_run(
                 """
                 <py-script src="foo.py"></py-script>
@@ -249,9 +253,7 @@ class TestBasic(PyScriptTest):
         assert "Failed to load resource" in self.console.error.lines[0]
 
         error_msgs = str(exc.value)
-
         expected_msg = "(PY0404): Fetching from URL foo.py failed with error 404"
-
         assert expected_msg in error_msgs
         assert self.assert_banner_message(expected_msg)
 


### PR DESCRIPTION
**DON'T REVIEW, IT'S NOT READY YET**

Currently, the following test passes:
```python
    def test_pyscript_hello(self):
        self.pyscript_run(
            """
            <script type="py">
                raise Exception("hello")
            </script>
            """
        )
```

What happens is that we intercept the Python exception and display a nice banner on the DOM, but the test itself passes. As suggested by @WebReflection this is error prone: if we have Python exceptions on the page, the test should fail by default, and we should have a way to silence it in case those exceptions are expected.

This PR treats Python errors as we treat JS errors: unhandled exceptions cause the test to fail, but you can silence them by calling `self.check_py_errors()`, exactly as you can call `self.check_js_errors()`.
