### PR TITLE
fix interpreter absoluteURL

### DIFF
--- a/pyscript.core/esm/loader.js
+++ b/pyscript.core/esm/loader.js
@@ -15,8 +15,10 @@ export const getRuntime = (id, config) => {
         /* c8 ignore start */
         if (config.endsWith(".json")) {
             options = fetch(config).then(getJSON);
+            config = absoluteURL(config);
         } else if (config.endsWith(".toml")) {
             options = fetch(config).then(getText).then(parse);
+            config = absoluteURL(config);
         } else {
             try {
                 options = JSON.parse(config);


### PR DESCRIPTION
## Description

Fix [baseURL](https://github.com/pyscript/pyscript/blob/next/pyscript.core/esm/interpreters.js#L34) passing in absoluteURL call which is used by [URL](https://github.com/pyscript/pyscript/blob/next/pyscript.core/esm/interpreter/_utils.js#L123)

## Changes

<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
