### PR TITLE
Bump micropython to version 1.20.0-253.

### DIFF
--- a/pyscript.core/esm/interpreter/micropython.js
+++ b/pyscript.core/esm/interpreter/micropython.js
@@ -7,7 +7,7 @@ const type = "micropython";
 /* c8 ignore start */
 export default {
     type,
-    module: (version = "1.20.0-239") =>
+    module: (version = "1.20.0-253") =>
         `https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@${version}/micropython.mjs`,
     async engine({ loadMicroPython }, config, url) {
         const { stderr, stdout, get } = stdio();

--- a/pyscript.core/node.importmap
+++ b/pyscript.core/node.importmap
@@ -2,7 +2,7 @@
     "imports": {
         "http://pyodide": "./test/mocked/pyodide.mjs",
         "https://cdn.jsdelivr.net/pyodide/v0.23.2/full/pyodide.mjs": "./test/mocked/pyodide.mjs",
-        "https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-239/micropython.mjs": "./test/mocked/micropython.mjs",
+        "https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-253/micropython.mjs": "./test/mocked/micropython.mjs",
         "https://cdn.jsdelivr.net/npm/basic-toml@0.3.1/es.js": "./test/mocked/toml.mjs"
     }
 }

--- a/pyscript.core/test/remote.html
+++ b/pyscript.core/test/remote.html
@@ -11,7 +11,7 @@
     <body>
         <script
             type="micropython"
-            version="https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-239/micropython.mjs"
+            version="https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-253/micropython.mjs"
         >
             import sys
             import js


### PR DESCRIPTION
## Description

Bump MicroPython to the latest version from @dpgeorge.

## Changes

Revised the build number from 239 -> 253.

## Checklist

-   [ ] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
