### PR TITLE
Micropython via CDN

### DIFF
--- a/pyscript.core/esm/interpreter/micropython.js
+++ b/pyscript.core/esm/interpreter/micropython.js
@@ -14,7 +14,8 @@ const type = "micropython";
 /* c8 ignore start */
 export default {
     type,
-    module: () => `http://localhost:8080/micropython/micropython.mjs`,
+    module: (version = "1.20.0-239") =>
+        `https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@${version}/micropython.mjs`,
     async engine({ loadMicroPython }, config, url) {
         const { stderr, stdout, get } = stdio();
         url = url.replace(/\.m?js$/, ".wasm");

--- a/pyscript.core/esm/interpreters.js
+++ b/pyscript.core/esm/interpreters.js
@@ -22,7 +22,7 @@ export const interpreter = new Proxy(new Map(), {
             const [type, ...rest] = id.split("@");
             const interpreter = registry.get(type);
             const url = /^https?:\/\//i.test(rest)
-                ? rest[0]
+                ? rest.join("@")
                 : interpreter.module(...rest);
             map.set(id, {
                 url,

--- a/pyscript.core/node.importmap
+++ b/pyscript.core/node.importmap
@@ -2,7 +2,7 @@
     "imports": {
         "http://pyodide": "./test/mocked/pyodide.mjs",
         "https://cdn.jsdelivr.net/pyodide/v0.23.2/full/pyodide.mjs": "./test/mocked/pyodide.mjs",
-        "http://localhost:8080/micropython/micropython.mjs": "./test/mocked/micropython.mjs",
+        "https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-239/micropython.mjs": "./test/mocked/micropython.mjs",
         "https://cdn.jsdelivr.net/npm/basic-toml@0.3.1/es.js": "./test/mocked/toml.mjs"
     }
 }

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -50,6 +50,6 @@
         "coincident": "^0.4.1"
     },
     "worker": {
-        "blob": "sha256-kLYRLjGo4M/ktwNwpCTFnzXiduZBBEXEvbzYGBXe9yk="
+        "blob": "sha256-XQCxBN0Tsy6N0TFG5kG5/CaigwJWLnA63q5ZnUchya4="
     }
 }

--- a/pyscript.core/test/remote.html
+++ b/pyscript.core/test/remote.html
@@ -11,7 +11,7 @@
     <body>
         <script
             type="micropython"
-            version="http://localhost:8080/micropython/micropython.mjs"
+            version="https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-239/micropython.mjs"
         >
             import sys
             import js


### PR DESCRIPTION
## Description

This MR would like to use MicroPython from a CDN and not localhost.

## Changes

  * used current remote module **which does not work due missing CORS headers** ... waiting for it to be a proper CDN

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
