### PR TITLE
Shared array buffer missing error

### DIFF
--- a/pyscript.core/esm/worker/_template.js
+++ b/pyscript.core/esm/worker/_template.js
@@ -14,10 +14,12 @@ import { getRuntime, getRuntimeID } from "../loader.js";
 try {
     new SharedArrayBuffer(4);
 } catch (_) {
-    throw new Error([
-        'Unable to use SharedArrayBuffer due insecure environment.',
-        'Please read requirements in MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements'
-    ].join('\n'));
+    throw new Error(
+        [
+            "Unable to use SharedArrayBuffer due insecure environment.",
+            "Please read requirements in MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements",
+        ].join("\n"),
+    );
 }
 
 let engine, run, runtimeEvent;

--- a/pyscript.core/esm/worker/_template.js
+++ b/pyscript.core/esm/worker/_template.js
@@ -9,6 +9,17 @@ import coincident from "coincident/structured";
 import { registry } from "../runtimes.js";
 import { getRuntime, getRuntimeID } from "../loader.js";
 
+// bails out out of the box with a native/meaningful error
+// in case the SharedArrayBuffer is not available
+try {
+    new SharedArrayBuffer(4);
+} catch (_) {
+    throw new Error([
+        'Unable to use SharedArrayBuffer due insecure environment.',
+        'Please read requirements in MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements'
+    ].join('\n'));
+}
+
 let engine, run, runtimeEvent;
 const add = (type, fn) => {
     addEventListener(

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -50,6 +50,6 @@
         "coincident": "^0.2.3"
     },
     "worker": {
-        "blob": "sha256-m8uF2bNB691FtVIpuDfAT/avUolqZRQwO9tD3r88+6A="
+        "blob": "sha256-LhH/RqqHJJNjYkIoMjALOt1xdneBHAyy+jgMKO07Mx0="
     }
 }


### PR DESCRIPTION
## Description

As @antocuni spotted, once minified and bundled as Blob, the error around being unable to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) is way too cryptic.

This MR would like to help understanding security implications when such primitive is meant to be used.

## Changes

  * added an explicit try/catch around the worker Blob minified code

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
