### PR TITLE
Fix lifetime for pyExec results

### DIFF
--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -191,7 +191,7 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
                 pyReplTag: this,
                 result,
             });
-            interpreter._remote.destroyIfProxy(result);
+            await interpreter._remote.destroyIfProxy(result);
             this.autogenerateMaybe();
         }
 

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -191,6 +191,7 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
                 pyReplTag: this,
                 result,
             });
+            interpreter.destroyIfProxy(result);
 
             this.autogenerateMaybe();
         }

--- a/pyscriptjs/src/components/pyrepl.ts
+++ b/pyscriptjs/src/components/pyrepl.ts
@@ -191,8 +191,7 @@ export function make_PyRepl(interpreter: InterpreterClient, app: PyScriptApp) {
                 pyReplTag: this,
                 result,
             });
-            interpreter.destroyIfProxy(result);
-
+            interpreter._remote.destroyIfProxy(result);
             this.autogenerateMaybe();
         }
 

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -36,6 +36,7 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
             await app.plugins.beforePyScriptExec({ interpreter, src, pyScriptTag });
             const { result } = await pyExec(interpreter, src, pyScriptTag);
             await app.plugins.afterPyScriptExec({ interpreter, src, pyScriptTag, result });
+            interpreter._remote.destroyIfProxy(result);
         } finally {
             releaseLock();
             app.decrementPendingTags();

--- a/pyscriptjs/src/components/pyscript.ts
+++ b/pyscriptjs/src/components/pyscript.ts
@@ -36,7 +36,7 @@ export function make_PyScript(interpreter: InterpreterClient, app: PyScriptApp) 
             await app.plugins.beforePyScriptExec({ interpreter, src, pyScriptTag });
             const { result } = await pyExec(interpreter, src, pyScriptTag);
             await app.plugins.afterPyScriptExec({ interpreter, src, pyScriptTag, result });
-            interpreter._remote.destroyIfProxy(result);
+            await interpreter._remote.destroyIfProxy(result);
         } finally {
             releaseLock();
             app.decrementPendingTags();

--- a/pyscriptjs/src/python/pyscript/_internal.py
+++ b/pyscriptjs/src/python/pyscript/_internal.py
@@ -2,9 +2,9 @@ import ast
 from collections import namedtuple
 from contextlib import contextmanager
 
+from js import Object
 from pyodide.code import eval_code
 from pyodide.ffi import JsProxy, to_js
-from js import Object
 
 from ._event_loop import (
     defer_user_asyncio,

--- a/pyscriptjs/src/python/pyscript/_internal.py
+++ b/pyscriptjs/src/python/pyscript/_internal.py
@@ -2,9 +2,9 @@ import ast
 from collections import namedtuple
 from contextlib import contextmanager
 
-from js import Object
 from pyodide.code import eval_code
-from pyodide.ffi import JsProxy
+from pyodide.ffi import JsProxy, to_js
+from js import Object
 
 from ._event_loop import (
     defer_user_asyncio,
@@ -103,7 +103,7 @@ def run_pyscript(code: str, id: str = None) -> JsProxy:
     with display_target(id), defer_user_asyncio():
         result = eval_code(code, globals=__main__.__dict__)
 
-    return Object.new(result=result)
+    return to_js({"result": result}, depth=1, dict_converter=Object.fromEntries)
 
 
 __all__ = [

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -275,16 +275,8 @@ export class RemoteInterpreter extends Object {
     }
 
     destroyIfProxy(px: any): void {
-        if (this.interface.ffi) {
-            // Pyodide 0.23
-            if (px instanceof this.interface.ffi.PyProxy) {
-                px.destroy();
-            }
-        } else {
-            // older Pyodide
-            if (this.interface.isPyProxy(px)) {
-                px.destroy();
-            }
+        if (px instanceof this.interface.ffi.PyProxy) {
+            px.destroy();
         }
     }
 

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -274,6 +274,20 @@ export class RemoteInterpreter extends Object {
         this.FS.writeFile(path, data, { canOwn: true });
     }
 
+    destroyIfProxy(px: any): void {
+        if(this.interface.ffi) {
+            // Pyodide 0.23
+            if(px instanceof this.interface.ffi.PyProxy) {
+                px.destroy();
+            }
+        } else {
+            // older Pyodide
+            if(this.interface.isPyProxy(px)) {
+                px.destroy();
+            }
+        }
+    }
+
     /**
      * delegates clearing importlib's module path
      * caches to the underlying interface

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -275,8 +275,16 @@ export class RemoteInterpreter extends Object {
     }
 
     destroyIfProxy(px: any): void {
-        if (px instanceof this.interface.ffi.PyProxy) {
-            px.destroy();
+        if (this.interface.ffi) {
+            // Pyodide 0.23
+            if (px instanceof this.interface.ffi.PyProxy) {
+                px.destroy();
+            }
+        } else {
+            // older Pyodide
+            if (this.interface.isPyProxy(px)) {
+                px.destroy();
+            }
         }
     }
 

--- a/pyscriptjs/src/remote_interpreter.ts
+++ b/pyscriptjs/src/remote_interpreter.ts
@@ -275,14 +275,14 @@ export class RemoteInterpreter extends Object {
     }
 
     destroyIfProxy(px: any): void {
-        if(this.interface.ffi) {
+        if (this.interface.ffi) {
             // Pyodide 0.23
-            if(px instanceof this.interface.ffi.PyProxy) {
+            if (px instanceof this.interface.ffi.PyProxy) {
                 px.destroy();
             }
         } else {
             // older Pyodide
-            if(this.interface.isPyProxy(px)) {
+            if (this.interface.isPyProxy(px)) {
                 px.destroy();
             }
         }

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -679,6 +679,14 @@ class TestPyRepl(PyScriptTest):
     def test_repl_results(self):
         self.writefile("loadReplSrc2.py", "2")
         self.writefile("loadReplSrc3.py", "print('3')")
+        """
+
+        
+            
+            # should print 2: if it prints 3 that means that c was not properly
+            # released by py-repl
+        """
+
         self.pyscript_run(
             """
             <py-repl id="py-repl1" output="out1">
@@ -689,12 +697,16 @@ class TestPyRepl(PyScriptTest):
             <py-repl id="py-repl2" output="out2">
             c = [1,2,3]
             from sys import getrefcount
-            print(getrefcount(c))
+            # should print 2: 1 from the reference c and 1 since getrefcount
+            # holds a reference to its argument 
+            print(getrefcount(c)) 
             c
             </py-repl>
             <div id="out2"></div>
 
             <py-repl id="py-repl3" output="out3">
+            # should also print 2: if it prints 3 that would mean that c was not properly
+            # released by py-repl
             getrefcount(c)
             </py-repl>
             <div id="out3"></div>
@@ -710,5 +722,6 @@ class TestPyRepl(PyScriptTest):
         py_repl3.locator("button").click()
 
         assert self.page.wait_for_selector("#out1").inner_text() == "42"
-        assert self.page.wait_for_selector("#out2").inner_text() == "2\n\n[1, 2, 3]"
+        assert self.page.wait_for_selector("#out2").inner_text() == "2\n\n[1, 2, 3]"'
+        # Check that c was released
         assert self.page.wait_for_selector("#out3").inner_text() == "2"

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -679,13 +679,6 @@ class TestPyRepl(PyScriptTest):
     def test_repl_results(self):
         self.writefile("loadReplSrc2.py", "2")
         self.writefile("loadReplSrc3.py", "print('3')")
-        """
-
-
-
-            # should print 2: if it prints 3 that means that c was not properly
-            # released by py-repl
-        """
 
         self.pyscript_run(
             """

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -715,6 +715,6 @@ class TestPyRepl(PyScriptTest):
         py_repl3.locator("button").click()
 
         assert self.page.wait_for_selector("#out1").inner_text() == "42"
-        assert self.page.wait_for_selector("#out2").inner_text() == "2\n\n[1, 2, 3]"'
+        assert self.page.wait_for_selector("#out2").inner_text() == "2\n\n[1, 2, 3]"
         # Check that c was released
         assert self.page.wait_for_selector("#out3").inner_text() == "2"

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -675,7 +675,6 @@ class TestPyRepl(PyScriptTest):
         )
         assert self.console.error.lines[-1] == errorMsg
 
-
     @skip_worker("dont-care")
     def test_repl_results(self):
         self.writefile("loadReplSrc2.py", "2")
@@ -703,7 +702,7 @@ class TestPyRepl(PyScriptTest):
         )
         py_repl1 = self.page.locator("py-repl#py-repl1")
         py_repl1.locator("button").click()
-        
+
         py_repl2 = self.page.locator("py-repl#py-repl2")
         py_repl2.locator("button").click()
 

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -674,3 +674,42 @@ class TestPyRepl(PyScriptTest):
             "Are your filename and path correct?"
         )
         assert self.console.error.lines[-1] == errorMsg
+
+
+    @skip_worker("dont-care")
+    def test_repl_results(self):
+        self.writefile("loadReplSrc2.py", "2")
+        self.writefile("loadReplSrc3.py", "print('3')")
+        self.pyscript_run(
+            """
+            <py-repl id="py-repl1" output="out1">
+            42
+            </py-repl>
+            <div id="out1"></div>
+
+            <py-repl id="py-repl2" output="out2">
+            c = [1,2,3]
+            from sys import getrefcount
+            print(getrefcount(c))
+            c
+            </py-repl>
+            <div id="out2"></div>
+
+            <py-repl id="py-repl3" output="out3">
+            getrefcount(c)
+            </py-repl>
+            <div id="out3"></div>
+            """
+        )
+        py_repl1 = self.page.locator("py-repl#py-repl1")
+        py_repl1.locator("button").click()
+        
+        py_repl2 = self.page.locator("py-repl#py-repl2")
+        py_repl2.locator("button").click()
+
+        py_repl3 = self.page.locator("py-repl#py-repl3")
+        py_repl3.locator("button").click()
+
+        assert self.page.wait_for_selector("#out1").inner_text() == "42"
+        assert self.page.wait_for_selector("#out2").inner_text() == "2\n\n[1, 2, 3]"
+        assert self.page.wait_for_selector("#out3").inner_text() == "2"

--- a/pyscriptjs/tests/integration/test_py_repl.py
+++ b/pyscriptjs/tests/integration/test_py_repl.py
@@ -681,8 +681,8 @@ class TestPyRepl(PyScriptTest):
         self.writefile("loadReplSrc3.py", "print('3')")
         """
 
-        
-            
+
+
             # should print 2: if it prints 3 that means that c was not properly
             # released by py-repl
         """
@@ -698,8 +698,8 @@ class TestPyRepl(PyScriptTest):
             c = [1,2,3]
             from sys import getrefcount
             # should print 2: 1 from the reference c and 1 since getrefcount
-            # holds a reference to its argument 
-            print(getrefcount(c)) 
+            # holds a reference to its argument
+            print(getrefcount(c))
             c
             </py-repl>
             <div id="out2"></div>


### PR DESCRIPTION
Currently if the result from pyExec is a PyProxy, it gets destroyed. This switches to using `to_js` to handle this (it is better to use than an explicit `create_proxy` since it automatically decides whether to create a proxy or not).
I also added `destroyIfProxy` which checks if something is a `PyProxy` and then destroys it. Each use of `pyExec` needs to call `destroyIfProxy` on the result after it is done with it.

-   [x] Add a test
