### PR TITLE
[next] Use all jsdelivr suggested fields for CDN

### DIFF
--- a/pyscript.core/index.js
+++ b/pyscript.core/index.js
@@ -1,0 +1,1 @@
+export * from "./dist/core.js";

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.11",
+    "version": "0.1.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.11",
+            "version": "0.1.15",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,10 +1,13 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.11",
+    "version": "0.1.15",
     "type": "module",
     "description": "PyScript",
-    "module": "./dist/core.js",
-    "unpkg": "./dist/core.js",
+    "module": "./index.js",
+    "unpkg": "./index.js",
+    "jsdelivr": "./index.js",
+    "browser": "./index.js",
+    "main": "./index.js",
     "exports": {
         ".": {
             "types": "./types/core.d.ts",


### PR DESCRIPTION
## Description

This MR adds all [suggested fields](https://github.com/jsdelivr/jsdelivr#publishing-packages) to hint CDNs where to find our entry point for `@pyscript/core` hopefully simplifying the URL to remember whenever we'd like to import it in our documentations, without needing to write the whole thing.

This issue is also related: https://github.com/pyscript/pyscript/issues/1688

## Changes

  * added all *recommended* fields to the package
  * used a dummy `index.js` file to avoid redirect issues in *unpkg* and *esm-run*

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
