### PR TITLE
Add `pexpect` to environment.yml

### DIFF
--- a/pyscriptjs/environment.yml
+++ b/pyscriptjs/environment.yml
@@ -19,6 +19,7 @@ dependencies:
           - playwright==1.33.0
           - pytest-playwright==0.3.3
           - pytest-xdist==3.3.0
+          - pexpect
           # We need Pyodide and micropip so we can import them in our Python
           # unit tests
           - pyodide_py==0.23.2


### PR DESCRIPTION
## Description

Adds the pexpect package to the conda environment file, which it seems is required to run the integration tests but not included on a clean install.

(Tests were working fine on my normal computer, but not on a fresh install)

<details>
<summary> Full Console Error Output </summary>
<p>

```
(/home/jglass/Documents/pyscript/pyscriptjs/env) jglass@jglass-XPS-8930:~/Documents/pyscript$ make test-integration
mkdir -p test_results
cd pyscript.core && /home/jglass/Documents/pyscript/pyscriptjs/env/bin/pytest -vv  tests/integration/ --log-cli-level=warning --junitxml=../integration.xml
Traceback (most recent call last):
  File "/home/jglass/Documents/pyscript/pyscriptjs/env/bin/pytest", line 11, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 189, in console_main
    code = main()
           ^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 147, in main
    config = _prepareconfig(args, plugins)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 328, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_hooks.py", line 265, in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_callers.py", line 55, in _multicall
    gen.send(outcome)
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/helpconfig.py", line 103, in pytest_cmdline_parse
    config: Config = outcome.get_result()
                     ^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1077, in pytest_cmdline_parse
    self.parse(args)
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1366, in parse
    self._preparse(args, addopts=addopts)
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1249, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/jglass/.local/lib/python3.11/site-packages/pluggy/_manager.py", line 287, in load_setuptools_entrypoints
    plugin = ep.load()
             ^^^^^^^^^
  File "/home/jglass/Documents/pyscript/pyscriptjs/env/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jglass/Documents/pyscript/pyscriptjs/env/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1128, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/home/jglass/.local/lib/python3.11/site-packages/pytest_pyodide/__init__.py", line 3, in <module>
    from .decorator import run_in_pyodide
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/home/jglass/.local/lib/python3.11/site-packages/pytest_pyodide/decorator.py", line 15, in <module>
    from .runner import _BrowserBaseRunner
  File "/home/jglass/.local/lib/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/home/jglass/.local/lib/python3.11/site-packages/pytest_pyodide/runner.py", line 5, in <module>
    import pexpect
ModuleNotFoundError: No module named 'pexpect'
make: *** [Makefile:98: test-integration] Error 1
```

</p>
</details>
