### PR TITLE
Fix #1482 - Add utils.py to the list of modules

### DIFF
--- a/examples/repl2.html
+++ b/examples/repl2.html
@@ -27,7 +27,7 @@
         </nav>
         <section class="pyscript">
             <h1 class="font-semibold text-2xl ml-5">Custom REPL</h1>
-            <py-tutor modules="antigravity.py">
+            <py-tutor modules="utils.py;antigravity.py">
                 <py-config>
                     packages = [
                       "bokeh",


### PR DESCRIPTION
## Description

We forgot to add the `utils.py` file within the list of modules to use in the py-tutor

## Changes

  * added `utils.py;antigravity.py` as `modules` attribute instead of just `antigravity.py` 

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
