### PR TITLE
[next] Use the very same source for all Python interpreters

### DIFF
--- a/pyscript.core/test/py-events.html
+++ b/pyscript.core/test/py-events.html
@@ -9,18 +9,7 @@
         <script type="module" src="../core.js"></script>
     </head>
     <body>
-        <script type="pyodide">
-            def print_version(event):
-              import sys
-              print(event.type)
-              print(sys.version)
-
-            class Printer:
-                def version(self, event):
-                    print_version(event)
-
-            printer = Printer()
-        </script>
+        <script type="pyodide" src="./py-events.py"></script>
         <button
             pyodide-pointerdown="print_version"
             pyodide-click="printer.version"
@@ -28,13 +17,7 @@
             pyodide version
         </button>
 
-        <script type="micropython">
-            def print_version(event):
-              import sys
-              print(event.type)
-              print(sys.version)
-        </script>
-        <!-- ⚠️ MicroPython bug: it fails the printer.version case -->
+        <script type="micropython" src="./py-events.py"></script>
         <button
             micropython-pointerdown="print_version"
             micropython-click="printer.version"

--- a/pyscript.core/test/py-events.py
+++ b/pyscript.core/test/py-events.py
@@ -1,0 +1,13 @@
+def print_version(event):
+    import sys
+
+    print(event.type)
+    print(sys.version)
+
+
+class Printer:
+    def version(self, event):
+        print_version(event)
+
+
+printer = Printer()


### PR DESCRIPTION
## Description

I've messed up with the integration test and this one makes it sure both pyodide and micropython use the exact same file to orchestrate events around (when triggered).

## Changes

  * remove the inline scripts to orchestrate the same logic
  * test everything is actually good on both interpreters

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
