### PR TITLE
[next] Fix #1675 - use `async` runner in py-script too

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,12 +11,12 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.2.5"
+                "polyscript": "^0.3.0"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
                 "@rollup/plugin-terser": "^0.4.3",
-                "rollup": "^3.28.1",
+                "rollup": "^3.29.0",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.2",
@@ -935,9 +935,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.2.5.tgz",
-            "integrity": "sha512-c2q4EyvMMdmIH0e85rF7I+fefX0YfEq2g9hzzMeLMOiYcGap04SobVlGO5oDP1KW/k0rFHBR6wN68kzRKOcixA==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.3.0.tgz",
+            "integrity": "sha512-kdB6yXuYFh86XqHaA28gSIgeNqVVIBq/8fyuPBwlXuF339fNrzFmXAi8KadC7LIdllO4p0WgQKPMnBqRd9wmdg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
@@ -1550,9 +1550,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.28.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
-            "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+            "version": "3.29.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.0.tgz",
+            "integrity": "sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -33,12 +33,12 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.2.5"
+        "polyscript": "^0.3.0"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.3",
-        "rollup": "^3.28.1",
+        "rollup": "^3.29.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.2",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -215,10 +215,11 @@ class PyScriptElement extends HTMLElement {
     async connectedCallback() {
         if (!this.executed) {
             this.executed = true;
-            const { io, run } = await this._pyodide.promise;
+            const { io, run, runAsync } = await this._pyodide.promise;
+            const runner = this.hasAttribute("async") ? runAsync : run;
             this.srcCode = await fetchSource(this, io, !this.childElementCount);
             this.replaceChildren();
-            run(this.srcCode);
+            runner(this.srcCode);
             this.style.display = "block";
         }
     }

--- a/pyscript.core/test/async.html
+++ b/pyscript.core/test/async.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script type="module" src="../core.js"></script>
+    </head>
+    <body>
+        <py-script async>
+            import asyncio
+            print('foo')
+            await asyncio.sleep(1)
+            print('bar')
+        </py-script>
+    </body>
+</html>


### PR DESCRIPTION
## Description

This MR addresses [this issue](https://github.com/pyscript/pyscript/issues/1675) working on `<script>` but not on `<py-script>`.

## Changes

  * ensure `<py-script>` custom elements also run async code when `async` attribute is present
  * update *polyscript* to latest

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
