### PR TITLE
[next] Errors on ambiguous/conflicting code intents

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.21",
+            "version": "0.1.22",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/exceptions.js
+++ b/pyscript.core/src/exceptions.js
@@ -7,19 +7,20 @@ const CLOSEBUTTON =
  */
 export const ErrorCode = {
     GENERIC: "PY0000", // Use this only for development then change to a more specific error code
-    FETCH_ERROR: "PY0001",
-    FETCH_NAME_ERROR: "PY0002",
-    // Currently these are created depending on error code received from fetching
-    FETCH_UNAUTHORIZED_ERROR: "PY0401",
-    FETCH_FORBIDDEN_ERROR: "PY0403",
-    FETCH_NOT_FOUND_ERROR: "PY0404",
-    FETCH_SERVER_ERROR: "PY0500",
-    FETCH_UNAVAILABLE_ERROR: "PY0503",
+    CONFLICTING_CODE: "PY0409",
     BAD_CONFIG: "PY1000",
     MICROPIP_INSTALL_ERROR: "PY1001",
     BAD_PLUGIN_FILE_EXTENSION: "PY2000",
     NO_DEFAULT_EXPORT: "PY2001",
     TOP_LEVEL_AWAIT: "PY9000",
+    // Currently these are created depending on error code received from fetching
+    FETCH_ERROR: "PY0001",
+    FETCH_NAME_ERROR: "PY0002",
+    FETCH_UNAUTHORIZED_ERROR: "PY0401",
+    FETCH_FORBIDDEN_ERROR: "PY0403",
+    FETCH_NOT_FOUND_ERROR: "PY0404",
+    FETCH_SERVER_ERROR: "PY0500",
+    FETCH_UNAVAILABLE_ERROR: "PY0503",
 };
 
 export class UserError extends Error {

--- a/pyscript.core/test/error.html
+++ b/pyscript.core/test/error.html
@@ -14,5 +14,9 @@
     print(4, 5, 6)
     second()
   </py-script>
+  <py-script src="whatever.py">
+    print(4, 5, 6)
+    second()
+  </py-script>
 </head>
 </html>

--- a/pyscript.core/test/no-error.html
+++ b/pyscript.core/test/no-error.html
@@ -15,5 +15,9 @@
     print(4, 5, 6)
     second()
   </py-script>
+  <py-script src="whatever.py">
+    print(4, 5, 6)
+    second()
+  </py-script>
 </head>
 </html>

--- a/pyscript.core/types/exceptions.d.ts
+++ b/pyscript.core/types/exceptions.d.ts
@@ -1,6 +1,12 @@
 export function _createAlertBanner(message: any, level: any, messageType?: string, logMessage?: boolean): void;
 export namespace ErrorCode {
     let GENERIC: string;
+    let CONFLICTING_CODE: string;
+    let BAD_CONFIG: string;
+    let MICROPIP_INSTALL_ERROR: string;
+    let BAD_PLUGIN_FILE_EXTENSION: string;
+    let NO_DEFAULT_EXPORT: string;
+    let TOP_LEVEL_AWAIT: string;
     let FETCH_ERROR: string;
     let FETCH_NAME_ERROR: string;
     let FETCH_UNAUTHORIZED_ERROR: string;
@@ -8,11 +14,6 @@ export namespace ErrorCode {
     let FETCH_NOT_FOUND_ERROR: string;
     let FETCH_SERVER_ERROR: string;
     let FETCH_UNAVAILABLE_ERROR: string;
-    let BAD_CONFIG: string;
-    let MICROPIP_INSTALL_ERROR: string;
-    let BAD_PLUGIN_FILE_EXTENSION: string;
-    let NO_DEFAULT_EXPORT: string;
-    let TOP_LEVEL_AWAIT: string;
 }
 export class UserError extends Error {
     constructor(errorCode: any, message?: string, messageType?: string);


### PR DESCRIPTION
## Description

This MR addresses the discussion made in https://github.com/pyscript/pyscript/issues/1714 and tests everything works as expected.

## Changes

  * add utilities to verify there is no conflict or weird / ambiguous behavior when a `<py-script>` or `<script type="py">` node has both content and either an `src` attribute or a non empty `worker` one
  * tested manually everything actually works as expected

**Note** we still don't have full support for plugins and/or errors coming from workers use cases so this does not produce the same result with workers, but it's setup to do so.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
