### PR TITLE
[next] Follow up on stderr

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "type": "module",
     "description": "PyScript",
     "module": "./dist/core.js",

--- a/pyscript.core/src/plugins/error.js
+++ b/pyscript.core/src/plugins/error.js
@@ -9,13 +9,10 @@ hooks.onBeforeRun.add(function override(pyScript) {
     const { stderr } = pyScript.io;
 
     // override it with our own logic
-    pyScript.io.stderr = (...args) => {
-        // grab the message of the first argument (Error)
-        const [{ message }] = args;
-        // show it
-        notify(message);
-        // still let other plugins or PyScript itself do the rest
-        return stderr(...args);
+    pyScript.io.stderr = (error, ...rest) => {
+        notify(error.message || error);
+        // let other plugins or stderr hook, if any, do the rest
+        return stderr(error, ...rest);
     };
 
     // be sure uncaught Python errors are also visible


### PR DESCRIPTION
## Description

After landing https://github.com/pyscript/pyscript/pull/1682 I've realized we are currently assuming the first argument of `stderr` is an instance of *Error*, but actually the `stderr` can be an explicit `string` too if used as explicit target in Python (i.e. print to stderr).

Accordingly, we need to be sure if that's the case, we still handle / show such error as expected, otherwise it'd be `undefined` in the banner.

## Changes

  * use `error` argument as it is, reaching `.message` if available, falling back to the `error` itself if not

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
