### PR TITLE
PyScript next core to bootstrap current PyScript

### DIFF
--- a/pyscript.core/esm/plugins.js
+++ b/pyscript.core/esm/plugins.js
@@ -141,14 +141,16 @@ const plugins = new Map();
 
 /**
  * Allows plugins and components on the page to receive runtimes to execute any code.
- * @param {string} name the unique plugin name
+ * @param {string | string[]} selector the unique plugin name
  * @param {PluginOptions} options the plugin configuration
  */
-export const registerPlugin = (name, options) => {
-    if (PLUGINS_SELECTORS.includes(name))
-        throw new Error(`plugin ${name} already registered`);
-    PLUGINS_SELECTORS.push(name);
-    plugins.set(name, { options, known: new WeakSet() });
-    $$(name).forEach(handlePlugin);
+export const registerPlugin = (selector, options) => {
+    for (const name of [].concat(selector)) {
+        if (PLUGINS_SELECTORS.includes(name))
+            throw new Error(`plugin for ${name} already registered`);
+        PLUGINS_SELECTORS.push(name);
+        plugins.set(name, { options, known: new WeakSet() });
+        $$(name).forEach(handlePlugin);
+    }
 };
 /* c8 ignore stop */

--- a/pyscriptjs/package-lock.json
+++ b/pyscriptjs/package-lock.json
@@ -8,7 +8,9 @@
             "name": "pyscript",
             "version": "0.0.1",
             "dependencies": {
+                "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
+                "coincident": "^0.4.0",
                 "not-so-weak": "^1.0.0"
             },
             "devDependencies": {
@@ -2089,6 +2091,16 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+        },
+        "node_modules/@ungap/with-resolvers": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@ungap/with-resolvers/-/with-resolvers-0.1.0.tgz",
+            "integrity": "sha512-g7f0IkJdPW2xhY7H4iE72DAsIyfuwEFc6JWc2tYFwKDMWWAF699vGjrM348cwQuOXgHpe1gWFe+Eiyjx/ewvvw=="
+        },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -2550,6 +2562,14 @@
                 "@codemirror/search": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0"
+            }
+        },
+        "node_modules/coincident": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-0.4.0.tgz",
+            "integrity": "sha512-s4uoaRx9Tbaigy3iuD9+ap92hIp16ZejiF/S4ngI4AEtcXWs5Ad5GoKoUWfjUkYXwXtGQ6hlghwUTyW8j32vXw==",
+            "dependencies": {
+                "@ungap/structured-clone": "^1.2.0"
             }
         },
         "node_modules/collect-v8-coverage": {
@@ -7566,6 +7586,16 @@
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
+        "@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+        },
+        "@ungap/with-resolvers": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@ungap/with-resolvers/-/with-resolvers-0.1.0.tgz",
+            "integrity": "sha512-g7f0IkJdPW2xhY7H4iE72DAsIyfuwEFc6JWc2tYFwKDMWWAF699vGjrM348cwQuOXgHpe1gWFe+Eiyjx/ewvvw=="
+        },
         "abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -7900,6 +7930,14 @@
                 "@codemirror/search": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0"
+            }
+        },
+        "coincident": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-0.4.0.tgz",
+            "integrity": "sha512-s4uoaRx9Tbaigy3iuD9+ap92hIp16ZejiF/S4ngI4AEtcXWs5Ad5GoKoUWfjUkYXwXtGQ6hlghwUTyW8j32vXw==",
+            "requires": {
+                "@ungap/structured-clone": "^1.2.0"
             }
         },
         "collect-v8-coverage": {

--- a/pyscriptjs/package.json
+++ b/pyscriptjs/package.json
@@ -41,7 +41,9 @@
         "xterm": "^5.1.0"
     },
     "dependencies": {
+        "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
+        "coincident": "^0.4.0",
         "not-so-weak": "^1.0.0"
     }
 }

--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -192,7 +192,7 @@ export class PyScriptApp {
     async _startInterpreter_main(interpreter_cfg: InterpreterConfig) {
         logger.info('Starting the interpreter in the main thread');
         // this is basically equivalent to worker_initialize()
-        const remote_interpreter = new RemoteInterpreter(interpreter_cfg.src);
+        const remote_interpreter = new RemoteInterpreter(interpreter_cfg.src, true);
         const { port1, port2 } = new Synclink.FakeMessageChannel() as unknown as MessageChannel;
         port1.start();
         port2.start();


### PR DESCRIPTION
## Description

This MR is trying to hook current core into whatever we had before as PyScript logic, which includes a lot of Synclink indirect wrappers and it does things in a different way, so there's no point in trying to re-write the entirety of it to accommodate something as different as pyscript core is at the moment.

## Changes

  * use core `registerPlugin` explicitly to hint a desired runtime for *py-script* is needed
  * wrap the core interpreter instead of the current one but keep surrounding logic in place
  * make `registerPlugin` awa of possible `string[]` of selectors instead of just one, to accommodate the `<script type="py">` current case too, beside `<py-script>` tag

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
