### PR TITLE
[next] Better Errors - Worker

### DIFF
--- a/pyscript.core/esm/worker/class.js
+++ b/pyscript.core/esm/worker/class.js
@@ -53,5 +53,12 @@ export default (...args) =>
 
         if (isHook) this.onWorkerReady?.(this.interpreter, worker);
 
+        worker.addEventListener("message", (event) => {
+            if (event.data instanceof Error) {
+                event.stopImmediatePropagation();
+                worker.onerror(event);
+            }
+        });
+
         return worker;
     };

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -69,6 +69,6 @@
         "coincident": "^0.11.1"
     },
     "worker": {
-        "blob": "sha256-Ku7KFQEos4ex24kNmg6mhCafl5jblyxgiWfXyVxhpUk="
+        "blob": "sha256-YJ2S61l39eRltU0ldf3Q7CfCASBa8FrQLLsfXUSzBHc="
     }
 }

--- a/pyscript.core/test/error.html
+++ b/pyscript.core/test/error.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    </head>
+    <body>
+        <div>See console ➡️</div>
+        <script type="micropython">
+            from xworker import XWorker
+
+            def handle_error(event):
+                print("Python")
+                print(event.data.message)
+
+            w = XWorker('./error.py')
+            w.onerror = handle_error
+        </script>
+        <script type="module">
+            import { XWorker } from "../core.js";
+
+            const w = new XWorker("./error.py", { type: "micropython" });
+            w.onerror = ({ data: error }) => {
+                console.log('JS', error);
+            };
+        </script>
+    </body>
+</html>

--- a/pyscript.core/test/error.py
+++ b/pyscript.core/test/error.py
@@ -1,0 +1,3 @@
+# from xworker import xworker
+
+xworker.postMessage("error")


### PR DESCRIPTION
## Description

This issue partially addresses https://github.com/pyscript/pyscript/issues/1596 by forwarding errors to the main thread in a way that the Worker can naturally intercept via `onerror`.

It is still responsibility of *core* users to handle errors visually on the page, if they want, but it wasn't possible before these changes.

It is also possible, through these changes, to provide an `XWorker` on the main thread that automatically handle errors visually, so this is  required step forward to provide better errors handling in general.

## Changes

  * implement a super early listener for `message` that contains errors as only `data` point
  * add `try/catch` all over worker evaluation and/or bootstrap
  * tested manually that either JS or Python are able to forward events from a worker

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
