### PR TITLE
[next] Cumulative pre-release patches

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.8",
+            "version": "0.1.9",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.3.0"
+                "polyscript": "^0.3.1"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
@@ -282,9 +282,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001527",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
-            "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
+            "version": "1.0.30001528",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001528.tgz",
+            "integrity": "sha512-0Db4yyjR9QMNlsxh+kKWzQtkyflkG/snYheSzkjmvdEtEXB1+jt7A2HmSEiO6XIJPIbo92lHNGNySvE5pZcs5Q==",
             "dev": true,
             "funding": [
                 {
@@ -315,6 +315,14 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/codedent": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/codedent/-/codedent-0.1.2.tgz",
+            "integrity": "sha512-qEqzcy5viM3UoCN0jYHZeXZoyd4NZQzYFg0kOBj8O1CgoGG9WYYTF+VeQRsN0OSKFjF3G1u4WDUOtOsWEx6N2w==",
+            "dependencies": {
+                "plain-tag": "^0.1.3"
             }
         },
         "node_modules/coincident": {
@@ -589,9 +597,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.508",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-            "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==",
+            "version": "1.4.510",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.510.tgz",
+            "integrity": "sha512-xPfLIPFcN/WLXBpQ/K4UgE98oUBO5Tia6BD4rkSR0wE7ep/PwBVlgvPJQrIBpmJGVAmUzwPKuDbVt9XV6+uC2g==",
             "dev": true
         },
         "node_modules/entities": {
@@ -934,14 +942,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/plain-tag": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/plain-tag/-/plain-tag-0.1.3.tgz",
+            "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
+        },
         "node_modules/polyscript": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.3.0.tgz",
-            "integrity": "sha512-kdB6yXuYFh86XqHaA28gSIgeNqVVIBq/8fyuPBwlXuF339fNrzFmXAi8KadC7LIdllO4p0WgQKPMnBqRd9wmdg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.3.1.tgz",
+            "integrity": "sha512-9cePhhLMgcUfnBbx8l7zv4N4ZRU18rtJ2QHM0hhoEBeu+Nist485rZ0/n/cLR04xi3yDqifvNWjl+g/Tkx4gnQ==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
+                "codedent": "^0.1.2",
                 "coincident": "^0.11.5"
             }
         },
@@ -1855,9 +1869,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.0.tgz",
+            "integrity": "sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==",
             "optional": true,
             "engines": {
                 "node": ">=10.0.0"

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "type": "module",
     "description": "PyScript",
     "module": "./dist/core.js",
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "server": "npx static-handler --cors --coep --coop --corp .",
-        "build": "node rollup/stdlib.cjs && node rollup/plugins.cjs && rollup --config rollup/core.config.js && npm run ts",
+        "build": "node rollup/stdlib.cjs && node rollup/plugins.cjs && rm -rf dist && rollup --config rollup/core.config.js && npm run ts",
         "ts": "tsc -p ."
     },
     "keywords": [
@@ -29,7 +29,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.3.0"
+        "polyscript": "^0.3.1"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -1,7 +1,6 @@
 import "@ungap/with-resolvers";
 import { $ } from "basic-devtools";
 import { define, XWorker } from "polyscript";
-import { htmlDecode } from "./utils.js";
 import sync from "./sync.js";
 
 import stdlib from "./stdlib.js";
@@ -10,6 +9,7 @@ import plugins from "./plugins.js";
 // TODO: this is not strictly polyscript related but handy ... not sure
 //       we should factor this utility out a part but this works anyway.
 import { queryTarget } from "../node_modules/polyscript/esm/script-handler.js";
+import { dedent } from "../node_modules/polyscript/esm/utils.js";
 import { Hook } from "../node_modules/polyscript/esm/worker/hooks.js";
 
 import { robustFetch as fetch } from "./fetch.js";
@@ -65,14 +65,14 @@ const fetchSource = async (tag, io, asText) => {
         }
     }
 
-    if (asText) return tag.textContent;
+    if (asText) return dedent(tag.textContent);
 
     console.warn(
         'Deprecated: use <script type="py"> for an always safe content parsing:\n',
         tag.innerHTML,
     );
 
-    return htmlDecode(tag.innerHTML);
+    return dedent(tag.innerHTML);
 };
 
 // common life-cycle handlers for any node
@@ -128,13 +128,18 @@ export const hooks = {
 
 const workerHooks = {
     codeBeforeRunWorker: () =>
-        [stdlib, ...hooks.codeBeforeRunWorker].join("\n"),
+        [stdlib, ...hooks.codeBeforeRunWorker].map(dedent).join("\n"),
     codeBeforeRunWorkerAsync: () =>
-        [stdlib, ...hooks.codeBeforeRunWorkerAsync].join("\n"),
-    codeAfterRunWorker: () => [...hooks.codeAfterRunWorker].join("\n"),
+        [stdlib, ...hooks.codeBeforeRunWorkerAsync].map(dedent).join("\n"),
+    codeAfterRunWorker: () =>
+        [...hooks.codeAfterRunWorker].map(dedent).join("\n"),
     codeAfterRunWorkerAsync: () =>
-        [...hooks.codeAfterRunWorkerAsync].join("\n"),
+        [...hooks.codeAfterRunWorkerAsync].map(dedent).join("\n"),
 };
+
+// avoid running further script if the previous one had
+// some import that would inevitably delay its execution
+let queuePlugins;
 
 // define the module as both `<script type="py">` and `<py-script>`
 define("py", {
@@ -172,7 +177,14 @@ define("py", {
                 toBeAwaited.push(value());
         }
 
-        if (toBeAwaited.length) await Promise.all(toBeAwaited);
+        // this grants queued results when first script/tag has plugins
+        // and the second one *might* rely on first tag execution
+        if (toBeAwaited.length) {
+            const all = Promise.all(toBeAwaited);
+            queuePlugins = queuePlugins ? queuePlugins.then(() => all) : all;
+        }
+
+        if (queuePlugins) await queuePlugins;
 
         // allows plugins to do whatever they want with the element
         // before regular stuff happens in here

--- a/pyscript.core/src/plugins/error.js
+++ b/pyscript.core/src/plugins/error.js
@@ -17,6 +17,11 @@ hooks.onBeforeRun.add(function override(pyScript) {
         // still let other plugins or PyScript itself do the rest
         return stderr(...args);
     };
+
+    // be sure uncaught Python errors are also visible
+    addEventListener("error", ({ message }) => {
+        if (message.startsWith("Uncaught PythonError")) notify(message);
+    });
 });
 
 // Error hook utilities

--- a/pyscript.core/src/utils.js
+++ b/pyscript.core/src/utils.js
@@ -1,6 +1,0 @@
-const entity = { "<": "&lt;", ">": "&gt;" };
-const escape = (str) => str.replace(/[<>]/g, (key) => entity[key]);
-
-export const htmlDecode = (html) =>
-    new DOMParser().parseFromString(escape(html), "text/html").documentElement
-        .textContent;

--- a/pyscript.core/test/click.html
+++ b/pyscript.core/test/click.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PyScript Next Plugin Bug?</title>
+  <link rel="stylesheet" href="../dist/core.css">
+  <script type="module" src="../dist/core.js"></script>
+</head>
+<body>
+  <script type="py">
+    from pyscript import display, document
+    from datetime import datetime as dt
+    from pyodide.ffi.wrappers import add_event_listener
+
+    element = document.querySelector("#just-a-button")
+
+    def on_click(event):
+      print(f"Hello from Python! {dt.now()}")
+      display(f"Hello from Python! {dt.now()}", append=False, target='eresult')
+
+    add_event_listener(element, "click", on_click)
+  </script>
+
+  <button id="just-a-button">click and check the console</button>
+
+  <div id="result"></div>
+</body>
+</html>


### PR DESCRIPTION
Fix #1680

## Description

This MR fixes uncaught errors at distance + other issues spotted while investigating the *error* issue.

## Changes

  * updated *polyscript* to its latest which fixes all the code indentation issues, needed to avoid issues with foreign hooks for workers too
  * updated *code* to also use the very same tiny utility that apply dedent to foreign hooks and nodes (as their content) to be sure all code always starts from `0` spaces as indentation
  * added bug details to [this pyodide issue](https://github.com/pyodide/pyodide/issues/3938#issuecomment-1709848457)
  * added a workaround in *core* to be sure we also catch uncaught errors from Pyodide and forward these to our notification mechanism
  * added @fpliger test to smoke-test everything works as expected
  * fixed an unordered race condition introduced by lazy plugins where the first script would wait for plugins to be resolved while the second one might execute sooner instead and tested that's always the case and the order is granted as it was before plugins introduction
  * added a *cleanup* build step to avoid having locally undesired and confusing `dist/*` entries on updates and be sure we never publish unintended artifacts to *npm*

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
