### PR TITLE
Issue 1532

### DIFF
--- a/pyscript.core/esm/index.js
+++ b/pyscript.core/esm/index.js
@@ -63,7 +63,7 @@ const listener = async (event) => {
 for (let { name, ownerElement: el } of $x(
     `.//@*[${prefixes.map((p) => `starts-with(name(),"${p}")`).join(" or ")}]`,
 )) {
-    name = name.slice(name.indexOf("-") + 1);
+    name = name.slice(name.lastIndexOf("-") + 1);
     if (name !== "env") el.addEventListener(name, listener);
 }
 
@@ -72,7 +72,7 @@ const mo = new MutationObserver((records) => {
         // attributes are tested via integration / e2e
         /* c8 ignore next 17 */
         if (type === "attributes") {
-            const i = attributeName.indexOf("-") + 1;
+            const i = attributeName.lastIndexOf("-") + 1;
             if (i) {
                 const prefix = attributeName.slice(0, i);
                 for (const p of prefixes) {

--- a/pyscript.core/esm/interpreter/micropython.js
+++ b/pyscript.core/esm/interpreter/micropython.js
@@ -13,7 +13,7 @@ const type = "micropython";
 // REQUIRES INTEGRATION TEST
 /* c8 ignore start */
 export default {
-    type: [type, "mpy"],
+    type,
     module: () => `http://localhost:8080/micropython/micropython.mjs`,
     async engine({ loadMicroPython }, config, url) {
         const { stderr, stdout, get } = stdio();

--- a/pyscript.core/esm/interpreter/pyodide.js
+++ b/pyscript.core/esm/interpreter/pyodide.js
@@ -13,7 +13,7 @@ const type = "pyodide";
 // REQUIRES INTEGRATION TEST
 /* c8 ignore start */
 export default {
-    type: [type, "py"],
+    type,
     module: (version = "0.23.2") =>
         `https://cdn.jsdelivr.net/pyodide/v${version}/full/pyodide.mjs`,
     async engine({ loadPyodide }, config, url) {

--- a/pyscript.core/esm/interpreter/ruby-wasm-wasi.js
+++ b/pyscript.core/esm/interpreter/ruby-wasm-wasi.js
@@ -1,6 +1,6 @@
 import { clean, fetchPaths } from "./_utils.js";
 
-const type = "ruby";
+const type = "ruby-wasm-wasi";
 
 // MISSING:
 //  * there is no VFS apparently or I couldn't reach any
@@ -19,8 +19,8 @@ const worker = (method) =>
     };
 
 export default {
+    type,
     experimental: true,
-    type: [type, "rb"],
     module: (version = "2.0.0") =>
         `https://cdn.jsdelivr.net/npm/ruby-3_2-wasm-wasi@${version}/dist/browser.esm.js`,
     async engine({ DefaultRubyVM }, config, url) {

--- a/pyscript.core/esm/interpreter/wasmoon.js
+++ b/pyscript.core/esm/interpreter/wasmoon.js
@@ -11,7 +11,7 @@ const worker = (method) =>
     };
 
 export default {
-    type: [type, "lua"],
+    type,
     module: (version = "1.15.0") =>
         `https://cdn.jsdelivr.net/npm/wasmoon@${version}/+esm`,
     async engine({ LuaFactory, LuaLibraries }, config) {

--- a/pyscript.core/esm/interpreters.js
+++ b/pyscript.core/esm/interpreters.js
@@ -52,7 +52,7 @@ const register = (interpreter) => {
 //:RUNTIMES
 import micropython from "./interpreter/micropython.js";
 import pyodide from "./interpreter/pyodide.js";
-import ruby from "./interpreter/ruby.js";
+import ruby_wasm_wasi from "./interpreter/ruby-wasm-wasi.js";
 import wasmoon from "./interpreter/wasmoon.js";
-for (const interpreter of [micropython, pyodide, ruby, wasmoon])
+for (const interpreter of [micropython, pyodide, ruby_wasm_wasi, wasmoon])
     register(interpreter);

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -50,6 +50,6 @@
         "coincident": "^0.4.1"
     },
     "worker": {
-        "blob": "sha256-TbwtN60VpzVf6WDe6PfdTcHNVyKO4Z2zUN1gi/0rJeE="
+        "blob": "sha256-kLYRLjGo4M/ktwNwpCTFnzXiduZBBEXEvbzYGBXe9yk="
     }
 }

--- a/pyscript.core/rollup/build_interpreters.cjs
+++ b/pyscript.core/rollup/build_interpreters.cjs
@@ -15,10 +15,15 @@ const createRuntimes = () => {
     }
     // generate the output to append at the end of the file
     const output = [];
-    for (const interpreter of interpreters)
+    for (let i = 0; i < interpreters.length; i++) {
+        const interpreter = interpreters[i].replace(/-/g, "_");
         output.push(
-            `import ${interpreter} from "./interpreter/${interpreter}.js";`,
+            `import ${interpreter.replace(/-/g, "_")} from "./interpreter/${
+                interpreters[i]
+            }.js";`,
         );
+        interpreters[i] = interpreter;
+    }
     output.push(
         `
 for (const interpreter of [${interpreters.join(", ")}])

--- a/pyscript.core/test/async.html
+++ b/pyscript.core/test/async.html
@@ -8,7 +8,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py" async>
+        <script type="pyodide" async>
             from js import document, fetch
 
             response = await fetch("async.html")

--- a/pyscript.core/test/env.html
+++ b/pyscript.core/test/env.html
@@ -8,26 +8,26 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="mpy">
+        <script type="micropython">
             import sys
             import js
             version = sys.version
             js.document.currentScript.target.textContent = version
         </script>
         <hr />
-        <script type="mpy">
+        <script type="micropython">
             import js
             js.document.currentScript.target.textContent = version
         </script>
         <hr />
-        <script type="py">
+        <script type="pyodide">
             import sys
             import js
             version = sys.version
             js.document.currentScript.target.textContent = version
         </script>
         <hr />
-        <script type="py" target="last-script-target">
+        <script type="pyodide" target="last-script-target">
             import js
             js.document.currentScript.target.textContent = version
         </script>

--- a/pyscript.core/test/fetch.html
+++ b/pyscript.core/test/fetch.html
@@ -7,7 +7,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="mpy" config="./fetch.toml">
+        <script type="micropython" config="./fetch.toml">
             import js
             import a, b
             js.console.log(a.x)

--- a/pyscript.core/test/index.html
+++ b/pyscript.core/test/index.html
@@ -8,7 +8,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py">
+        <script type="pyodide">
             import sys
             import js
             js.document.currentScript.target.textContent = sys.version

--- a/pyscript.core/test/index.js
+++ b/pyscript.core/test/index.js
@@ -69,31 +69,31 @@ const { registerPlugin } = require("../cjs");
     // all tests
     for (const test of [
         async function versionedRuntime() {
-            document.head.innerHTML = `<script type="py" version="0.23.2">${content}</script>`;
+            document.head.innerHTML = `<script type="pyodide" version="0.23.2">${content}</script>`;
             await tick();
             assert(pyodide.content, content);
-            assert(pyodide.target.tagName, "PY-SCRIPT");
+            assert(pyodide.target.tagName, "PYODIDE-SCRIPT");
         },
 
         async function basicExpectations() {
-            document.head.innerHTML = `<script type="py">${content}</script>`;
+            document.head.innerHTML = `<script type="pyodide">${content}</script>`;
             await tick();
             assert(pyodide.content, content);
-            assert(pyodide.target.tagName, "PY-SCRIPT");
+            assert(pyodide.target.tagName, "PYODIDE-SCRIPT");
         },
 
         async function foreignRuntime() {
-            document.head.innerHTML = `<script type="py" version="http://pyodide">${content}</script>`;
+            document.head.innerHTML = `<script type="pyodide" version="http://pyodide">${content}</script>`;
             await tick();
             assert(pyodide.content, content);
-            assert(pyodide.target.tagName, "PY-SCRIPT");
+            assert(pyodide.target.tagName, "PYODIDE-SCRIPT");
         },
 
         async function basicMicroPython() {
-            document.head.innerHTML = `<script type="mpy">${content}</script>`;
+            document.head.innerHTML = `<script type="micropython">${content}</script>`;
             await tick();
             assert(micropython.content, content);
-            assert(micropython.target.tagName, "MPY-SCRIPT");
+            assert(micropython.target.tagName, "MICROPYTHON-SCRIPT");
             const script = document.head.firstElementChild;
             document.body.appendChild(script);
             await tick();
@@ -107,7 +107,7 @@ const { registerPlugin } = require("../cjs");
             );
             shadowRoot.innerHTML = `
         <my-plugin></my-plugin>
-        <script src="./whatever" env="unique" type="py" target="my-plugin"></script>
+        <script src="./whatever" env="unique" type="pyodide" target="my-plugin"></script>
       `.trim();
             await tick();
             assert(pyodide.content, "OK");
@@ -118,7 +118,7 @@ const { registerPlugin } = require("../cjs");
             setTarget(div);
             shadowRoot.innerHTML = `
         <my-plugin></my-plugin>
-        <script type="py"></script>
+        <script type="pyodide"></script>
       `.trim();
             await tick();
             assert(pyodide.target, div);
@@ -128,7 +128,7 @@ const { registerPlugin } = require("../cjs");
             setTarget("my-plugin");
             shadowRoot.innerHTML = `
         <my-plugin></my-plugin>
-        <script type="py"></script>
+        <script type="pyodide"></script>
       `.trim();
             await tick();
             assert(pyodide.target.tagName, "MY-PLUGIN");
@@ -137,7 +137,7 @@ const { registerPlugin } = require("../cjs");
         async function jsonConfig() {
             const packages = {};
             patchFetch(() => Promise.resolve({ json: () => ({ packages }) }));
-            shadowRoot.innerHTML = `<script config="./whatever.json" type="py"></script>`;
+            shadowRoot.innerHTML = `<script config="./whatever.json" type="pyodide"></script>`;
             await tick();
             assert(pyodide.packages, packages);
         },
@@ -149,7 +149,7 @@ const { registerPlugin } = require("../cjs");
             patchFetch(() =>
                 Promise.resolve({ text: () => Promise.resolve(jsonPackages) }),
             );
-            shadowRoot.innerHTML = `<script config="./whatever.toml" type="py"></script>`;
+            shadowRoot.innerHTML = `<script config="./whatever.toml" type="pyodide"></script>`;
             // there are more promises in here let's increase the tick delay to avoid flaky tests
             await tick(20);
             assert(
@@ -173,7 +173,7 @@ const { registerPlugin } = require("../cjs");
                 }),
             );
             shadowRoot.innerHTML = `
-        <script type="py" config="./fetch.toml">
+        <script type="pyodide" config="./fetch.toml">
           import js
           import a, b
           js.console.log(a.x)
@@ -184,9 +184,9 @@ const { registerPlugin } = require("../cjs");
         },
 
         async function testDefaultRuntime() {
-            const py = await pyscript.env.py;
+            const pyodide = await pyscript.env.pyodide;
             const keys = Object.keys(loadPyodide()).join(",");
-            assert(Object.keys(py).join(","), keys);
+            assert(Object.keys(pyodide).join(","), keys);
 
             const unique = await pyscript.env.unique;
             assert(Object.keys(unique).join(","), keys);

--- a/pyscript.core/test/isolated.html
+++ b/pyscript.core/test/isolated.html
@@ -7,16 +7,16 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py">
+        <script type="pyodide">
             # define a "global" variable and print it
             shared_env = 1
             print(shared_env)
         </script>
-        <script type="py">
+        <script type="pyodide">
             # just print the "global" variable from same env
             print(shared_env)
         </script>
-        <script type="py" env="another-one">
+        <script type="pyodide" env="another-one">
             # see the error
             print(shared_env)
         </script>

--- a/pyscript.core/test/many.html
+++ b/pyscript.core/test/many.html
@@ -9,13 +9,13 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py" version="0.23.2">
+        <script type="pyodide" version="0.23.2">
             import sys
             import js
             js.document.currentScript.target.textContent = sys.version
         </script>
-        <script type="mpy" src="three.py"></script>
-        <script type="py" config="./config.json">
+        <script type="micropython" src="three.py"></script>
+        <script type="pyodide" config="./config.json">
             import matplotlib.pyplot as plt
             import matplotlib.tri as tri
             import numpy as np

--- a/pyscript.core/test/matplot.html
+++ b/pyscript.core/test/matplot.html
@@ -9,7 +9,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py" config="./config.toml">
+        <script type="pyodide" config="./config.toml">
             import matplotlib.pyplot as plt
             import matplotlib.tri as tri
             import numpy as np

--- a/pyscript.core/test/matplot.json.html
+++ b/pyscript.core/test/matplot.json.html
@@ -9,7 +9,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py" config="./config.json">
+        <script type="pyodide" config="./config.json">
             import matplotlib.pyplot as plt
             import matplotlib.tri as tri
             import numpy as np

--- a/pyscript.core/test/matplot.worker.html
+++ b/pyscript.core/test/matplot.worker.html
@@ -9,7 +9,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="mpy">
+        <script type="micropython">
             from js import XWorker
 
             def show_image(event):
@@ -19,7 +19,7 @@
               img.src = event.data
               document.body.appendChild(img)
 
-            w = XWorker('./matplot.py', **{'type': 'py', 'config': './config.toml'})
+            w = XWorker('./matplot.py', **{'type': 'pyodide', 'config': './config.toml'})
             w.onmessage = show_image
         </script>
     </body>

--- a/pyscript.core/test/micropython.html
+++ b/pyscript.core/test/micropython.html
@@ -9,7 +9,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="mpy">
+        <script type="micropython">
             import sys
             import js
             js.document.currentScript.target.textContent = sys.version

--- a/pyscript.core/test/no-sw.html
+++ b/pyscript.core/test/no-sw.html
@@ -9,7 +9,7 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py">
+        <script type="pyodide">
             import sys
             import js
             js.document.currentScript.target.textContent = sys.version

--- a/pyscript.core/test/order.html
+++ b/pyscript.core/test/order.html
@@ -17,15 +17,21 @@
         <script type="module" src="../esm/index.js"></script>
     </head>
     <body>
-        <script type="mpy" src="http://localhost:7357/print-a.py"></script>
-        <script type="mpy">
+        <script
+            type="micropython"
+            src="http://localhost:7357/print-a.py"
+        ></script>
+        <script type="micropython">
             print('B')
         </script>
-        <script type="mpy" src="http://localhost:7357/print-a.py"></script>
-        <script type="mpy">
+        <script
+            type="micropython"
+            src="http://localhost:7357/print-a.py"
+        ></script>
+        <script type="micropython">
             print('C')
         </script>
-        <script type="mpy">
+        <script type="micropython">
             print('D')
         </script>
         <pre>

--- a/pyscript.core/test/plugins/index.html
+++ b/pyscript.core/test/plugins/index.html
@@ -15,7 +15,7 @@
         <script type="module">
             import { registerPlugin } from "@pyscript/core";
             registerPlugin("mpy-script", {
-                type: "micropython", // or just 'mpy'
+                type: "micropython",
                 async onRuntimeReady(micropython, element) {
                     console.log(micropython);
                     // Somehow this doesn't work in MicroPython

--- a/pyscript.core/test/plugins/lua.html
+++ b/pyscript.core/test/plugins/lua.html
@@ -15,7 +15,7 @@
         <script type="module">
             import { registerPlugin } from "@pyscript/core";
             registerPlugin("lua-script", {
-                type: "wasmoon", // or just 'lua'
+                type: "wasmoon",
                 async onRuntimeReady(wasmoon, element) {
                     // Somehow this doesn't work in Wasmoon
                     wasmoon.io.stdout = (message) => {

--- a/pyscript.core/test/plugins/py-script.js
+++ b/pyscript.core/test/plugins/py-script.js
@@ -19,7 +19,7 @@ const sharedPyodide = new Promise((resolve) => {
     const config = pyConfig?.getAttribute("src") || pyConfig?.textContent;
     registerPlugin("py-script", {
         config,
-        type: "pyodide", // or just 'py'
+        type: "pyodide",
         codeBeforeRunWorker: `print('codeBeforeRunWorker')`,
         codeAfterRunWorker: `print('codeAfterRunWorker')`,
         onBeforeRun(pyodide, node) {

--- a/pyscript.core/test/py-events.html
+++ b/pyscript.core/test/py-events.html
@@ -9,28 +9,28 @@
         <script type="module" src="../min.js"></script>
     </head>
     <body>
-        <script type="py">
+        <script type="pyodide">
             def print_version(event):
               import sys
               print(event.type)
               print(sys.version)
         </script>
         <button
-            py-pointerdown="print_version(event)"
-            py-click="print_version(event)"
+            pyodide-pointerdown="print_version(event)"
+            pyodide-click="print_version(event)"
         >
-            python version
+            pyodide version
         </button>
 
-        <script type="mpy">
+        <script type="micropython">
             def print_version(event):
               import sys
               print(event.type)
               print(sys.version)
         </script>
         <button
-            mpy-pointerdown="print_version(event)"
-            mpy-click="print_version(event)"
+            micropython-pointerdown="print_version(event)"
+            micropython-click="print_version(event)"
         >
             micropython version
         </button>

--- a/pyscript.core/test/remote.html
+++ b/pyscript.core/test/remote.html
@@ -10,7 +10,7 @@
     </head>
     <body>
         <script
-            type="mpy"
+            type="micropython"
             version="http://localhost:8080/micropython/micropython.mjs"
         >
             import sys

--- a/pyscript.core/test/ruby.html
+++ b/pyscript.core/test/ruby.html
@@ -17,12 +17,14 @@
         <script type="module" src="../esm/index.js"></script>
     </head>
     <body>
-        <script type="rb">
+        <script type="ruby-wasm-wasi">
             def print_version(event)
               puts event[:type]
               print "ruby #{ RUBY_VERSION }p#{ RUBY_PATCHLEVEL }"
             end
         </script>
-        <button rb-click="print_version(event)">ruby version</button>
+        <button ruby-wasm-wasi-click="print_version(event)">
+            ruby-wasm-wasi version
+        </button>
     </body>
 </html>

--- a/pyscript.core/test/shadow-dom.html
+++ b/pyscript.core/test/shadow-dom.html
@@ -19,7 +19,7 @@
                         const sd = super().attachShadow({ mode: "closed" });
                         sd.appendChild(
                             Object.assign(document.createElement("script"), {
-                                type: "mpy",
+                                type: "micropython",
                                 textContent: `
             import sys
             import js

--- a/pyscript.core/test/table.html
+++ b/pyscript.core/test/table.html
@@ -20,7 +20,7 @@
         <table cellspacing="2" cellpadding="2">
             <tr>
                 <td>check edge cases</td>
-                <script type="mpy">
+                <script type="micropython">
                     import sys
                     import js
 

--- a/pyscript.core/test/test.html
+++ b/pyscript.core/test/test.html
@@ -17,7 +17,7 @@
         <script type="module" src="../esm/index.js"></script>
     </head>
     <body>
-        <script type="py">
+        <script type="pyodide">
             def print_version():
               import sys
               print(sys.version)
@@ -25,15 +25,15 @@
         </script>
         <button py-click="print_version()">python version</button>
 
-        <script type="mpy">
+        <script type="micropython">
             def print_version():
               import sys
               print(sys.version)
               print("bad.", file=sys.stderr)
         </script>
-        <button mpy-click="print_version()">micropython version</button>
+        <button micropython-click="print_version()">micropython version</button>
 
-        <script type="lua">
+        <script type="wasmoon">
             function print_version()
               print(_VERSION)
               printErr(123)
@@ -41,11 +41,11 @@
         </script>
         <button lua-click="print_version()">lua version</button>
 
-        <script type="rb">
+        <script type="ruby-wasm-wasi">
             def print_version()
               print "ruby #{ RUBY_VERSION }p#{ RUBY_PATCHLEVEL }"
             end
         </script>
-        <button rb-click="print_version()">ruby version</button>
+        <button ruby-wasm-wasi-click="print_version()">ruby version</button>
     </body>
 </html>

--- a/pyscript.core/test/wasmoon.html
+++ b/pyscript.core/test/wasmoon.html
@@ -17,7 +17,7 @@
         <script type="module" src="../esm/index.js"></script>
     </head>
     <body>
-        <script type="lua" config="./fetch.toml">
+        <script type="wasmoon" config="./fetch.toml">
             local function read_file(path)
               local file = io.open(path, "rb")
               if not file then return nil end
@@ -32,6 +32,6 @@
               print(read_file('/a.py'))
             end
         </script>
-        <button lua-click="print_version(event)">lua version</button>
+        <button wasmoon-click="print_version(event)">wasmoon version</button>
     </body>
 </html>

--- a/pyscript.core/test/worker/index.html
+++ b/pyscript.core/test/worker/index.html
@@ -21,7 +21,7 @@
         <script type="module">
             import { XWorker } from "@pyscript/core";
 
-            const w = new XWorker("./worker.py", { type: "mpy" });
+            const w = new XWorker("./worker.py", { type: "micropython" });
             w.postMessage("JavaScript: Hello MicroPython 👋");
             w.onmessage = (event) => {
                 console.log(event.data);
@@ -29,7 +29,7 @@
         </script>
 
         <!-- XWorker - MicroPython to MicroPython -->
-        <script type="mpy">
+        <script type="micropython">
             from js import XWorker
 
             def handle_message(event):
@@ -41,25 +41,25 @@
         </script>
 
         <!-- XWorker - MicroPython to Pyodide -->
-        <script type="mpy">
+        <script type="micropython">
             from js import XWorker
 
             def handle_message(event):
               print(event.data)
 
-            w = XWorker('./worker.py', **{'type': 'py', 'async': True, 'config': '../fetch.toml'})
+            w = XWorker('./worker.py', **{'type': 'pyodide', 'async': True, 'config': '../fetch.toml'})
             w.postMessage('MicroPython: Hello Pyodide 👋')
             w.onmessage = handle_message
         </script>
 
         <!-- XWorker - MicroPython to Lua -->
-        <script type="mpy">
+        <script type="micropython">
             from js import XWorker
 
             def handle_message(event):
               print(event.data)
 
-            w = XWorker('./worker.lua', type='lua')
+            w = XWorker('./worker.lua', type='wasmoon')
             w.postMessage('MicroPython: Hello Lua 👋')
             w.onmessage = handle_message
         </script>

--- a/pyscript.core/test/worker/input.html
+++ b/pyscript.core/test/worker/input.html
@@ -19,7 +19,7 @@
         </script>
     </head>
     <body>
-        <script type="mpy">
+        <script type="micropython">
             from js import XWorker, Promise, document
 
             deferred = Promise.withResolvers()
@@ -37,10 +37,14 @@
               inputs[1].disabled = False
               return deferred.promise
 
-            w = XWorker('./input.lua', type='lua')
+            w = XWorker('./input.lua', type='wasmoon')
             w.sync.input = handle_input
         </script>
         <input type="text" placeholder="loading ..." required disabled />
-        <input type="submit" mpy-click="handle_result(event)" disabled />
+        <input
+            type="submit"
+            micropython-click="handle_result(event)"
+            disabled
+        />
     </body>
 </html>


### PR DESCRIPTION
## Description

This MR removes the ease of shortcuts and allows interpreters to only have designated project names.

This change lowers UX/DX of current next and all examples out there using `<script type="py">` or `<script type="mpy">` should now be more verbose about the type, but as described in the related issue this change allows anyone to write plugins that won't interfere with raw interpreters logic.

## Changes

  * renamed all `py`, `mpy`, `lua`, and `ruby`, or `rb` references in HTML or code to explicit `pyodide`, `micropython`, `wasmoon`, and `ruby-wasm-wasi` to explicit the project they are bound to, as opposite of conflicting with *plugins* possible shortcuts and naming convention
  * renamed the ruby file too

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
