### PR TITLE
[next] Micropython promise

### DIFF
--- a/pyscript.core/esm/runtime/_utils.js
+++ b/pyscript.core/esm/runtime/_utils.js
@@ -1,21 +1,7 @@
-import { getBuffer } from "../fetch-utils.js";
-import { absoluteURL, defineProperty } from "../utils.js";
 import "@ungap/with-resolvers";
 
-// REQUIRES INTEGRATION TEST
-/* c8 ignore start */
-// TODO: this should *NOT* be needed as the polyfill
-//       already patches on demand the Promise object
-const { withResolvers } = Promise;
-defineProperty(globalThis, "Promise", {
-    configurable: true,
-    value: class extends Promise {
-        withResolvers() {
-            return withResolvers.call(this);
-        }
-    },
-});
-/* c8 ignore stop */
+import { getBuffer } from "../fetch-utils.js";
+import { absoluteURL } from "../utils.js";
 
 /**
  * Trim code only if it's a single line that prettier or other tools might have modified.

--- a/pyscript.core/esm/runtime/micropython.js
+++ b/pyscript.core/esm/runtime/micropython.js
@@ -10,12 +10,19 @@ import {
 
 const type = "micropython";
 
+let patchPromise = true;
+
 // REQUIRES INTEGRATION TEST
 /* c8 ignore start */
 export default {
     type: [type, "mpy"],
     module: () => `http://localhost:8080/micropython/micropython.mjs`,
     async engine({ loadMicroPython }, config, url) {
+        // @bug https://github.com/micropython/micropython/issues/11749
+        if (patchPromise) {
+            patchPromise = false;
+            globalThis.Promise = class extends Promise {};
+        }
         const { stderr, stdout, get } = stdio();
         url = url.replace(/\.m?js$/, ".wasm");
         const runtime = await get(loadMicroPython({ stderr, stdout, url }));

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -50,6 +50,6 @@
         "coincident": "^0.2.3"
     },
     "worker": {
-        "blob": "sha256-s/Qe9L8Mxmdjzk/TnVwmMYA5AvEemsRkOeqtZG6uBLM="
+        "blob": "sha256-m8uF2bNB691FtVIpuDfAT/avUolqZRQwO9tD3r88+6A="
     }
 }

--- a/pyscript.core/test/worker/input.html
+++ b/pyscript.core/test/worker/input.html
@@ -40,34 +40,7 @@
             w = XWorker('./input.lua', type='lua')
             w.sync.input = handle_input
         </script>
-
         <input type="text" placeholder="loading ..." required disabled />
         <input type="submit" mpy-click="handle_result(event)" disabled />
-
-        <!--script type="mpy">
-          from js import XWorker, Array, Promise, Reflect, document
-
-          resolve = None
-
-          def trap_resolve(res, rej):
-            global resolve
-            resolve = res
-
-          def handle_result(event):
-            input = document.querySelector('input[type="text"]')
-            resolve(input.value)
-
-          def handle_input(data):
-            input = document.querySelector('input[type="text"]')
-            input.placeholder = data
-            input.disabled = False
-            # TODO: Promise.new(trap_resolve) does not work in MicroPython
-            #       but the following throws in Pyodide 😅 so fallback to deferred
-            return Reflect.construct(Promise, Array(trap_resolve))
-
-          # TODO: Proxy do not work in MicroPython so type='py' it is
-          w = XWorker('./input.py', type='py')
-          w.sync.input = handle_input
-      </script-->
     </body>
 </html>


### PR DESCRIPTION
## Description

There is [a MicroPython specific bug](https://github.com/micropython/micropython/issues/11749) around polyfills and globals and this MR would like to both simplify and avoid polluting globals with all other runtimes that have no issues whatsoever.

## Changes

  * moved the global patch needed only in MicroPython
  * simplified the patch and tested it manually via integration
  * cleaned up integration as `Promise.withresolvers()` **is** the way to go

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
