### PR TITLE
[next] Add basic integrations tests

### DIFF
--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -46,7 +46,7 @@ jobs:
 
             - name: install next deps
               working-directory: pyscript.core
-              run: npm i
+              run: npm i; npx playwright install
 
             - name: build next
               working-directory: pyscript.core

--- a/pyscript.core/README.md
+++ b/pyscript.core/README.md
@@ -50,7 +50,7 @@ Besides spinning the _localhost_ server via `npm run server`, the `npm run dev` 
 
 ## Integration Tests
 
-To keep it simple, and due technical differences between what we had before and what we actually need for core (special headers, multiple interpreters, different bootstrap logic), core integration tests can be performed simply running:
+To keep it simple, and due to technical differences between what was in PyScript before and what we actually need for core (special headers, multiple interpreters, different bootstrap logic), core integration tests can be performed simply by running:
 
 ```sh
 npm run test:integration
@@ -80,7 +80,7 @@ integration
 ```
 
 -   **interpreter** this folder contains, per each interpreter, a dedicated folder with the interpreter's name. Each of these sub-folders will contain all `.html` and other files to test every specific behavior. In this folder, it's possible to share files, config, or anything else that makes sense for one or more interpreters.
--   **\_shared.js** contains some utility used across all tests. Any file prefixed with `_` (underscore) will be ignored but it can be used by the code itself.
+-   **\_shared.js** contains some utility used across all tests. Any file prefixed with `_` (underscore) will be ignored for tests purposes but it can be used by the code itself.
 -   **micropython.js** and all others contain the actual test per each interpreter. If a test is the same across multiple interpreters it can be exported via the `_shared.js` file as it is for most _Pyodide_ and _MicroPython_ cases.
 
 The [test/integration.spec.js](./test/integration.spec.js) file simply loops over folders that match interpreters _by name_ and execute in parallel all tests.

--- a/pyscript.core/README.md
+++ b/pyscript.core/README.md
@@ -47,3 +47,46 @@ npm run server
 ### Dev Build
 
 Beside spinning the _localhost_ server via `npm run server`, the `npm run dev` will watch changes in the `./esm` folder and it will build automatically non optimized artifacts out of the box.
+
+## Integration Tests
+
+To keep it simple, and due technical differences between what we had before and what we actually need for core (special headers, multiple interpreters, different bootstrap logic), core integration tests can be performed simply running:
+
+```sh
+npm run test:integration
+```
+
+The package's entry takes care of eventually bootstrapping a localhost, start in parallel all tests, and shut down the server after, if any was bootstrapped.
+
+The tool to test integration is still _playwright_ but move things a bit faster (from my side) tests are written in JS.
+
+#### Integration Tests Structure
+
+```
+integration
+          ├ interpreter
+          │           ├ micropython
+          │           ├ pyodide
+          │           ├ ruby-wasm-wasi
+          │           ├ wasmoon
+          │           ├ xxx.yy
+          │           ├ xxx.toml
+          │           └ utils.js
+          ├ _shared.js
+          ├ micropython.js
+          ├ pyodide.js
+          ├ ruby-wasm-wasi.js
+          └ wasmoon.js
+```
+
+-   **interpreter** this folder contains, per each interpreter, a dedicated folder with the interpreter's name. Each of these sub-folders will contain all `.html` and other files to test every specific behavior. In this folder it's possible to share files, config, or anything else that makes sense for one or more interpreter.
+-   **\_shared.js** contains some utility used across all tests. Any file prefixed with `_` (underscore) will be ignored but it can be used by the code itself.
+-   **micropython.js** and all others contain the actual test per each interpreter. If a test is the same across multiple interpreters it can be exported via the `_shared.js` file as it is for most _Pyodide_ and _MicroPython_ cases.
+
+The [test/integration.spec.js](./test/integration.spec.js) file simply loops over folders that match interpreters _by name_ and execute in parallel all tests.
+
+#### Manual Test
+
+To **test manually** an integration test, simply `npm run server` and reach the _html_ file created for that particular test.
+
+As example, reaching http://localhost:8080/test/integration/interpreter/micropython/fetch.html would log in console and show expectations on the page and this can be easily tested via multiple browsers by simply reaching the very same integration test.

--- a/pyscript.core/README.md
+++ b/pyscript.core/README.md
@@ -10,7 +10,7 @@ Please read [the documentation page](./docs/README.md) to know all the user-faci
 
 ## Development
 
-The working folder (source code of truth) is the `./esm` one, while the `./cjs` is populated as dual module and to test (but it's 1:1 code, no transpilation except for imports/exports).
+The working folder (source code of truth) is the `./esm` one, while the `./cjs` is populated as a dual module and to test (but it's 1:1 code, no transpilation except for imports/exports).
 
 ```sh
 # install all dependencies needed by core
@@ -46,7 +46,7 @@ npm run server
 
 ### Dev Build
 
-Beside spinning the _localhost_ server via `npm run server`, the `npm run dev` will watch changes in the `./esm` folder and it will build automatically non optimized artifacts out of the box.
+Besides spinning the _localhost_ server via `npm run server`, the `npm run dev` will watch changes in the `./esm` folder and it will build automatically non optimized artifacts out of the box.
 
 ## Integration Tests
 
@@ -56,9 +56,9 @@ To keep it simple, and due technical differences between what we had before and 
 npm run test:integration
 ```
 
-The package's entry takes care of eventually bootstrapping a localhost, start in parallel all tests, and shut down the server after, if any was bootstrapped.
+The package's entry takes care of eventually bootstrapping localhost, starting in parallel all tests, and shutting down the server after, if any was bootstrapped.
 
-The tool to test integration is still _playwright_ but move things a bit faster (from my side) tests are written in JS.
+The tool to test integration is still _playwright_ but moves things a bit faster (from my side) tests are written in JS.
 
 #### Integration Tests Structure
 
@@ -79,7 +79,7 @@ integration
           └ wasmoon.js
 ```
 
--   **interpreter** this folder contains, per each interpreter, a dedicated folder with the interpreter's name. Each of these sub-folders will contain all `.html` and other files to test every specific behavior. In this folder it's possible to share files, config, or anything else that makes sense for one or more interpreter.
+-   **interpreter** this folder contains, per each interpreter, a dedicated folder with the interpreter's name. Each of these sub-folders will contain all `.html` and other files to test every specific behavior. In this folder, it's possible to share files, config, or anything else that makes sense for one or more interpreters.
 -   **\_shared.js** contains some utility used across all tests. Any file prefixed with `_` (underscore) will be ignored but it can be used by the code itself.
 -   **micropython.js** and all others contain the actual test per each interpreter. If a test is the same across multiple interpreters it can be exported via the `_shared.js` file as it is for most _Pyodide_ and _MicroPython_ cases.
 
@@ -89,4 +89,4 @@ The [test/integration.spec.js](./test/integration.spec.js) file simply loops ove
 
 To **test manually** an integration test, simply `npm run server` and reach the _html_ file created for that particular test.
 
-As example, reaching http://localhost:8080/test/integration/interpreter/micropython/fetch.html would log in console and show expectations on the page and this can be easily tested via multiple browsers by simply reaching the very same integration test.
+As example, reaching http://localhost:8080/test/integration/interpreter/micropython/fetch.html would log in the console and show expectations on the page and this can be easily tested via multiple browsers by simply reaching the very same integration test.

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -16,6 +16,7 @@
             },
             "devDependencies": {
                 "@node-loader/import-maps": "^1.1.0",
+                "@playwright/test": "^1.35.1",
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-terser": "^0.4.3",
                 "ascjs": "^5.0.1",
@@ -252,6 +253,25 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+            "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "playwright-core": "1.35.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
         "node_modules/@rollup/plugin-node-resolve": {
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
@@ -331,6 +351,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
             "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "20.3.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+            "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
             "dev": true
         },
         "node_modules/@types/resolve": {
@@ -1680,6 +1706,18 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/playwright-core": {
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+            "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
+            "dev": true,
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2407,6 +2445,17 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@playwright/test": {
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+            "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "fsevents": "2.3.2",
+                "playwright-core": "1.35.1"
+            }
+        },
         "@rollup/plugin-node-resolve": {
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
@@ -2453,6 +2502,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
             "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "20.3.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+            "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
             "dev": true
         },
         "@types/resolve": {
@@ -3463,6 +3518,12 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
+        },
+        "playwright-core": {
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+            "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
             "dev": true
         },
         "prelude-ls": {

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -6,14 +6,16 @@
     "types": "./types/index.d.ts",
     "scripts": {
         "server": "npx static-handler --cors --coep --coop --corp .",
-        "build": "npm run rollup:xworker && npm run rollup:core && npm run rollup:pyscript && eslint esm/ && npm run ts && npm run cjs && npm run test",
+        "build": "npm run rollup:xworker && npm run rollup:core && npm run rollup:pyscript && eslint esm/ && npm run ts && npm run cjs",
         "cjs": "ascjs --no-default esm cjs",
         "dev": "node dev.cjs",
         "rollup:core": "rollup --config rollup/core.config.js",
         "rollup:pyscript": "rollup --config rollup/pyscript.config.js",
         "rollup:xworker": "rollup --config rollup/xworker.config.js",
-        "test": "c8 --100 node --experimental-loader @node-loader/import-maps test/index.js ",
+        "test": "c8 --100 node --experimental-loader @node-loader/import-maps test/index.js && npm run test:integration",
         "test:html": "npm run test && c8 report -r html",
+        "test:integration//": "Don't bother with spinning servers. Trap the tests EXIT_CODE. Kill the running server, if any. Return the EXIT_CODE to eventually throw an error.",
+        "test:integration": "static-handler --cors --coep --coop --corp . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test --fully-parallel test/ || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
         "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info",
         "size": "npm run size:module && npm run size:worker",
         "size:module": "echo module is $(cat core.js | brotli | wc -c) bytes once compressed",
@@ -29,6 +31,7 @@
     "license": "MIT",
     "devDependencies": {
         "@node-loader/import-maps": "^1.1.0",
+        "@playwright/test": "^1.35.1",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-terser": "^0.4.3",
         "ascjs": "^5.0.1",
@@ -66,6 +69,6 @@
         "coincident": "^0.11.1"
     },
     "worker": {
-        "blob": "sha256-lKnkzAqePCcARjTnFS6sRscDVvubVW8t5ptuccVkREc="
+        "blob": "sha256-Ku7KFQEos4ex24kNmg6mhCafl5jblyxgiWfXyVxhpUk="
     }
 }

--- a/pyscript.core/test/integration.spec.js
+++ b/pyscript.core/test/integration.spec.js
@@ -1,0 +1,19 @@
+const { existsSync, readdirSync } = require('node:fs');
+const { join } = require('node:path');
+const playwright = require('@playwright/test');
+
+// integration tests for interpreters
+const TEST_INTERPRETER = join(__dirname, 'integration');
+
+// source of truth for interpreters
+const CORE_INTERPRETER = join(__dirname, '..', 'esm', 'interpreter');
+
+for (const file of readdirSync(TEST_INTERPRETER)) {
+  // filter only JS files that match their counter-part interpreter
+  if (/\.js$/.test(file) && existsSync(join(CORE_INTERPRETER, file))) {
+    require(join(TEST_INTERPRETER, file))(
+      playwright,
+      `http://localhost:8080/test/integration/interpreter/${file.slice(0, -3)}`
+    );
+  }
+}

--- a/pyscript.core/test/integration/_shared.js
+++ b/pyscript.core/test/integration/_shared.js
@@ -9,8 +9,6 @@ exports.shared = {
         await expect(result.trim()).toBe('OK');
     },
 
-    // the `remoteBootstrap` value indicates approximately how long it takes
-    // for the different / worker interpreter to bootstrap
     worker: ({ expect }, url) => async ({ page }) => {
         const logs = [];
         page.on('console', msg => logs.push(msg.text()));

--- a/pyscript.core/test/integration/_shared.js
+++ b/pyscript.core/test/integration/_shared.js
@@ -1,0 +1,48 @@
+'use strict';
+
+exports.shared = {
+    bootstrap: ({ expect }, baseURL) => async ({ page }) => {
+        await page.goto(`${baseURL}/bootstrap.html`);
+        await page.waitForSelector('html.ready');
+        await page.getByRole('button').click();
+        const result = await page.evaluate(() => document.body.innerText);
+        await expect(result.trim()).toBe('OK');
+    },
+
+    // the `remoteBootstrap` value indicates approximately how long it takes
+    // for the different / worker interpreter to bootstrap
+    worker: ({ expect }, url) => async ({ page }) => {
+        const logs = [];
+        page.on('console', msg => logs.push(msg.text()));
+        await page.goto(url);
+        await page.waitForSelector('html.worker.ready');
+        await expect(logs.join(',')).toBe('main,thread');
+    },
+
+    workerWindow: ({ expect }, baseURL) => async ({ page }) => {
+        await page.goto(`${baseURL}/worker-window.html`);
+        await page.waitForSelector('html.worker.ready');
+        const result = await page.evaluate(() => document.body.innerText);
+        await expect(result.trim()).toBe('OK');
+    },
+};
+
+exports.python = {
+    bootstrap: ({ expect }, baseURL) => async ({ page }) => {
+        await page.goto(`${baseURL}/bootstrap.html`);
+        await page.waitForSelector('html.ready');
+        const result = await page.evaluate(() => document.body.innerText);
+        await expect(result.trim()).toBe('OK');
+    },
+
+    fetch: ({ expect }, url) => async ({ page }) => {
+        const logs = [];
+        page.on('console', msg => logs.push(msg.text()));
+        await page.goto(url);
+        await page.waitForSelector('html.ready');
+        await expect(logs.length).toBe(1);
+        await expect(logs[0]).toBe('hello from A');
+        const body = await page.evaluate(() => document.body.innerText);
+        await expect(body.trim()).toBe('hello from A, hello from B');
+    },
+};

--- a/pyscript.core/test/integration/interpreter/a.py
+++ b/pyscript.core/test/integration/interpreter/a.py
@@ -1,0 +1,2 @@
+x = "hello from A"
+print(x)

--- a/pyscript.core/test/integration/interpreter/b.py
+++ b/pyscript.core/test/integration/interpreter/b.py
@@ -1,0 +1,1 @@
+x = "hello from B"

--- a/pyscript.core/test/integration/interpreter/fetch.toml
+++ b/pyscript.core/test/integration/interpreter/fetch.toml
@@ -1,0 +1,2 @@
+[[fetch]]
+files = ["./a.py", "./b.py"]

--- a/pyscript.core/test/integration/interpreter/micropython/bootstrap.html
+++ b/pyscript.core/test/integration/interpreter/micropython/bootstrap.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('micropython');
+    </script>
+</head>
+<body>
+    <script type="micropython">
+        import js
+        js.document.currentScript.target.textContent = "OK"
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/micropython/fetch.html
+++ b/pyscript.core/test/integration/interpreter/micropython/fetch.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script type="module">
+            import { init } from '../utils.js';
+            init('micropython');
+        </script>
+    </head>
+    <body>
+        <script type="micropython" config="../fetch.toml">
+            import js
+            import a, b
+            js.document.currentScript.target.textContent = a.x + ", " + b.x
+        </script>
+    </body>
+</html>

--- a/pyscript.core/test/integration/interpreter/micropython/worker-lua.html
+++ b/pyscript.core/test/integration/interpreter/micropython/worker-lua.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('micropython');
+    </script>
+</head>
+<body>
+    <script type="micropython">
+        from xworker import XWorker
+
+        def handle_message(event):
+          print(event.data)
+
+        w = XWorker('../wasmoon/worker.lua', type='wasmoon')
+        w.postMessage('main')
+        w.onmessage = handle_message
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/micropython/worker-window.html
+++ b/pyscript.core/test/integration/interpreter/micropython/worker-window.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('micropython');
+    </script>
+</head>
+<body>
+    <script type="micropython">
+        from xworker import XWorker
+        XWorker('./worker-window.py')
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/micropython/worker-window.py
+++ b/pyscript.core/test/integration/interpreter/micropython/worker-window.py
@@ -1,0 +1,9 @@
+from xworker import xworker
+
+document = xworker.window.document
+
+document.body.textContent = "OK"
+
+# be sure the page knows the worker has done parsing to avoid
+# unnecessary random timeouts all over the tests
+document.documentElement.className += " worker"

--- a/pyscript.core/test/integration/interpreter/micropython/worker.html
+++ b/pyscript.core/test/integration/interpreter/micropython/worker.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('micropython');
+    </script>
+</head>
+<body>
+    <script type="micropython">
+        from xworker import XWorker
+
+        def handle_message(event):
+          print(event.data)
+
+        w = XWorker('./worker.py')
+        w.postMessage('main')
+        w.onmessage = handle_message
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/micropython/worker.py
+++ b/pyscript.core/test/integration/interpreter/micropython/worker.py
@@ -1,0 +1,15 @@
+from xworker import xworker
+
+document = xworker.window.document
+
+
+def on_message(event):
+    print(event.data)
+    xworker.postMessage("thread")
+
+
+xworker.onmessage = on_message
+
+# be sure the page knows the worker has done parsing to avoid
+# unnecessary random timeouts all over the tests
+document.documentElement.className += " worker"

--- a/pyscript.core/test/integration/interpreter/pyodide/bootstrap.html
+++ b/pyscript.core/test/integration/interpreter/pyodide/bootstrap.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('pyodide');
+    </script>
+</head>
+<body>
+    <script type="pyodide">
+        import js
+        js.document.currentScript.target.textContent = "OK"
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/pyodide/fetch.html
+++ b/pyscript.core/test/integration/interpreter/pyodide/fetch.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script type="module">
+            import { init } from '../utils.js';
+            init('pyodide');
+        </script>
+    </head>
+    <body>
+        <script type="pyodide" config="../fetch.toml">
+            import js
+            import a, b
+            js.document.currentScript.target.textContent = a.x + ", " + b.x
+        </script>
+    </body>
+</html>

--- a/pyscript.core/test/integration/interpreter/pyodide/pyodide.js
+++ b/pyscript.core/test/integration/interpreter/pyodide/pyodide.js
@@ -1,0 +1,3 @@
+import '/core.js';
+await pyscript.env.pyodide;
+document.documentElement.classList.add('ready');

--- a/pyscript.core/test/integration/interpreter/pyodide/sync.html
+++ b/pyscript.core/test/integration/interpreter/pyodide/sync.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('pyodide');
+    </script>
+</head>
+<body>
+    <script type="pyodide">
+        import asyncio
+        from xworker import XWorker
+
+        XWorker('./sync.py').sync.sleep = asyncio.sleep
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/pyodide/sync.py
+++ b/pyscript.core/test/integration/interpreter/pyodide/sync.py
@@ -1,0 +1,12 @@
+import time
+from xworker import xworker
+
+time.sleep = xworker.sync.sleep
+
+print("before")
+time.sleep(1)
+print("after")
+
+# be sure the page knows the worker has done parsing to avoid
+# unnecessary random timeouts all over the tests
+xworker.window.document.documentElement.classList.add("worker")

--- a/pyscript.core/test/integration/interpreter/pyodide/worker.html
+++ b/pyscript.core/test/integration/interpreter/pyodide/worker.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('pyodide');
+    </script>
+</head>
+<body>
+    <script type="pyodide">
+        from xworker import XWorker
+
+        def handle_message(event):
+          print(event.data)
+
+        w = XWorker('./worker.py')
+        w.postMessage('main')
+        w.onmessage = handle_message
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/pyodide/worker.py
+++ b/pyscript.core/test/integration/interpreter/pyodide/worker.py
@@ -1,0 +1,13 @@
+from xworker import xworker
+
+
+def on_message(event):
+    print(event.data)
+    xworker.postMessage("thread")
+
+
+xworker.onmessage = on_message
+
+# be sure the page knows the worker has done parsing to avoid
+# unnecessary random timeouts all over the tests
+xworker.window.document.documentElement.classList.add("worker")

--- a/pyscript.core/test/integration/interpreter/ruby-wasm-wasi/bootstrap.html
+++ b/pyscript.core/test/integration/interpreter/ruby-wasm-wasi/bootstrap.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('ruby-wasm-wasi');
+    </script>
+</head>
+<body>
+    <script type="ruby-wasm-wasi">
+        def show_OK(event)
+            event[:target][:textContent] = 'OK'
+        end
+    </script>
+    <button ruby-wasm-wasi-click="show_OK"></button>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/ruby-wasm-wasi/ruby-wasm-wasi.js
+++ b/pyscript.core/test/integration/interpreter/ruby-wasm-wasi/ruby-wasm-wasi.js
@@ -1,0 +1,3 @@
+import '/core.js';
+await pyscript.env['ruby-wasm-wasi'];
+document.documentElement.classList.add('ready');

--- a/pyscript.core/test/integration/interpreter/utils.js
+++ b/pyscript.core/test/integration/interpreter/utils.js
@@ -1,0 +1,5 @@
+import '/core.js';
+
+export const init = name => pyscript.env[name].then(() => {
+    document.documentElement.classList.add('ready');
+});

--- a/pyscript.core/test/integration/interpreter/wasmoon/bootstrap.html
+++ b/pyscript.core/test/integration/interpreter/wasmoon/bootstrap.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('wasmoon');
+    </script>
+</head>
+<body>
+    <script type="wasmoon">
+        function show_OK(event)
+            event.target.textContent = 'OK'
+        end
+    </script>
+    <button wasmoon-click="show_OK"></button>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/wasmoon/wasmoon.js
+++ b/pyscript.core/test/integration/interpreter/wasmoon/wasmoon.js
@@ -1,0 +1,3 @@
+import '/core.js';
+await pyscript.env.wasmoon;
+document.documentElement.classList.add('ready');

--- a/pyscript.core/test/integration/interpreter/wasmoon/worker.html
+++ b/pyscript.core/test/integration/interpreter/wasmoon/worker.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="module">
+        import { init } from '../utils.js';
+        init('wasmoon');
+    </script>
+</head>
+<body>
+    <script type="wasmoon">
+        function handle_message(event)
+            print(event.data)
+        end
+
+        w = XWorker('./worker.lua')
+        w.postMessage('main')
+        w.onmessage = handle_message
+    </script>
+</body>
+</html>

--- a/pyscript.core/test/integration/interpreter/wasmoon/worker.lua
+++ b/pyscript.core/test/integration/interpreter/wasmoon/worker.lua
@@ -1,0 +1,10 @@
+function on_message(event)
+    print(event.data)
+    xworker.postMessage('thread')
+end
+
+xworker.onmessage = on_message
+
+-- be sure the page knows the worker has done parsing to avoid
+-- unnecessary random timeouts all over the tests
+xworker.window.document.documentElement.classList.add("worker")

--- a/pyscript.core/test/integration/micropython.js
+++ b/pyscript.core/test/integration/micropython.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { shared, python } = require('./_shared.js');
+
+module.exports = (playwright, baseURL) => {
+    const { test } = playwright;
+
+    test('MicroPython bootstrap', python.bootstrap(playwright, baseURL));
+
+    test('MicroPython fetch', python.fetch(playwright, `${baseURL}/fetch.html`));
+
+    test('MicroPython to MicroPython Worker', shared.worker(playwright, `${baseURL}/worker.html`));
+
+    test('MicroPython Worker window', shared.workerWindow(playwright, baseURL));
+
+    test('MicroPython to Wasmoon Worker', shared.worker(playwright, `${baseURL}/worker-lua.html`));
+};

--- a/pyscript.core/test/integration/pyodide.js
+++ b/pyscript.core/test/integration/pyodide.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { shared, python } = require('./_shared.js');
+
+module.exports = (playwright, baseURL) => {
+    const { expect, test } = playwright;
+
+    test('Pyodide bootstrap', python.bootstrap(playwright, baseURL));
+
+    test('Pyodide fetch', python.fetch(playwright, `${baseURL}/fetch.html`));
+
+    test('Pyodide to Pyodide Worker', shared.worker(playwright, `${baseURL}/worker.html`));
+
+    test('Pyodide sync (time)', async ({ page }) => {
+        const logs = [];
+        page.on('console', msg => logs.push({text: msg.text(), time: new Date}));
+        await page.goto(`${baseURL}/sync.html`);
+        await page.waitForSelector('html.worker.ready');
+        await expect(logs.length).toBe(2);
+        const [
+            {text: text1, time: time1},
+            {text: text2, time: time2}
+        ] = logs;
+        await expect(text1).toBe('before');
+        await expect(text2).toBe('after');
+        await expect((time2 - time1) >= 1000).toBe(true);
+    });
+};

--- a/pyscript.core/test/integration/ruby-wasm-wasi.js
+++ b/pyscript.core/test/integration/ruby-wasm-wasi.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { shared } = require('./_shared.js');
+
+module.exports = (playwright, baseURL) => {
+    const { test } = playwright;
+
+    test('Ruby WASM WASI bootstrap', shared.bootstrap(playwright, baseURL));
+};

--- a/pyscript.core/test/integration/wasmoon.js
+++ b/pyscript.core/test/integration/wasmoon.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { shared } = require('./_shared.js');
+
+module.exports = (playwright, baseURL) => {
+    const { test } = playwright;
+
+    test('Wasmoon bootstrap', shared.bootstrap(playwright, baseURL));
+
+    test('Wasmoon to Wasmoon Worker', shared.worker(playwright, `${baseURL}/worker.html`));
+};


### PR DESCRIPTION
## Description

This MR goal is to ensure at least most basic integration tests orchestration, setup, and functionalities, are available for our offered interpreters:

  * all of them should be able to bootstrap and be meaningful on a page
  * most of them (ruby a part) should be able to deal with *XWorker* orchestration
  * exposed *xworker.window* and *xworker.sync* work as expected
  * an interpreter can run other interpreters out of a *XWorker* setup
  * no plugins (as in *custom types*) are tested, as we don't have a whole story for these yet

The reason this has been a **WIP** for a while is:

  * due Workers and multiple interpreters, it's basically pointless to bring in what we had for "*classic PyScript*"
  * the *PyScript Next* can still orchestrate its integration tests a part
  * we need a server able to enable all headers needed for *SharedArrayBuffer* and since all tests to date used a NodeJS based tiny module that allows that out of the box, I've kept it simple for the time being
  * the integration bootstrap in the `package.json` is commented in line within the package because we want to enable multi thread testing (huge performance boost) but we need only a single server running to test all the things
  * all interpreters share the same code ... it's unclear to me if we should test all the things for every of them but in some case that's not just possible. As example, Wasmoon and Ruby don't get a `js` module to import anything from, but they can use DOM as tested in here. The same goes for `window` or `sync`: these are all the exact same code path, so I doubt having these tested (as copy/paste practice) all over are kinda unnecessary, as long as the basics work already.
  * because of previous points, I didn't implement (yet) *config* related tests, as these might well be interpreter dependent too, so I'd like to be aligned before I move forward tests.
  * Wasmoon and Ruby tests also kinda prove that having events as we do now just works.

However, because we're going to move this project elsewhere I think all these discussions can and should be done once we focus on PyScript Next as core *custom type*, and keep core simple enough to move fast.

## Changes

  * added a `spec.js` file to orchestrate tests
  * added an `integration` folder that branches every single interpreter to be able to fine-tune tests per each case (see Pyodide sync test)
  * added a file able to share common tests per runtime or programming language
  * added a smart package entry to ignore any already running server (debugging purpose) yet avoid leaking spawned servers in the wild (or CI)
  * the package also self clean itself on tests done
  * added multiple HTML files and related files per each test
  * added some default timeout for workers as Playwright doesn't seem to offer much around this use case
  * tested fetch and latest events behavior
  * added documentation about integration tests

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
