### PR TITLE
0.0.6

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "PyScript Next core",
     "main": "./cjs/index.js",
     "types": "./types/index.d.ts",


### PR DESCRIPTION
## Description

The currently published module has already `0.0.6` tag but with `npm version patch` there's not automatic MR to the project.

This MR simply aligns current tags and version to *next*.

## Changes

  * align both package.json and package-lock.json to the current, already published, latest

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
