### PR TITLE
Fix typo in py-events attributes handling

### DIFF
--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -130,14 +130,14 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
             for (const { type, target, attributeName, addedNodes } of records) {
                 if (type === 'attributes') {
                     // consider only py-* attributes
-                    if (type.startsWith('py-')) {
+                    if (attributeName.startsWith('py-')) {
                         // if the attribute is currently present
                         if ((target as Element).hasAttribute(attributeName)) {
                             // handle the element
                             addPyScriptEventListener(
                                 getInterpreter(target as Element),
                                 target as Element,
-                                type.slice(3),
+                                attributeName.slice(3),
                             );
                         } else {
                             // remove the listener because the element should not answer
@@ -145,7 +145,7 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
 
                             // Note: this is *NOT* a misused-promise, this is how async events work.
                             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                            target.removeEventListener(type.slice(3), pyScriptListener);
+                            target.removeEventListener(attributeName.slice(3), pyScriptListener);
                         }
                     }
                     // skip further loop on empty addedNodes


### PR DESCRIPTION
## Description

There was a bad copy/paste typo in the code related to attributes removal which was passing the test only because we couldn't catch the error (although practically the behavior was correct because the handler was throwing, not because it was doing the right thing).

## Changes

  * use `attributeName` and not the `type` from the record, as the `type` is not the `event.type` but the record type

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
