### PR TITLE
Fix element.select tests

### DIFF
--- a/pyscriptjs/tests/integration/test_03_element.py
+++ b/pyscriptjs/tests/integration/test_03_element.py
@@ -137,12 +137,28 @@ class TestElement(PyScriptTest):
             <py-script>
             from pyscript import Element
             el = Element("foo")
-            el.select("bar", from_content=True)
+            js.console.log(el.select("option").value)
             </py-script>
             """
         )
-        select = self.page.wait_for_selector("#foo")
-        assert select.inner_text() == "Bar"
+        assert self.console.log.lines[-1] == "bar"
+
+    @skip_worker("FIXME: js.document")
+    def test_element_select_content(self):
+        """Test the element select"""
+        self.pyscript_run(
+            """
+            <template id="foo">
+                <div>Bar</div>
+            </template>
+            <py-script>
+            from pyscript import Element
+            el = Element("foo")
+            js.console.log(el.select("div", from_content=True).innerHtml)
+            </py-script>
+            """
+        )
+        assert self.console.log.lines[-1] == "Bar"
 
     @skip_worker("FIXME: js.document")
     def test_element_clone_no_id(self):


### PR DESCRIPTION
## Description

This MR simply fixes the test around `element.select(...)` as it wasn't fully testing or working as expected.

## Changes

  * actually verify that the `.select` method returns the right element by tag name
  * added a test for `content` use case through a template tag

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
