### PR TITLE
Src loading and focusing of repl

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ Features
 - Resored the `output-mode` attribute of `py-repl` tags. If `output-mode` == 'append', the DOM element where output is printed is _not_ cleared before writing new results.
 - Load code from the attribute src of py-repl and preload it into the corresponding py-repl tag by use the attribute `str` in your `py-repl` tag([#1292](https://github.com/pyscript/pyscript/pull/1292))
 - &lt;py-repl&gt; elements now have a `getPySrc()` method, which returns the code inside the REPL as a string.([#1516](https://github.com/pyscript/pyscript/pull/1292))
+- Replace repl content using the built-in func of CodeMirror, disable default focus, and add new attr focused.([#1593](https://github.com/pyscript/pyscript/pull/1593))
 
 ### Plugins
 - Plugins may now implement the `beforePyReplExec()` and `afterPyReplExec()` hooks, which are called immediately before and after code in a `py-repl` tag is executed. ([#1106](https://github.com/pyscript/pyscript/pull/1106))

--- a/docs/reference/elements/py-repl.md
+++ b/docs/reference/elements/py-repl.md
@@ -4,14 +4,14 @@ The `<py-repl>` element provides a REPL(Read Eval Print Loop) to evaluate multi-
 
 ## Attributes
 
-| attribute         | type    | default | description                          |
-|-------------------|---------|---------|--------------------------------------|
-| **auto-generate** | boolean |         | Auto-generates REPL after evaluation |
+| attribute         | type    | default | description                                                              |
+|-------------------|---------|---------|--------------------------------------------------------------------------|
+| **auto-generate** | boolean |         | Auto-generates REPL after evaluation                                     |
 | **output-mode**   | string  | ""      | Determines whether the output element is cleared prior to writing output |
-| **output**        | string  |         | The id of the element to write `stdout` and `stderr` to     |
-| **stderr**        | string  |         | The id of the element to write `stderr` to |
-| **src**           | string  |         | Resource to be preloaded into the REPL |
-
+| **output**        | string  |         | The id of the element to write `stdout` and `stderr` to                  |
+| **stderr**        | string  |         | The id of the element to write `stderr` to                               |
+| **src**           | string  |         | Resource to be preloaded into the REPL                                   |
+| **focused**       | string  | ""      | Indicating focus status                                                  |
 
 ### `auto-generate`
 If a \<py-repl\> tag has the `auto-generate` attribute, upon execution, another \<pr-repl\> tag will be created and added to the DOM as a sibling of the current tag.
@@ -27,6 +27,9 @@ The ID of an element in the DOM that `stderr` will be written to. Defaults to No
 
 ### `src`
 If a \<py-repl\> tag has the `src` attribute, during page initialization, resource in the `src` will be preloaded into the REPL. Please note that this will not run in advance. If there is content in the \<py-repl\> tag, it will be cleared and replaced with preloaded resource.
+
+### `focused`
+Indicate whether the component is in a focused state. Note that if this attribute is present during component creation, it will be focused `once` and only have indicative significance thereafter.
 
 ## Methods
 

--- a/examples/repl.html
+++ b/examples/repl.html
@@ -39,7 +39,7 @@
                     files = ["./antigravity.py"]
                 </py-config>
                 <div style="margin-right: 3rem">
-                    <py-repl id="my-repl" auto-generate="true"> </py-repl>
+                    <py-repl id="my-repl" auto-generate="true" focused> </py-repl>
                 </div>
             </py-tutor>
         </section>

--- a/examples/repl2.html
+++ b/examples/repl2.html
@@ -41,7 +41,7 @@
                     files = ["./utils.py", "./antigravity.py"]
                 </py-config>
                 <div style="margin-right: 3rem">
-                    <py-repl id="my-repl" auto-generate="true"> </py-repl>
+                    <py-repl id="my-repl" auto-generate="true" focused> </py-repl>
                     <div id="output" class="p-4"></div>
                 </div>
             </py-tutor>


### PR DESCRIPTION
## Description
* Replace repl content using the built-in func of CodeMirror.
* Cancel the default focus of the component, because in some browsers, the page will automatically scroll to the editor position, affecting the webpage experience.Using the focused attribute to achieve editor focus behavior during automatic generation and indicating focus status.

## Changes

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md`
-   [x] I have created documentation for this(if applicable)
