### PR TITLE
[next] Bootstrap plugins directly

### DIFF
--- a/pyscript.core/rollup/plugins.cjs
+++ b/pyscript.core/rollup/plugins.cjs
@@ -10,7 +10,11 @@ for (const file of readdirSync(join(__dirname, "..", "src", "plugins"))) {
             ? name
             : `[${JSON.stringify(name)}]`;
         const value = JSON.stringify(`./plugins/${file}`);
-        plugins.push(`    ${key}: () => import(${value}),`);
+        plugins.push(
+            // this comment is needed to avoid bundlers eagerly embedding lazy
+            // dependencies, causing all sort of issues once in production
+            `    ${key}: () => import(/* webpackIgnore: true */ ${value}),`,
+        );
     }
 }
 

--- a/pyscript.core/src/config.js
+++ b/pyscript.core/src/config.js
@@ -1,0 +1,44 @@
+/**
+ * This file parses a generic <py-config> or config attribute
+ * to use as base config for all py-script elements, importing
+ * also a queue of plugins *before* the interpreter (if any) resolves.
+ */
+import { $ } from "basic-devtools";
+
+import allPlugins from "./plugins.js";
+import { robustFetch as fetch, getText } from "./fetch.js";
+
+// TODO: this is not strictly polyscript related but handy ... not sure
+//       we should factor this utility out a part but this works anyway.
+import { parse } from "../node_modules/polyscript/esm/toml.js";
+
+// find the shared config for all py-script elements
+let config, plugins, parsed;
+let pyConfig = $("py-config");
+if (pyConfig) config = pyConfig.getAttribute("src") || pyConfig.textContent;
+else {
+    pyConfig = $('script[type="py"][config]');
+    if (pyConfig) config = pyConfig.getAttribute("config");
+}
+
+// load its content if remote
+if (/^https?:\/\//.test(config)) config = await fetch(config).then(getText);
+
+// parse config only if not empty
+if (config?.trim()) {
+    try {
+        parsed = JSON.parse(config);
+    } catch (_) {
+        parsed = await parse(config);
+    }
+}
+
+// parse all plugins and optionally ignore only
+// those flagged as "undesired" via `!` prefix
+const toBeAwaited = [];
+for (const [key, value] of Object.entries(allPlugins)) {
+    if (!parsed?.plugins?.includes(`!${key}`)) toBeAwaited.push(value());
+}
+if (toBeAwaited.length) plugins = Promise.all(toBeAwaited);
+
+export { config, plugins };

--- a/pyscript.core/src/fetch.js
+++ b/pyscript.core/src/fetch.js
@@ -1,4 +1,7 @@
 import { FetchError, ErrorCode } from "./exceptions.js";
+import { getText } from "../node_modules/polyscript/esm/fetch-utils.js";
+
+export { getText };
 
 /**
  * This is a fetch wrapper that handles any non 200 responses and throws a

--- a/pyscript.core/src/plugins.js
+++ b/pyscript.core/src/plugins.js
@@ -1,4 +1,4 @@
 // ⚠️ This file is an artifact: DO NOT MODIFY
 export default {
-    error: () => import("./plugins/error.js"),
+    error: () => import(/* webpackIgnore: true */ "./plugins/error.js"),
 };

--- a/pyscript.core/types/config.d.ts
+++ b/pyscript.core/types/config.d.ts
@@ -1,0 +1,2 @@
+export let config: any;
+export let plugins: any;

--- a/pyscript.core/types/core.d.ts
+++ b/pyscript.core/types/core.d.ts
@@ -21,6 +21,5 @@ export namespace hooks {
     let codeAfterRunWorker: Set<string>;
     let codeAfterRunWorkerAsync: Set<string>;
 }
-declare let config: any;
+import { config } from "./config.js";
 import sync from "./sync.js";
-export {};

--- a/pyscript.core/types/fetch.d.ts
+++ b/pyscript.core/types/fetch.d.ts
@@ -8,3 +8,4 @@
  * @returns {Promise<Response>}
  */
 export function robustFetch(url: string, options?: Request): Promise<Response>;
+export { getText };


### PR DESCRIPTION
## Description

Fix https://github.com/pyscript/pyscript/issues/1697

This MR normalizes the shared `py-config` across all scripts/tags as custom `py-script` type, bootstrapping all default plugins, unless specified otherwise, out of the box and *before* the interpreter resolves / is ready.

This MR indirectly fixes the assumption every element could've used a different config, as that was an error-prone slippery slope anyway, and it grants that on the main thread only one *py-config* would dictate the rules.

This MR still allows different workers to have a different config, with different plugins, as those won't ever interfere with each others, and each worker might, or might not, use one or more package within its own execution (virtual) environment.

Last, but not least, this MR allows worker to be sure default plugins from core landed on the page, enabling progress around this issue https://github.com/pyscript/pyscript/issues/1678

## Changes

  * move the plugins bootstrap into a delegated `config.js` file which responsibility is to provide the config to the interpreter **and** to bootstrap all default plugins that are not explicitly disabled
  * reuse as much as possible *polyscript* internals to avoid bloating the library. **follow-up**: should *polyscript* export much more than it does now, maybe as explicit "*foreign-utilities.js*" file? **edit** follow up - https://github.com/pyscript/polyscript/issues/35
  * pass along an already parsed *config* to *polyscript* avoiding double processing for it. **follow-up** workers can accept a *config* as pre-defined object literal only in workers; it might be beneficial in general to change *polyscript* there and allow passing an object also for main-thread custom types, as these are defined imperatively and not necessarily out of attributes when `define(CUSTOM_TYPE, ...)` is used - **edit** follow up https://github.com/pyscript/polyscript/issues/34

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
