### PR TITLE
Avoid test_zz_examples.py file from executing

### DIFF
--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -90,7 +90,7 @@ test:
 	make test-py
 	make test-integration-parallel
 
-# run all integration tests *including examples* sequentially
+# run all integration tests *excluding examples* sequentially
 test-integration:
 	mkdir -p test_results
 	$(PYTEST_EXE) -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml -k 'not zz_examples'
@@ -106,7 +106,7 @@ test-examples:
 	mkdir -p test_results
 	$(PYTEST_EXE) -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml -k 'zz_examples'
 
-# run integration tests in parallel (currently running out of memory)
+# run examples only integration tests in parallel (currently running out of memory)
 test-examples-parallel:
 	make examples
 	mkdir -p test_results

--- a/pyscriptjs/Makefile
+++ b/pyscriptjs/Makefile
@@ -89,12 +89,11 @@ test:
 	make test-ts
 	make test-py
 	make test-integration-parallel
-	make test-examples
 
 # run all integration tests *including examples* sequentially
 test-integration:
 	mkdir -p test_results
-	$(PYTEST_EXE) -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml
+	$(PYTEST_EXE) -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml -k 'not zz_examples'
 
 # run all integration tests *except examples* in parallel (examples use too much memory)
 test-integration-parallel:
@@ -106,6 +105,12 @@ test-examples:
 	make examples
 	mkdir -p test_results
 	$(PYTEST_EXE) -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml -k 'zz_examples'
+
+# run integration tests in parallel (currently running out of memory)
+test-examples-parallel:
+	make examples
+	mkdir -p test_results
+	$(PYTEST_EXE) --numprocesses auto -vv $(ARGS) tests/integration/ --log-cli-level=warning --junitxml=test_results/integration.xml -k 'zz_examples'
 
 test-py:
 	@echo "Tests from $(src_dir)"


### PR DESCRIPTION
## Description

~~We are currently all blocked by red MRs due some issue with the fake server which is incapable of serving files **only in CI**.~~

As we previously discussed to run *examples* only nightly (or weekly) I'd like to propose we remove these from our daily CI pipe and we then setup some action/cronjob to run examples a part from our tasks.

## Changes

 * exclude zz_examples from the regular pipe
 * add an explicit `make test-examples-parallel` entry to be able to test our examples whenever CI needs to (or ourselves)

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
