### PR TITLE
Fix previous changlog date

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,7 +57,7 @@ Docs
 
 - Add docs for event handlers
 
-2023.01.1
+2023.03.1
 =========
 
 


### PR DESCRIPTION
The previous release in the changelog is listed as `2023.01.1`. The correct title of that release is `2023.03.1`.