### PR TITLE
fix access to interpreter globals without awaits

### DIFF
--- a/pyscriptjs/src/main.ts
+++ b/pyscriptjs/src/main.ts
@@ -71,6 +71,7 @@ export let runtime;
 export class PyScriptApp {
     config: AppConfig;
     interpreter: InterpreterClient;
+    unwrapped_remote: RemoteInterpreter;
     readyPromise: Promise<void>;
     PyScript: ReturnType<typeof make_PyScript>;
     plugins: PluginManager;
@@ -139,10 +140,10 @@ export class PyScriptApp {
         await this.plugins.configure(this.config);
         this.plugins.beforeLaunch(this.config);
         await this.loadInterpreter();
-        interpreter = this.interpreter;
+        interpreter = this.unwrapped_remote;
         // TODO: This is for backwards compatibility, it should be removed
         // when we finish the deprecation cycle of `runtime`
-        runtime = this.interpreter;
+        runtime = this.unwrapped_remote;
     }
 
     // lifecycle (2)
@@ -193,6 +194,7 @@ export class PyScriptApp {
         logger.info('Starting the interpreter in the main thread');
         // this is basically equivalent to worker_initialize()
         const remote_interpreter = new RemoteInterpreter(interpreter_cfg.src);
+        this.unwrapped_remote = remote_interpreter;
         const { port1, port2 } = new Synclink.FakeMessageChannel() as unknown as MessageChannel;
         port1.start();
         port2.start();

--- a/pyscriptjs/tests/integration/test_interpreter.py
+++ b/pyscriptjs/tests/integration/test_interpreter.py
@@ -1,9 +1,10 @@
-from .support import PyScriptTest
+from .support import PyScriptTest, skip_worker
 
 
 class TestInterpreterAccess(PyScriptTest):
     """Test accessing Python objects from JS via pyscript.interpreter"""
 
+    @skip_worker("WONTFIX: used without synclink to avoid awaits")
     def test_interpreter_python_access(self):
         self.pyscript_run(
             """
@@ -17,9 +18,9 @@ class TestInterpreterAccess(PyScriptTest):
 
         self.run_js(
             """
-            const x = await pyscript.interpreter.globals.get('x');
-            const py_func = await pyscript.interpreter.globals.get('py_func');
-            const py_func_res = await py_func();
+            const x = pyscript.interpreter.globals.get('x');
+            const py_func = pyscript.interpreter.globals.get('py_func');
+            const py_func_res = py_func();
             console.log(`x is ${x}`);
             console.log(`py_func() returns ${py_func_res}`);
             """
@@ -29,13 +30,14 @@ class TestInterpreterAccess(PyScriptTest):
             "py_func() returns 2",
         ]
 
+    @skip_worker("WONTFIX: used without synclink")
     def test_interpreter_script_execution(self):
         """Test running Python code from js via pyscript.interpreter"""
         self.pyscript_run("")
 
         self.run_js(
             """
-            const interface = pyscript.interpreter._remote.interface;
+            const interface = pyscript.interpreter.interface;
             await interface.runPython('print("Interpreter Ran This")');
             """
         )
@@ -46,13 +48,14 @@ class TestInterpreterAccess(PyScriptTest):
         py_terminal = self.page.wait_for_selector("py-terminal")
         assert py_terminal.text_content() == expected_message
 
+    @skip_worker("WONTFIX: used without synclink")
     def test_backward_compatibility_runtime_script_execution(self):
         """Test running Python code from js via pyscript.runtime"""
         self.pyscript_run("")
 
         self.run_js(
             """
-            const interface = pyscript.runtime._remote.interpreter;
+            const interface = pyscript.runtime.interpreter;
             await interface.runPython('print("Interpreter Ran This")');
             """
         )
@@ -63,6 +66,7 @@ class TestInterpreterAccess(PyScriptTest):
         py_terminal = self.page.wait_for_selector("py-terminal")
         assert py_terminal.text_content() == expected_message
 
+    @skip_worker("WONTFIX: used without synclink to avoid awaits")
     def test_backward_compatibility_runtime_python_access(self):
         """Test accessing Python objects from JS via pyscript.runtime"""
         self.pyscript_run(
@@ -77,9 +81,9 @@ class TestInterpreterAccess(PyScriptTest):
 
         self.run_js(
             """
-            const x = await pyscript.interpreter.globals.get('x');
-            const py_func = await pyscript.interpreter.globals.get('py_func');
-            const py_func_res = await py_func();
+            const x = pyscript.runtime.globals.get('x');
+            const py_func = pyscript.runtime.globals.get('py_func');
+            const py_func_res = py_func();
             console.log(`x is ${x}`);
             console.log(`py_func() returns ${py_func_res}`);
             """


### PR DESCRIPTION
## Description

Restores old behaviour of accessing `pyscript.interpreter` or `pyscript.runtime` as discussed here: https://github.com/pyscript/pyscript/discussions/1489#discussioncomment-6019586 during RC1 testing.

## Changes

<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
