### PR TITLE
Make getPySrc() a Documented Feature

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ Features
 - Added a `stderr` attribute of `py-repl` tags to route `sys.stderr` to a DOM element with the given ID. ([#1106](https://github.com/pyscript/pyscript/pull/1106))
 - Resored the `output-mode` attribute of `py-repl` tags. If `output-mode` == 'append', the DOM element where output is printed is _not_ cleared before writing new results.
 - Load code from the attribute src of py-repl and preload it into the corresponding py-repl tag by use the attribute `str` in your `py-repl` tag([#1292](https://github.com/pyscript/pyscript/pull/1292))
+- &lt;py-repl&gt; elements now have a `getPySrc()` method, which returns the code inside the REPL as a string.([#1516](https://github.com/pyscript/pyscript/pull/1292))
 
 ### Plugins
 - Plugins may now implement the `beforePyReplExec()` and `afterPyReplExec()` hooks, which are called immediately before and after code in a `py-repl` tag is executed. ([#1106](https://github.com/pyscript/pyscript/pull/1106))

--- a/docs/reference/elements/py-repl.md
+++ b/docs/reference/elements/py-repl.md
@@ -28,6 +28,14 @@ The ID of an element in the DOM that `stderr` will be written to. Defaults to No
 ### `src`
 If a \<py-repl\> tag has the `src` attribute, during page initialization, resource in the `src` will be preloaded into the REPL. Please note that this will not run in advance. If there is content in the \<py-repl\> tag, it will be cleared and replaced with preloaded resource.
 
+## Methods
+
+The following are methods that can be called on the \<py-repl\> element, from within Python or JavaScript
+
+### `getPySrc()`
+
+Returns the current code contents of the REPL as a string.
+
 ## Examples
 
 ### `<py-repl>` element set to auto-generate

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -595,6 +595,26 @@ class TestPyRepl(PyScriptTest):
         alert_banner = self.page.wait_for_selector(".alert-banner")
         assert expected_alert_banner_msg in alert_banner.inner_text()
 
+    def test_getPySrc_Contents(self):
+        """Test that an empty REPL returns an empty string as src, and that the typed contents
+        are returned as the source
+        """
+        self.pyscript_run(
+            """
+            <py-repl>
+            </py-repl>
+        """
+        )
+        py_repl = self.page.locator("py-repl")
+        src = py_repl.evaluate("node => node.getPySrc()")
+        assert src == ""
+        assert type(src) == str
+
+        py_repl.focus()
+        py_repl.type("Hello, world!")
+        src = py_repl.evaluate("node => node.getPySrc()")
+        assert src == "Hello, world!"
+
     def test_repl_load_content_from_src(self):
         self.writefile("loadReplSrc1.py", "print('1')")
         self.pyscript_run(


### PR DESCRIPTION
## Description

The ability to get the text contents of a \<py-repl\> is a long standing feature request (#954, and Stack Overflow [[1]](https://stackoverflow.com/questions/76428228/save-a-repl-session-from-pyscript-py-repl-environment) [[2]](https://stackoverflow.com/questions/74927506/how-to-get-active-repl-block-in-pyscript-and-copy-whatever-code-written-in-it)). 

This PR promotes the existing `getPySrc()` method of a py-repl to be an actual documented feature. It doesn't actually need to add any code, just adds that function to the documentation and provides a couple new tests.

## Changes

`<py-repl>` gains the `getPySrc()` method as public-facing API.

## Checklist

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
