### PR TITLE
[next] py-config + py-script invisible by default

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -224,7 +224,13 @@ define("py", {
     },
 });
 
-class PyScriptElement extends HTMLElement {
+class PyConfigElement extends HTMLElement {
+    constructor() {
+        super().style.display = "none";
+    }
+}
+
+class PyScriptElement extends PyConfigElement {
     constructor() {
         assign(super(), {
             _pyodide: Promise.withResolvers(),
@@ -251,6 +257,7 @@ class PyScriptElement extends HTMLElement {
     }
 }
 
+customElements.define("py-config", PyConfigElement);
 customElements.define("py-script", PyScriptElement);
 
 /**


### PR DESCRIPTION
## Description

This MR simplifies some quick testing/prototyping by making custom elements invisible by default.

## Changes

  * make both `<py-config>` and `<py-script>` elements invisible as soon as bootstrapped

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
