### PR TITLE
Fix Examples Tests in CI (Pin `pytest=7.1.2` et al)

### DIFF
--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -3,9 +3,9 @@ channels:
     - conda-forge
     - microsoft
 dependencies:
-    - python=3.11
+    - python=3.11.3
     - pip
-    - pytest=7
+    - pytest=7.1.2
     - nodejs=16
     - black
     - isort
@@ -16,9 +16,9 @@ dependencies:
     - markdown
     - toml
     - pip:
-          - playwright
-          - pytest-playwright
-          - pytest-xdist
+          - playwright==1.33.0
+          - pytest-playwright==0.3.3
+          - pytest-xdist==3.3.0
           # We need Pyodide and micropip so we can import them in our Python
           # unit tests
           - pyodide_py==0.22


### PR DESCRIPTION
## Description

As we've been [discussing at length on Discord](https://discord.com/channels/972017612454232116/1108339082825830432), the examples tests have been broken in CI/GitHub Actions since Monday. This PR fixes that.

The main issue was that the `pytest` feedstock in the anaconda main channel jumped from 7.1.2 to 7.3.1 on Monday evening, which for some reason broke our test setup. 
```
<item>
<title>pytest 7.3.1 [linux-32, linux-64, linux-aarch64, linux-ppc64le, linux-s390x, osx-64, osx-arm64, win-32, win-64]</title>
<description>The pytest framework makes it easy to write small tests, yet scales to support complex functional testing for applications and libraries.</description>
<link>https://docs.pytest.org/en/latest/</link>
<comments>https://github.com/pytest-dev/pytest/</comments>
<guid>https://pypi.io/packages/source/p/pytest/pytest-7.3.1.tar.gz</guid>
<pubDate>Mon, 15 May 2023 17:32:49 GMT</pubDate>
<source>https://docs.pytest.org/en/latest/</source>
</item>
```

Possibly because the `py` module was deprecated in 7.2? Will open a follow-up issue.

Fixes #1469 

## Changes

Changes/adds pinning for:
```
python: 3.11.3
pytest: 7.1.2
playwright==1.33.0
pytest-playwright==0.3.3
pytest-xdist==3.3.0
```
