### PR TITLE
[next] Better debugging

### DIFF
--- a/pyscript.core/.eslintrc.json
+++ b/pyscript.core/.eslintrc.json
@@ -8,5 +8,6 @@
         "ecmaVersion": 12,
         "sourceType": "module"
     },
+    "ignorePatterns": ["__template.js"],
     "rules": {}
 }

--- a/pyscript.core/.gitignore
+++ b/pyscript.core/.gitignore
@@ -5,4 +5,5 @@ cjs/
 !cjs/package.json
 core.js
 esm/worker/xworker.js
+esm/worker/__template.js
 types/

--- a/pyscript.core/.npmignore
+++ b/pyscript.core/.npmignore
@@ -16,4 +16,6 @@ node.importmap
 sw.js
 tsconfig.json
 cjs/worker/_template.js
+cjs/worker/__template.js
 esm/worker/_template.js
+esm/worker/__template.js

--- a/pyscript.core/README.md
+++ b/pyscript.core/README.md
@@ -43,3 +43,7 @@ NO_MIN=1 npm run build
 
 npm run server
 ```
+
+### Dev Build
+
+Beside spinning the _localhost_ server via `npm run server`, the `npm run dev` will watch changes in the `./esm` folder and it will build automatically non optimized artifacts out of the box.

--- a/pyscript.core/dev.cjs
+++ b/pyscript.core/dev.cjs
@@ -1,0 +1,33 @@
+let queue = Promise.resolve();
+
+const { exec } = require("node:child_process");
+
+const build = (fileName) => {
+    if (fileName) console.log(fileName, "changed");
+    else console.log("building without optimizations");
+    queue = queue.then(
+        () =>
+            new Promise((resolve, reject) => {
+                exec(
+                    "npm run rollup:xworker && npm run rollup:core && npm run rollup:pyscript",
+                    { cwd: __dirname, env: { ...process.env, NO_MIN: true } },
+                    (error) => {
+                        if (error) reject(error);
+                        else
+                            resolve(
+                                console.log(fileName || "", "build completed"),
+                            );
+                    },
+                );
+            }),
+    );
+};
+
+const options = {
+    ignored: /\/(?:__template|interpreters|xworker)\.[mc]?js$/,
+    persistent: true,
+};
+
+require("chokidar").watch("./esm", options).on("change", build);
+
+build();

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -8,6 +8,7 @@
         "server": "npx static-handler --cors --coep --coop --corp .",
         "build": "npm run rollup:xworker && npm run rollup:core && npm run rollup:pyscript && eslint esm/ && npm run ts && npm run cjs && npm run test",
         "cjs": "ascjs --no-default esm cjs",
+        "dev": "node dev.cjs",
         "rollup:core": "rollup --config rollup/core.config.js",
         "rollup:pyscript": "rollup --config rollup/pyscript.config.js",
         "rollup:xworker": "rollup --config rollup/xworker.config.js",
@@ -32,6 +33,7 @@
         "@rollup/plugin-terser": "^0.4.3",
         "ascjs": "^5.0.1",
         "c8": "^8.0.0",
+        "chokidar": "^3.5.3",
         "eslint": "^8.43.0",
         "linkedom": "^0.14.26",
         "rollup": "^3.25.3",
@@ -64,6 +66,6 @@
         "coincident": "^0.8.3"
     },
     "worker": {
-        "blob": "sha256-CaHDEAEttvghrbLR/GVAofT+zQZyy0Ri9tkpVTNBbiE="
+        "blob": "sha256-eWNZbyS06lxxlUW/bkU7/fl/Levxxxfiv/+frsgl/fA="
     }
 }


### PR DESCRIPTION
## Description

This MR goal is to build non optimized files, including the *Worker*, while watching for changes in the `./esm` folder, simplifying by far the current *core* development.

## Changes

  * avoid inlining as Blob the Worker content when *NO_MIN=1* is used to help developing with `debugger` or stop points in the file instead of the string
  * created a simple utility that watches recursively the `./esm` folder except files triggered while building
  * tested everything works as expected locally using the `npm run dev` helper

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
