### PR TITLE
Fix #1538 - use same customElements Registry utilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - id: check-docstring-first
           - id: check-executables-have-shebangs
           - id: check-json
-            exclude: tsconfig.json pyscript.core/cjs/package.json
+            exclude: tsconfig\.json|pyscript\.core/cjs/package\.json
           - id: check-toml
           - id: check-xml
           - id: check-yaml
@@ -46,6 +46,7 @@ repos:
       rev: "v3.0.0-alpha.6"
       hooks:
           - id: prettier
+            exclude: pyscript\.core/test
             args: [--tab-width, "4"]
 
     - repo: https://github.com/pre-commit/mirrors-eslint

--- a/pyscript.core/esm/index.js
+++ b/pyscript.core/esm/index.js
@@ -1,71 +1,16 @@
-import { $x, $$ } from "basic-devtools";
+import { $$ } from "basic-devtools";
 
 import xworker from "./worker/class.js";
-import { handle, interpreters } from "./script-handler.js";
-import { all, assign, create, defineProperty } from "./utils.js";
-import { registry, selectors, prefixes } from "./interpreters.js";
-import { PLUGINS_SELECTORS, handlePlugin } from "./plugins.js";
+import { handle } from "./script-handler.js";
+import { assign } from "./utils.js";
+import { selectors, prefixes } from "./interpreters.js";
+import { CUSTOM_SELECTORS, handleCustomType } from "./custom-types.js";
+import { listener, addAllListeners } from "./listeners.js";
 
-export { registerPlugin } from "./plugins.js";
+export { define, whenDefined } from "./custom-types.js";
 export const XWorker = xworker();
 
-const RUNTIME_SELECTOR = selectors.join(",");
-
-// ensure both interpreter and its queue are awaited then returns the interpreter
-const awaitRuntime = async (key) => {
-    if (interpreters.has(key)) {
-        const { interpreter, queue } = interpreters.get(key);
-        return (await all([interpreter, queue]))[0];
-    }
-
-    const available = interpreters.size
-        ? `Available interpreters are: ${[...interpreters.keys()]
-              .map((r) => `"${r}"`)
-              .join(", ")}.`
-        : `There are no interpreters in this page.`;
-
-    throw new Error(`The interpreter "${key}" was not found. ${available}`);
-};
-
-defineProperty(globalThis, "pyscript", {
-    value: {
-        env: new Proxy(create(null), { get: (_, name) => awaitRuntime(name) }),
-    },
-});
-
-let index = 0;
-globalThis.__events = new Map();
-
-// attributes are tested via integration / e2e
-/* c8 ignore next 17 */
-const listener = async (event) => {
-    const { type, currentTarget } = event;
-    for (let { name, value, ownerElement: el } of $x(
-        `./@*[${prefixes.map((p) => `name()="${p}${type}"`).join(" or ")}]`,
-        currentTarget,
-    )) {
-        name = name.slice(0, -(type.length + 1));
-        const interpreter = await awaitRuntime(
-            el.getAttribute(`${name}-env`) || name,
-        );
-        const i = index++;
-        try {
-            globalThis.__events.set(i, event);
-            registry.get(name).runEvent(interpreter, value, i);
-        } finally {
-            globalThis.__events.delete(i);
-        }
-    }
-};
-
-// attributes are tested via integration / e2e
-/* c8 ignore next 8 */
-for (let { name, ownerElement: el } of $x(
-    `.//@*[${prefixes.map((p) => `starts-with(name(),"${p}")`).join(" or ")}]`,
-)) {
-    name = name.slice(name.lastIndexOf("-") + 1);
-    if (name !== "env") el.addEventListener(name, listener);
-}
+const INTERPRETER_SELECTORS = selectors.join(",");
 
 const mo = new MutationObserver((records) => {
     for (const { type, target, attributeName, addedNodes } of records) {
@@ -92,12 +37,15 @@ const mo = new MutationObserver((records) => {
         }
         for (const node of addedNodes) {
             if (node.nodeType === 1) {
-                if (node.matches(RUNTIME_SELECTOR)) handle(node);
+                addAllListeners(node);
+                if (node.matches(INTERPRETER_SELECTORS)) handle(node);
                 else {
-                    $$(RUNTIME_SELECTOR, node).forEach(handle);
-                    if (!PLUGINS_SELECTORS.length) continue;
-                    handlePlugin(node);
-                    $$(PLUGINS_SELECTORS.join(","), node).forEach(handlePlugin);
+                    $$(INTERPRETER_SELECTORS, node).forEach(handle);
+                    if (!CUSTOM_SELECTORS.length) continue;
+                    handleCustomType(node);
+                    $$(CUSTOM_SELECTORS.join(","), node).forEach(
+                        handleCustomType,
+                    );
                 }
             }
         }
@@ -116,4 +64,5 @@ assign(Element.prototype, {
     },
 });
 
-$$(RUNTIME_SELECTOR, observe(document)).forEach(handle);
+addAllListeners(observe(document));
+$$(INTERPRETER_SELECTORS, document).forEach(handle);

--- a/pyscript.core/esm/listeners.js
+++ b/pyscript.core/esm/listeners.js
@@ -1,0 +1,71 @@
+import { $x } from "basic-devtools";
+
+import { interpreters } from "./script-handler.js";
+import { all, create, defineProperty } from "./utils.js";
+import { registry, prefixes } from "./interpreters.js";
+
+// TODO: this is ugly; need to find a better way
+defineProperty(globalThis, "pyscript", {
+    value: {
+        env: new Proxy(create(null), {
+            get: (_, name) => awaitInterpreter(name),
+        }),
+    },
+});
+
+let index = 0;
+globalThis.__events = new Map();
+
+/* c8 ignore start */ // attributes are tested via integration / e2e
+// ensure both interpreter and its queue are awaited then returns the interpreter
+const awaitInterpreter = async (key) => {
+    if (interpreters.has(key)) {
+        const { interpreter, queue } = interpreters.get(key);
+        return (await all([interpreter, queue]))[0];
+    }
+
+    const available = interpreters.size
+        ? `Available interpreters are: ${[...interpreters.keys()]
+              .map((r) => `"${r}"`)
+              .join(", ")}.`
+        : `There are no interpreters in this page.`;
+
+    throw new Error(`The interpreter "${key}" was not found. ${available}`);
+};
+
+export const listener = async (event) => {
+    const { type, currentTarget } = event;
+    for (let { name, value, ownerElement: el } of $x(
+        `./@*[${prefixes.map((p) => `name()="${p}${type}"`).join(" or ")}]`,
+        currentTarget,
+    )) {
+        name = name.slice(0, -(type.length + 1));
+        const interpreter = await awaitInterpreter(
+            el.getAttribute(`${name}-env`) || name,
+        );
+        const i = index++;
+        try {
+            globalThis.__events.set(i, event);
+            registry.get(name).runEvent(interpreter, value, i);
+        } finally {
+            globalThis.__events.delete(i);
+        }
+    }
+};
+
+/**
+ * Look for known prefixes and add related listeners.
+ * @param {Document | Element} root
+ */
+export const addAllListeners = (root) => {
+    for (let { name, ownerElement: el } of $x(
+        `.//@*[${prefixes
+            .map((p) => `starts-with(name(),"${p}")`)
+            .join(" or ")}]`,
+        root,
+    )) {
+        name = name.slice(name.lastIndexOf("-") + 1);
+        if (name !== "env") el.addEventListener(name, listener);
+    }
+};
+/* c8 ignore stop */

--- a/pyscript.core/esm/worker/class.js
+++ b/pyscript.core/esm/worker/class.js
@@ -5,7 +5,7 @@ import { getText } from "../fetch-utils.js";
 import workerHooks from "./hooks.js";
 
 /**
- * @typedef {Object} WorkerOptions plugin configuration
+ * @typedef {Object} WorkerOptions custom configuration
  * @prop {string} type the interpreter type to use
  * @prop {string} [version] the optional interpreter version to use
  * @prop {string} [config] the optional config to use within such interpreter

--- a/pyscript.core/test/plugins/index.html
+++ b/pyscript.core/test/plugins/index.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>Plugins</title>
         <style>
-            py-script {
+            mpy-script {
                 display: none;
             }
         </style>
@@ -13,9 +13,10 @@
             { "imports": { "@pyscript/core": "../../min.js" } }
         </script>
         <script type="module">
-            import { registerPlugin } from "@pyscript/core";
-            registerPlugin("mpy-script", {
-                type: "micropython",
+            import { define, whenDefined } from "@pyscript/core";
+            whenDefined("mpy").then(console.log);
+            define("mpy", {
+                interpreter: "micropython",
                 async onRuntimeReady(micropython, element) {
                     console.log(micropython);
                     // Somehow this doesn't work in MicroPython
@@ -25,11 +26,21 @@
                     micropython.run(element.textContent);
                     element.replaceChildren("See console ->");
                     element.style.display = "block";
+
+                    const button = document.createElement("button");
+                    button.textContent = "click";
+                    button.setAttribute("mpy-click", "test_click(event)");
+                    document.body.append(button);
                 },
             });
         </script>
     </head>
     <body>
-        <mpy-script> print('Hello Console!') </mpy-script>
+        <mpy-script mpy-click="test_click(event)">
+            def test_click(event):
+                print(event.type)
+
+            print('Hello Console!')
+        </mpy-script>
     </body>
 </html>

--- a/pyscript.core/test/plugins/lua.html
+++ b/pyscript.core/test/plugins/lua.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>Plugins</title>
         <style>
-            py-script {
+            lua-script {
                 display: none;
             }
         </style>
@@ -13,9 +13,9 @@
             { "imports": { "@pyscript/core": "../../min.js" } }
         </script>
         <script type="module">
-            import { registerPlugin } from "@pyscript/core";
-            registerPlugin("lua-script", {
-                type: "wasmoon",
+            import { define } from "@pyscript/core";
+            define("lua", {
+                interpreter: "wasmoon",
                 async onRuntimeReady(wasmoon, element) {
                     // Somehow this doesn't work in Wasmoon
                     wasmoon.io.stdout = (message) => {
@@ -29,6 +29,8 @@
         </script>
     </head>
     <body>
-        <lua-script> print('Hello Console!') </lua-script>
+        <lua-script lua-click="print(event.type)">
+            print('Hello Console!')
+        </lua-script>
     </body>
 </html>

--- a/pyscript.core/test/plugins/py-script.js
+++ b/pyscript.core/test/plugins/py-script.js
@@ -1,4 +1,4 @@
-import { registerPlugin } from "@pyscript/core";
+import { define } from "@pyscript/core";
 
 // append ASAP CSS to avoid showing content
 document.head.appendChild(document.createElement("style")).textContent = `
@@ -17,9 +17,9 @@ let bootstrap = true,
 const sharedPyodide = new Promise((resolve) => {
     const pyConfig = document.querySelector("py-config");
     const config = pyConfig?.getAttribute("src") || pyConfig?.textContent;
-    registerPlugin("py-script", {
+    define("py", {
         config,
-        type: "pyodide",
+        interpreter: "pyodide",
         codeBeforeRunWorker: `print('codeBeforeRunWorker')`,
         codeAfterRunWorker: `print('codeAfterRunWorker')`,
         onBeforeRun(pyodide, node) {


### PR DESCRIPTION
## Description

This MR further refines the ability for core to be extended through a `customElement` like registry where both `define` and `whenDefined` are used instead of the misleading `registerPlugin`.

Other fixes around listeners and DOM life-cycle events are in place too + manual integration tests work as expected.

## Changes

  * hooks defined custom "*types*" into core logic
  * make `interpreter` field on a custom *type* mandatory
  * bootstrap all listeners when a new *type* is defined
  * automatically create `<script type="type">` and `<type-scriipt>` for HTML parity with classic PyScript
  * factored out listeners + some renaming here and there beside `define` and `whenDefined`

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
