### PR TITLE
Update verison

### DIFF
--- a/pyscriptjs/src/version.ts
+++ b/pyscriptjs/src/version.ts
@@ -7,4 +7,4 @@
  *  circular imports.
  */
 
-export const version = '2022.12.1.dev';
+export const version = '2023.05.1.dev';

--- a/pyscriptjs/tests/integration/test_01_basic.py
+++ b/pyscriptjs/tests/integration/test_01_basic.py
@@ -293,7 +293,7 @@ class TestBasic(PyScriptTest):
         )
         assert (
             re.match(
-                r"version_info\(year=\d{4}, month=\d{2}, "
+                r"version_info\(year=\d{4}, month=\d{1,2}, "
                 r"minor=\d+, releaselevel='([a-zA-Z0-9]+)?'\)",
                 self.console.log.lines[-1],
             )


### PR DESCRIPTION
Currently, version.ts says the version is `2022.12.1.dev`, which is our notation for "in development, after the last release version which was called 2022.12.1." This updates that to the (now) correct `2023.05.1.dev`.