### PR TITLE
[next] try workaround explicit for jsdelivr

### DIFF
--- a/pyscript.core/jsdelivr.js
+++ b/pyscript.core/jsdelivr.js
@@ -1,0 +1,2 @@
+// @see https://github.com/jsdelivr/jsdelivr/issues/18528
+export * from "./core/dist/core.js";

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.15",
+    "version": "0.1.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.15",
+            "version": "0.1.17",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,11 +1,11 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.15",
+    "version": "0.1.17",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
     "unpkg": "./index.js",
-    "jsdelivr": "./index.js",
+    "jsdelivr": "./jsdelivr.js",
     "browser": "./index.js",
     "main": "./index.js",
     "exports": {


### PR DESCRIPTION
## Description

This MR tries to avoid the https://github.com/jsdelivr/jsdelivr/issues/18528 issue for the time being.

## Changes

  * explicitly point at non-existent folder structure due missing redirect in jsdelivr
  * bump patch version to wait for the CDN to catch-up on this change
  * confirm manually that `https://cdn.jsdelivr.net/npm/@pyscript/core@latest` ow returns, and produces, the expected result

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
