### PR TITLE
Fix #1514 - Provide a better feedback on HTML typos

### DIFF
--- a/pyscript.core/esm/index.js
+++ b/pyscript.core/esm/index.js
@@ -18,13 +18,13 @@ const awaitRuntime = async (key) => {
         return (await all([runtime, queue]))[0];
     }
 
-    const available = runtimes.size ?
-        `Available runtimes are: ${[...runtimes.keys()].map(r => `"${r}"`).join(', ')}.` :
-        `There are no runtimes in this page.`;
+    const available = runtimes.size
+        ? `Available runtimes are: ${[...runtimes.keys()]
+              .map((r) => `"${r}"`)
+              .join(", ")}.`
+        : `There are no runtimes in this page.`;
 
-    throw new Error(
-        `The runtime "${key}" was not found. ${available}`
-    );
+    throw new Error(`The runtime "${key}" was not found. ${available}`);
 };
 
 defineProperty(globalThis, "pyscript", {

--- a/pyscript.core/esm/index.js
+++ b/pyscript.core/esm/index.js
@@ -13,8 +13,18 @@ const RUNTIME_SELECTOR = selectors.join(",");
 
 // ensure both runtime and its queue are awaited then returns the runtime
 const awaitRuntime = async (key) => {
-    const { runtime, queue } = runtimes.get(key);
-    return (await all([runtime, queue]))[0];
+    if (runtimes.has(key)) {
+        const { runtime, queue } = runtimes.get(key);
+        return (await all([runtime, queue]))[0];
+    }
+
+    const available = runtimes.size ?
+        `Available runtimes are: ${[...runtimes.keys()].map(r => `"${r}"`).join(', ')}.` :
+        `There are no runtimes in this page.`;
+
+    throw new Error(
+        `The runtime "${key}" was not found. ${available}`
+    );
 };
 
 defineProperty(globalThis, "pyscript", {

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -50,6 +50,6 @@
         "coincident": "^0.2.3"
     },
     "worker": {
-        "blob": "sha256-T0DDfoQde+3gciIoHqPGP2SgMQpbY/nAMjfd1cg8jyA="
+        "blob": "sha256-XIl723wj4b0gyB5IGnLem05DRvl5bzkeMahwAmQFMrM="
     }
 }


### PR DESCRIPTION
## Description

This MR ensures the thrown error on possible typos on the page (around runtimes) is actually meaningful.

This MR has been manually tested by changing `mpy-click` to `py-click` within the `test/worker/input.html` manual integration test.

## Changes

  * resolve the runtime only if known
  * throw a meaningful error whenever no `<script type="runtime">` has been found in the page

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
