### PR TITLE
Fix #1577: Change script sources that include Cross-Origin Resource P…

### DIFF
--- a/examples/d3.html
+++ b/examples/d3.html
@@ -10,7 +10,7 @@
         />
         <script defer src="https://pyscript.net/latest/pyscript.js"></script>
         <link rel="stylesheet" href="./assets/css/examples.css" />
-        <script src="https://d3js.org/d3.v7.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
         <style>
             .loading {
                 display: inline-block;

--- a/examples/panel_deckgl.html
+++ b/examples/panel_deckgl.html
@@ -17,18 +17,18 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/widgets.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/widgets.css"
             type="text/css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/markdown.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/markdown.css"
             type="text/css"
         />
 
         <script
             type="text/javascript"
-            src="https://unpkg.com/h3-js@3.7.2/dist/h3-js.umd.js"
+            src="https://cdn.jsdelivr.net/npm/h3-js@3.7.2/dist/h3-js.umd.js"
         ></script>
         <script
             type="text/javascript"
@@ -52,7 +52,7 @@
         ></script>
         <script
             type="text/javascript"
-            src="https://api.mapbox.com/mapbox-gl-js/v2.6.1/mapbox-gl.js"
+            src="https://cdn.jsdelivr.net/npm/mapbox-gl@2.6.1/dist/mapbox-gl.min.js"
         ></script>
         <script
             type="text/javascript"
@@ -68,7 +68,7 @@
         ></script>
         <script
             type="text/javascript"
-            src="https://unpkg.com/@holoviz/panel@0.13.1/dist/panel.js"
+            src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/panel.js"
         ></script>
 
         <link
@@ -77,11 +77,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
         />
 
         <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script>

--- a/examples/panel_kmeans.html
+++ b/examples/panel_kmeans.html
@@ -17,12 +17,12 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/widgets.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/widgets.css"
             type="text/css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/markdown.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/markdown.css"
             type="text/css"
         />
 
@@ -40,7 +40,7 @@
         ></script>
         <script
             type="text/javascript"
-            src="https://unpkg.com/tabulator-tables@4.9.3/dist/js/tabulator.js"
+            src="https://cdn.jsdelivr.net/npm/tabulator-tables@4.9.3/dist/js/tabulator.js"
         ></script>
         <script
             type="text/javascript"
@@ -56,7 +56,7 @@
         ></script>
         <script
             type="text/javascript"
-            src="https://unpkg.com/@holoviz/panel@0.13.1/dist/panel.min.js"
+            src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/panel.min.js"
         ></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
@@ -68,11 +68,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
         />
 
         <style>

--- a/examples/panel_stream.html
+++ b/examples/panel_stream.html
@@ -17,18 +17,18 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/widgets.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/widgets.css"
             type="text/css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/css/markdown.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/css/markdown.css"
             type="text/css"
         />
 
         <script
             type="text/javascript"
-            src="https://unpkg.com/tabulator-tables@4.9.3/dist/js/tabulator.js"
+            src="https://cdn.jsdelivr.net/npm/tabulator-tables@4.9.3/dist/js/tabulator.js"
         ></script>
         <script
             type="text/javascript"
@@ -44,7 +44,7 @@
         ></script>
         <script
             type="text/javascript"
-            src="https://unpkg.com/@holoviz/panel@0.13.1/dist/panel.min.js"
+            src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/panel.min.js"
         ></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
@@ -56,11 +56,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/bootstraptemplate/bootstrap.css"
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
+            href="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.1/dist/bundled/defaulttheme/default.css"
         />
 
         <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script>


### PR DESCRIPTION
## Description
The cause of this issue is due to resources not having `Cross-Origin Resource-Policy` set. This causes the following examples to be broken:

- Simple d3 visualization (As an example, https://d3js.org/d3.v7.min.js does not have Cross-Origin Resource-Policy set)
- KMeans Demo in Panel
- Streaming Demo in Panel
- NYC Taxi Data Panel DeckGL Demo

<img width="886" alt="CORP" src="https://github.com/pyscript/pyscript/assets/6651691/9afb1a49-297d-45f1-a840-3baeac3acb89">

I have updated the sources that include the Cross-Origin Resource-Policy header. However, if the dependent sources fetch some other resources that do not have Cross-Origin Resource-Policy set, it will still fail to fetch. An error of this type occurs while fetching `tabulator_simple.min.css`, which is required by `panel.min.js` in the `KMeans Demo in Panel` or `Streaming Demo in Panel`. However, the examples won't be fundamentally broken after this fix.


## Changes

Updated script sources.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [x] I have updated `docs/changelog.md` (I don't think it is required in this case)
-   [x] I have created documentation for this(if applicable) (Not applicable)
