### PR TITLE
Deprecate `srcCode` Attribute

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -208,7 +208,7 @@ class PyScriptElement extends HTMLElement {
     constructor() {
         assign(super(), {
             _pyodide: Promise.withResolvers(),
-            srcCode: "",
+            _srcCode: "",
             executed: false,
         });
     }
@@ -218,16 +218,28 @@ class PyScriptElement extends HTMLElement {
     set id(value) {
         super.id = value;
     }
+
+    get srcCode(){
+        console.warn(
+            `'srcCode' Attribute is Deprecated: use the 'textContent' attribute to retrieve code from a <py-script> or <script type='py'> tag.`,
+        );
+        return this._srcCode;
+    }
+
+    set srcCode(code){
+        this._srcCode = code;
+    }
+
     async connectedCallback() {
         if (!this.executed) {
             this.executed = true;
             const { io, run, runAsync } = await this._pyodide.promise;
             const runner = this.hasAttribute("async") ? runAsync : run;
-            this.srcCode = await fetchSource(this, io, !this.childElementCount);
+            this._srcCode = await fetchSource(this, io, !this.childElementCount);
             this.replaceChildren();
             // notify before the code runs
             dispatch(this, TYPE);
-            runner(this.srcCode);
+            runner(this._srcCode);
             this.style.display = "block";
         }
     }

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -70,9 +70,9 @@ class TestBasic(PyScriptTest):
     def test_print(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 print('hello pyscript')
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "hello pyscript"
@@ -80,10 +80,10 @@ class TestBasic(PyScriptTest):
     def test_python_exception(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 print('hello pyscript')
                 raise Exception('this is an error')
-            </py-script>
+            </script>
         """
         )
         assert "hello pyscript" in self.console.log.lines
@@ -106,10 +106,10 @@ class TestBasic(PyScriptTest):
         self.pyscript_run(
             """
             <button py-click="onclick">Click me</button>
-            <py-script>
+            <script type="py">
                 def onclick(event):
                     raise Exception("this is an error inside handler")
-            </py-script>
+            </script>
         """
         )
 
@@ -131,15 +131,15 @@ class TestBasic(PyScriptTest):
 
     def test_execution_in_order(self):
         """
-        Check that they py-script tags are executed in the same order they are
+        Check that they script py tags are executed in the same order they are
         defined
         """
         self.pyscript_run(
             """
-            <py-script>import js; js.console.log('one')</py-script>
-            <py-script>js.console.log('two')</py-script>
-            <py-script>js.console.log('three')</py-script>
-            <py-script>js.console.log('four')</py-script>
+            <script type="py">import js; js.console.log('one')</script>
+            <script type="py">js.console.log('two')</script>
+            <script type="py">js.console.log('three')</script>
+            <script type="py">js.console.log('four')</script>
         """
         )
         assert self.console.log.lines[-4:] == [
@@ -151,16 +151,21 @@ class TestBasic(PyScriptTest):
 
     def test_escaping_of_angle_brackets(self):
         """
-        Check that py-script tags escape angle brackets
+        Check that script tags escape angle brackets
         """
         self.pyscript_run(
             """
-            <py-script>import js; js.console.log(1<2, 1>2)</py-script>
-            <py-script>js.console.log("<div></div>")</py-script>
+            <script type="py">import js; js.console.log("A", 1<2, 1>2)</script>
+            <script type="py">js.console.log("B <div></div>")</script>
+            <py-script>import js; js.console.log("C", 1<2, 1>2)</py-script>
+            <py-script>js.console.log("D <div></div>")</py-script>
+
         """
         )
-
-        assert self.console.log.lines[-2:] == ["true false", "<div></div>"]
+        assert self.console.log.lines[-4:] == ["A true false",
+                                               "B <div></div>",
+                                               "C true false",
+                                               "D <div></div>"]
 
     @pytest.mark.skip(reason="FIX TEST: Works on CHROME")
     def test_packages(self):
@@ -169,11 +174,11 @@ class TestBasic(PyScriptTest):
             <py-config>
                 packages = ["asciitree"]
             </py-config>
-            <py-script>
+            <script type="py">
                 import js
                 import asciitree
                 js.console.log('hello', asciitree.__name__)
-            </py-script>
+            </script>
             """
         )
 
@@ -183,7 +188,7 @@ class TestBasic(PyScriptTest):
             "hello asciitree",  # printed by us
         ]
 
-    # TODO: if there's no py-script there are surely no plugins neither
+    # TODO: if there's no <script type="py"> there are surely no plugins neither
     #       this test must be discussed or rewritten to make sense now
     @pytest.mark.skip("FIXME: No banner")
     def test_non_existent_package(self):
@@ -206,7 +211,7 @@ class TestBasic(PyScriptTest):
         assert expected_alert_banner_msg in alert_banner.inner_text()
         self.check_py_errors("Can't fetch metadata for 'i-dont-exist'")
 
-    # TODO: if there's no py-script there are surely no plugins neither
+    # TODO: if there's no <script type="py"> there are surely no plugins neither
     #       this test must be discussed or rewritten to make sense now
     @pytest.mark.skip("FIXME: No banner")
     def test_no_python_wheel(self):
@@ -250,7 +255,7 @@ class TestBasic(PyScriptTest):
         self.writefile("foo.py", "print('hello from foo')")
         self.pyscript_run(
             """
-            <py-script src="foo.py"></py-script>
+            <script type="py" src="foo.py"></script>
             """
         )
         assert self.console.log.lines[-1] == "hello from foo"
@@ -258,7 +263,7 @@ class TestBasic(PyScriptTest):
     def test_py_script_src_not_found(self):
         self.pyscript_run(
             """
-            <py-script src="foo.py"></py-script>
+            <script type="py" src="foo.py"></script>
             """,
             check_js_errors=False,
         )
@@ -269,7 +274,7 @@ class TestBasic(PyScriptTest):
         # assert any((expected_msg in line) for line in self.console.js_error.lines)
         # assert self.assert_banner_message(expected_msg)
 
-        # pyscript_tag = self.page.locator("py-script")
+        # pyscript_tag = self.page.locator("script-py")
         # assert pyscript_tag.inner_html() == ""
 
         # self.check_js_errors(expected_msg)
@@ -279,8 +284,8 @@ class TestBasic(PyScriptTest):
     def test_js_version(self):
         self.pyscript_run(
             """
-            <py-script>
-            </py-script>
+            <script type="py">
+            </script>
             """
         )
         self.page.add_script_tag(content="console.log(pyscript.version)")
@@ -295,11 +300,11 @@ class TestBasic(PyScriptTest):
     def test_python_version(self):
         self.pyscript_run(
             """
-        <py-script>
+        <script type="py">
             import js
             js.console.log(pyscript.__version__)
             js.console.log(str(pyscript.version_info))
-        </py-script>
+        </script>
         """
         )
         assert (
@@ -321,35 +326,39 @@ class TestBasic(PyScriptTest):
         """
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 import sys
                 print("hello world", file=sys.stderr)
-            </py-script>
+            </script>
             """
         )
 
         assert self.page.locator(".py-error").inner_text() == "hello world"
 
+    @pytest.mark.skip("this works for py-script but not for script py")
     def test_getPySrc_returns_source_code(self):
         self.pyscript_run(
             """
-            <py-script>print("hello world!")</py-script>
+            <py-script>print("hello from py-script")</py-script>
+            <script type="py">print("hello from script py")</script>
             """
         )
-
         pyscript_tag = self.page.locator("py-script")
         assert pyscript_tag.inner_html() == ""
-        assert pyscript_tag.evaluate("node => node.srcCode") == 'print("hello world!")'
+        assert pyscript_tag.evaluate("node => node.srcCode") == 'print("hello from py-script")'
+        script_py_tag = self.page.locator('script[type="py"]')
+        assert script_py_tag.evaluate("node => node.srcCode") == 'print("hello from script py")'
+
 
     @pytest.mark.skip(reason="FIX TEST: works in chrome!")
     def test_py_attribute_without_id(self):
         self.pyscript_run(
             """
             <button py-click="myfunc">Click me</button>
-            <py-script>
+            <script type="py">
                 def myfunc(event):
                     print("hello world!")
-            </py-script>
+            </script>
             """
         )
         btn = self.page.wait_for_selector("button")

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -335,7 +335,7 @@ class TestBasic(PyScriptTest):
 
         assert self.page.locator(".py-error").inner_text() == "hello world"
 
-    @pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
+    #@pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
     def test_getPySrc_returns_source_code(self):
         self.pyscript_run(
             """
@@ -346,8 +346,10 @@ class TestBasic(PyScriptTest):
         pyscript_tag = self.page.locator("py-script")
         assert pyscript_tag.inner_html() == ""
         assert pyscript_tag.evaluate("node => node.srcCode") == 'print("hello from py-script")'
+        assert "'srcCode' Attribute is Deprecated: use the 'textContent' attribute to retrieve code from a <py-script> or <script type='py'> tag." in self.console.warning.lines
+
         script_py_tag = self.page.locator('script[type="py"]')
-        assert script_py_tag.evaluate("node => node.srcCode") == 'print("hello from script py")'
+        assert script_py_tag.evaluate("node => node.textContent") == 'print("hello from script py")'
 
 
     @pytest.mark.skip(reason="FIX TEST: works in chrome!")

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -6,16 +6,22 @@ from .support import PyScriptTest
 
 
 class TestBasic(PyScriptTest):
-    def test_pyscript_hello(self):
+    def test_script_py_hello(self):
         self.pyscript_run(
             """
             <script type="py">
                 import js
-                js.console.log('hello pyscript')
+                js.console.log('hello from script py')
             </script>
+
+            <py-script>
+                import js
+                js.console.log('hello from py-script')
+            </py-script>
             """
         )
-        assert self.console.log.lines == ["hello pyscript"]
+        assert self.console.log.lines == ["hello from script py",
+                                          "hello from py-script"]
 
     def test_execution_thread(self):
         self.pyscript_run(

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -335,7 +335,6 @@ class TestBasic(PyScriptTest):
 
         assert self.page.locator(".py-error").inner_text() == "hello world"
 
-    #@pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
     def test_getPySrc_returns_source_code(self):
         self.pyscript_run(
             """

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -335,7 +335,7 @@ class TestBasic(PyScriptTest):
 
         assert self.page.locator(".py-error").inner_text() == "hello world"
 
-    @pytest.mark.skip("this works for py-script but not for script py")
+    @pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
     def test_getPySrc_returns_source_code(self):
         self.pyscript_run(
             """

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -148,14 +148,15 @@ class TestDisplay(PyScriptTest):
             <script type="py">
                 from pyscript import display
                 def display_hello():
-                    display('hello', target='second-pyscript-tag')
+                    display('hello', target='output')
             </script>
-            <script type="py" id="second-pyscript-tag">
+            <script type="py">
                 display_hello()
             </script>
+            <div id="output"></div>
             """
         )
-        text = self.page.locator("id=second-pyscript-tag").inner_text()
+        text = self.page.locator("id=output").inner_text()
         assert text == "hello"
 
     def test_explicit_target_on_button_tag(self):
@@ -173,52 +174,31 @@ class TestDisplay(PyScriptTest):
         text = self.page.locator("id=my-button").inner_text()
         assert "hello" in text
 
-    def test_explicit_different_target_from_call(self):
-        self.pyscript_run(
-            """
-            <script type="py" id="first-pyscript-tag">
-                from pyscript import display
-                def display_hello():
-                    display('hello', target='second-pyscript-tag')
-            </script>
-            <script type="py" id="second-pyscript-tag">
-                print('nothing to see here')
-            </script>
-            <script type="py">
-                display_hello()
-            </script>
-        """
-        )
-        text = self.page.locator("id=second-pyscript-tag").all_inner_texts()
-        assert "hello" in text
-
     def test_append_true(self):
         self.pyscript_run(
             """
             <script type="py">
                 from pyscript import display
-                display('hello world', append=True)
+                display('AAA', append=True)
+                display('BBB', append=True)
             </script>
         """
         )
-        node_list = self.page.query_selector_all(DISPLAY_OUTPUT_ID_PATTERN)
-        pattern = r"<div>hello world</div>"
-
-        assert node_list[0].inner_html() == pattern
-        assert len(node_list) == 1
+        output = self.page.locator('script-py')
+        assert output.inner_text() == 'AAA\nBBB'
 
     def test_append_false(self):
         self.pyscript_run(
             """
             <script type="py">
                 from pyscript import display
-                display('hello world', append=False)
+                display('AAA', append=False)
+                display('BBB', append=False)
             </script>
         """
         )
-        inner_html = self.page.content()
-        pattern = r'<script type="py" id="py-.*">hello world</script>'
-        assert re.search(pattern, inner_html)
+        output = self.page.locator('script-py')
+        assert output.inner_text() == 'BBB'
 
     def test_display_multiple_values(self):
         self.pyscript_run(
@@ -231,8 +211,8 @@ class TestDisplay(PyScriptTest):
             </script>
             """
         )
-        inner_text = self.page.inner_text("html")
-        assert inner_text == "hello\nworld"
+        output = self.page.locator('script-py')
+        assert output.inner_text() == "hello\nworld"
 
     def test_display_multiple_append_false(self):
         self.pyscript_run(
@@ -244,9 +224,8 @@ class TestDisplay(PyScriptTest):
             </script>
         """
         )
-        inner_html = self.page.content()
-        pattern = r'<script type="py" id="py-.*">world</script>'
-        assert re.search(pattern, inner_html)
+        output = self.page.locator('script-py')
+        assert output.inner_text() == "world"
 
     # TODO: this is a display.py issue to fix when append=False is used
     #       do not use the first element, just clean up and then append

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -108,22 +108,23 @@ class TestDisplay(PyScriptTest):
     def test_implicit_target_from_a_different_tag(self):
         self.pyscript_run(
             """
-                <script type="py" id="py1">
+                <script type="py">
                     from pyscript import display
                     def say_hello():
                         display('hello')
                 </script>
 
-                <script type="py" id="py2">
+                <script type="py">
                     from pyscript import display
                     say_hello()
                 </script>
             """
         )
-        py1 = self.page.locator("#py1")
-        py2 = self.page.locator("#py2")
-        assert py1.inner_text() == ""
-        assert py2.inner_text() == "hello"
+        elems = self.page.locator("script-py")
+        py0 = elems.nth(0)
+        py1 = elems.nth(1)
+        assert py0.inner_text() == ""
+        assert py1.inner_text() == "hello"
 
     def test_no_explicit_target(self):
         self.pyscript_run(

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -74,11 +74,12 @@ class TestDisplay(PyScriptTest):
                 from pyscript import display
                 display('hello 1')
             </script>
-                <p>hello in between 1 and 2</p>
-            <script type="py" id="second">
+            <p>hello in between 1 and 2</p>
+            <script type="py">
                 from pyscript import display
                 display('hello 2', target="second")
             </script>
+            <p id="second"></p>
             <script type="py" id="third">
                 from pyscript import display
                 display('hello 3')

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -21,11 +21,11 @@ class TestDisplay(PyScriptTest):
     def test_simple_display(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 print('ciao')
                 from pyscript import display
                 display("hello world")
-            </py-script>
+            </script>
             """,
             timeout=20000,
         )
@@ -37,15 +37,15 @@ class TestDisplay(PyScriptTest):
     def test_consecutive_display(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello 1')
-            </py-script>
+            </script>
             <p>hello 2</p>
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello 3')
-            </py-script>
+            </script>
             """
         )
         inner_text = self.page.inner_text("body")
@@ -57,10 +57,10 @@ class TestDisplay(PyScriptTest):
     def test_target_attribute(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello world', target="mydiv")
-            </py-script>
+            </script>
             <div id="mydiv"></div>
             """
         )
@@ -70,19 +70,19 @@ class TestDisplay(PyScriptTest):
     def test_consecutive_display_target(self):
         self.pyscript_run(
             """
-            <py-script id="first">
+            <script type="py" id="first">
                 from pyscript import display
                 display('hello 1')
-            </py-script>
+            </script>
                 <p>hello in between 1 and 2</p>
-            <py-script id="second">
+            <script type="py" id="second">
                 from pyscript import display
                 display('hello 2', target="second")
-            </py-script>
-            <py-script id="third">
+            </script>
+            <script type="py" id="third">
                 from pyscript import display
                 display('hello 3')
-            </py-script>
+            </script>
             """
         )
         inner_text = self.page.inner_text("body")
@@ -93,30 +93,30 @@ class TestDisplay(PyScriptTest):
     def test_multiple_display_calls_same_tag(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello')
                 display('world')
-            </py-script>
+            </script>
         """
         )
-        tag = self.page.locator("py-script")
+        tag = self.page.locator("script-py")
         lines = tag.inner_text().splitlines()
         assert lines == ["hello", "world"]
 
     def test_implicit_target_from_a_different_tag(self):
         self.pyscript_run(
             """
-                <py-script id="py1">
+                <script type="py" id="py1">
                     from pyscript import display
                     def say_hello():
                         display('hello')
-                </py-script>
+                </script>
 
-                <py-script id="py2">
+                <script type="py" id="py2">
                     from pyscript import display
                     say_hello()
-                </py-script>
+                </script>
             """
         )
         py1 = self.page.locator("#py1")
@@ -127,30 +127,30 @@ class TestDisplay(PyScriptTest):
     def test_no_explicit_target(self):
         self.pyscript_run(
             """
-                <py-script>
+                <script type="py">
                     from pyscript import display
                     def display_hello(error):
                         display('hello world')
-                </py-script>
+                </script>
                 <button id="my-button" py-click="display_hello">Click me</button>
             """
         )
         self.page.locator("button").click()
 
-        text = self.page.locator("py-script").text_content()
+        text = self.page.locator("script-py").text_content()
         assert "hello world" in text
 
     def test_explicit_target_pyscript_tag(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 def display_hello():
                     display('hello', target='second-pyscript-tag')
-            </py-script>
-            <py-script id="second-pyscript-tag">
+            </script>
+            <script type="py" id="second-pyscript-tag">
                 display_hello()
-            </py-script>
+            </script>
             """
         )
         text = self.page.locator("id=second-pyscript-tag").inner_text()
@@ -159,11 +159,11 @@ class TestDisplay(PyScriptTest):
     def test_explicit_target_on_button_tag(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 def display_hello(error):
                     display('hello', target='my-button')
-            </py-script>
+            </script>
             <button id="my-button" py-click="display_hello">Click me</button>
         """
         )
@@ -174,17 +174,17 @@ class TestDisplay(PyScriptTest):
     def test_explicit_different_target_from_call(self):
         self.pyscript_run(
             """
-            <py-script id="first-pyscript-tag">
+            <script type="py" id="first-pyscript-tag">
                 from pyscript import display
                 def display_hello():
                     display('hello', target='second-pyscript-tag')
-            </py-script>
-            <py-script id="second-pyscript-tag">
+            </script>
+            <script type="py" id="second-pyscript-tag">
                 print('nothing to see here')
-            </py-script>
-            <py-script>
+            </script>
+            <script type="py">
                 display_hello()
-            </py-script>
+            </script>
         """
         )
         text = self.page.locator("id=second-pyscript-tag").all_inner_texts()
@@ -193,10 +193,10 @@ class TestDisplay(PyScriptTest):
     def test_append_true(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello world', append=True)
-            </py-script>
+            </script>
         """
         )
         node_list = self.page.query_selector_all(DISPLAY_OUTPUT_ID_PATTERN)
@@ -208,25 +208,25 @@ class TestDisplay(PyScriptTest):
     def test_append_false(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello world', append=False)
-            </py-script>
+            </script>
         """
         )
         inner_html = self.page.content()
-        pattern = r'<py-script id="py-.*">hello world</py-script>'
+        pattern = r'<script type="py" id="py-.*">hello world</script>'
         assert re.search(pattern, inner_html)
 
     def test_display_multiple_values(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 hello = 'hello'
                 world = 'world'
                 display(hello, world)
-            </py-script>
+            </script>
             """
         )
         inner_text = self.page.inner_text("html")
@@ -235,15 +235,15 @@ class TestDisplay(PyScriptTest):
     def test_display_multiple_append_false(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display('hello', append=False)
                 display('world', append=False)
-            </py-script>
+            </script>
         """
         )
         inner_html = self.page.content()
-        pattern = r'<py-script id="py-.*">world</py-script>'
+        pattern = r'<script type="py" id="py-.*">world</script>'
         assert re.search(pattern, inner_html)
 
     # TODO: this is a display.py issue to fix when append=False is used
@@ -282,13 +282,13 @@ class TestDisplay(PyScriptTest):
     def test_display_list_dict_tuple(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 l = ['A', 1, '!']
                 d = {'B': 2, 'List': l}
                 t = ('C', 3, '!')
                 display(l, d, t)
-            </py-script>
+            </script>
             """
         )
         inner_text = self.page.inner_text("html")
@@ -299,32 +299,33 @@ class TestDisplay(PyScriptTest):
             == "['A', 1, '!']\n{'B': 2, 'List': ['A', 1, '!']}\n('C', 3, '!')"
         )
 
+    @pytest.mark.skip("The asserts are commented out. Investigate")
     def test_display_should_escape(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 display("<p>hello world</p>")
-            </py-script>
+            </script>
             """
         )
-        # out = self.page.locator("py-script > div")
+        # out = self.page.locator("script-py > div")
         node_list = self.page.query_selector_all(DISPLAY_OUTPUT_ID_PATTERN)
         node_list[0]
         # assert out.inner_html() == html.escape("<p>hello world</p>")
         # assert out.inner_text() == "<p>hello world</p>"
 
-    @pytest.mark.skip("FIXME: HTML has been removed from pyscript")
+    @pytest.mark.skip("The asserts are commented out. Investigate")
     def test_display_HTML(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display, HTML
                 display(HTML("<p>hello world</p>"))
-            </py-script>
+            </script>
             """
         )
-        # out = self.page.locator("py-script > div")
+        # out = self.page.locator("script-py > div")
         node_list = self.page.query_selector_all(DISPLAY_OUTPUT_ID_PATTERN)
         node_list[0]
         # assert out.inner_html() == "<p>hello world</p>"
@@ -339,14 +340,14 @@ class TestDisplay(PyScriptTest):
         self.pyscript_run(
             """
                 <py-config> packages = ["matplotlib"] </py-config>
-                <py-script>
+                <script type="py">
                     from pyscript import display
                     import matplotlib.pyplot as plt
                     xpoints = [3, 6, 9]
                     ypoints = [1, 2, 3]
                     plt.plot(xpoints, ypoints)
                     display(plt)
-                </py-script>
+                </script>
             """
         )
         wait_for_render(self.page, "*", "<img src=['\"]data:image")
@@ -367,13 +368,13 @@ class TestDisplay(PyScriptTest):
     def test_empty_HTML_and_console_output(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 import js
                 print('print from python')
                 js.console.log('print from js')
                 js.console.error('error from js');
-            </py-script>
+            </script>
         """
         )
         inner_html = self.page.content()
@@ -386,17 +387,17 @@ class TestDisplay(PyScriptTest):
     def test_text_HTML_and_console_output(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 import js
                 display('this goes to the DOM')
                 print('print from python')
                 js.console.log('print from js')
                 js.console.error('error from js');
-            </py-script>
+            </script>
         """
         )
-        inner_text = self.page.inner_text("py-script")
+        inner_text = self.page.inner_text("script-py")
         assert inner_text == "this goes to the DOM"
         assert self.console.log.lines[-2:] == [
             "print from python",
@@ -408,10 +409,10 @@ class TestDisplay(PyScriptTest):
     def test_console_line_break(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
             print('1print\\n2print')
             print('1console\\n2console')
-            </py-script>
+            </script>
         """
         )
         console_text = self.console.all.lines
@@ -439,12 +440,12 @@ class TestDisplay(PyScriptTest):
             </py-config>
 
             <div id="img-target" />
-            <py-script>
+            <script type="py">
                 from pyscript import display
                 from PIL import Image
                 img = Image.new("RGB", (4, 4), color=(0, 0, 0))
                 display(img, target='img-target', append=False)
-            </py-script>
+            </script>
             """
         )
 

--- a/pyscript.core/tests/integration/test_03_element.py
+++ b/pyscript.core/tests/integration/test_03_element.py
@@ -12,11 +12,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo"></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             print(el.id)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "foo"
@@ -30,11 +30,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <input id="foo" value="bar">
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             print(el.value)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "bar"
@@ -48,11 +48,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo"><b>bar</b></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             print(el.innerHtml)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "<b>bar</b>"
@@ -66,12 +66,12 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo"></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.write("Hello!")
             el.write("World!")
-            </py-script>
+            </script>
             """
         )
         div = self.page.wait_for_selector("#foo")
@@ -83,12 +83,12 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo"></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.write("Hello!")
             el.write("World!", append=True)
-            </py-script>
+            </script>
             """
         )
         parent_div = self.page.wait_for_selector("#foo")
@@ -103,11 +103,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo">Hello!</div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.clear()
-            </py-script>
+            </script>
             """
         )
         div = self.page.locator("#foo")
@@ -119,11 +119,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <input id="foo" value="bar">
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.clear()
-            </py-script>
+            </script>
             """
         )
         input = self.page.wait_for_selector("#foo")
@@ -137,11 +137,11 @@ class TestElement(PyScriptTest):
             <select id="foo">
                 <option value="bar">Bar</option>
             </select>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             js.console.log(el.select("option").value)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "bar"
@@ -154,11 +154,11 @@ class TestElement(PyScriptTest):
             <template id="foo">
                 <div>Bar</div>
             </template>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             js.console.log(el.select("div", from_content=True).innerHtml)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "Bar"
@@ -169,11 +169,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo">Hello!</div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.clone()
-            </py-script>
+            </script>
             """
         )
         divs = self.page.locator("#foo")
@@ -187,11 +187,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo">Hello!</div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.clone(new_id="bar")
-            </py-script>
+            </script>
             """
         )
         divs = self.page.locator("#foo")
@@ -214,14 +214,14 @@ class TestElement(PyScriptTest):
                     James
                 </div>
             </div>
-            <py-script>
+            <script type="py">
                 from pyscript import Element
 
                 bond_div = Element("bond")
                 james_div = Element("james")
 
                 bond_div.clone(new_id="bond-2", to=james_div)
-            </py-script>
+            </script>
             """
         )
         bond_divs = self.page.locator("#bond")
@@ -242,11 +242,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo" class="bar baz"></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.remove_class("bar")
-            </py-script>
+            </script>
             """
         )
         div = self.page.locator("#foo")
@@ -258,11 +258,11 @@ class TestElement(PyScriptTest):
         self.pyscript_run(
             """
             <div id="foo" class="foo bar baz"></div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.remove_class(["foo", "baz", "bar"])
-            </py-script>
+            </script>
             """
         )
         div = self.page.locator("#foo")
@@ -275,11 +275,11 @@ class TestElement(PyScriptTest):
             """
             <style> .red { color: red; } </style>
             <div id="foo">Hi!</div>
-            <py-script>
+            <script type="py">
             from pyscript import Element
             el = Element("foo")
             el.add_class("red")
-            </py-script>
+            </script>
             """
         )
         div = self.page.locator("#foo")
@@ -292,11 +292,11 @@ class TestElement(PyScriptTest):
             """
             <style> .red { color: red; } .bold { font-weight: bold; } </style>
             <div id="foo">Hi!</div>
-            <py-script>
+            <script type="py">
                 from pyscript import Element
                 el = Element("foo")
                 el.add_class(["red", "bold"])
-            </py-script>
+            </script>
             """
         )
         div = self.page.locator("#foo")

--- a/pyscript.core/tests/integration/test_async.py
+++ b/pyscript.core/tests/integration/test_async.py
@@ -123,9 +123,9 @@ class TestAsync(PyScriptTest):
         inner_text = self.page.inner_text("html")
         assert "A0\nA1\nB0\nB1" in filter_inner_text(inner_text)
 
-    @pytest.mark.skip("it seems that the 2nd task is never created, "
-                      "but note that it works if you use <py-script> instead. "
-                      "Investigate.")
+    @pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>. "
+                      "it seems that the 2nd task is never created, "
+                      "but note that it works if you use <py-script> instead")
     def test_multiple_async_multiple_display_targeted_script_py(self):
         self.pyscript_run(
             """

--- a/pyscript.core/tests/integration/test_async.py
+++ b/pyscript.core/tests/integration/test_async.py
@@ -5,7 +5,7 @@ class TestAsync(PyScriptTest):
     # ensure_future() and create_task() should behave similarly;
     # we'll use the same source code to test both
     coroutine_script = """
-        <py-script>
+        <script type="py">
         import js
         import asyncio
         js.console.log("first")
@@ -14,7 +14,7 @@ class TestAsync(PyScriptTest):
             js.console.log("third")
         asyncio.{func}(main())
         js.console.log("second")
-        </py-script>
+        </script>
         """
 
     def test_asyncio_ensure_future(self):
@@ -30,7 +30,7 @@ class TestAsync(PyScriptTest):
     def test_asyncio_gather(self):
         self.pyscript_run(
             """
-            <py-script id="pys">
+            <script type="py" id="pys">
             import asyncio
             import js
             from pyodide.ffi import to_js
@@ -45,7 +45,7 @@ class TestAsync(PyScriptTest):
                 js.console.log("DONE")
 
             asyncio.ensure_future(get_results())
-            </py-script>
+            </script>
             """
         )
         self.wait_for_console("DONE")
@@ -54,7 +54,7 @@ class TestAsync(PyScriptTest):
     def test_multiple_async(self):
         self.pyscript_run(
             """
-        <py-script>
+        <script type="py">
             import js
             import asyncio
             async def a_func():
@@ -62,9 +62,9 @@ class TestAsync(PyScriptTest):
                     js.console.log('A', i)
                     await asyncio.sleep(0.1)
             asyncio.ensure_future(a_func())
-        </py-script>
+        </script>
 
-        <py-script>
+        <script type="py">
             import js
             import asyncio
             async def b_func():
@@ -73,7 +73,7 @@ class TestAsync(PyScriptTest):
                     await asyncio.sleep(0.1)
                 js.console.log('b func done')
             asyncio.ensure_future(b_func())
-        </py-script>
+        </script>
         """
         )
         self.wait_for_console("b func done")
@@ -90,7 +90,7 @@ class TestAsync(PyScriptTest):
     def test_multiple_async_multiple_display_targeted(self):
         self.pyscript_run(
             """
-                <py-script id='pyA'>
+                <script type="py" id='pyA'>
                     from pyscript import display
                     import js
                     import asyncio
@@ -101,8 +101,8 @@ class TestAsync(PyScriptTest):
                             await asyncio.sleep(0.1)
                     asyncio.ensure_future(a_func())
 
-                </py-script>
-                <py-script id='pyB'>
+                </script>
+                <script type="py" id='pyB'>
                     from pyscript import display
                     import js
                     import asyncio
@@ -114,7 +114,7 @@ class TestAsync(PyScriptTest):
                         js.console.log("B DONE")
 
                     asyncio.ensure_future(a_func())
-                </py-script>
+                </script>
             """
         )
         self.wait_for_console("B DONE")
@@ -124,7 +124,7 @@ class TestAsync(PyScriptTest):
     def test_async_display_untargeted(self):
         self.pyscript_run(
             """
-                <py-script>
+                <script type="py">
                     from pyscript import display
                     import asyncio
                     import js
@@ -135,16 +135,16 @@ class TestAsync(PyScriptTest):
                         js.console.log("DONE")
 
                     asyncio.ensure_future(a_func())
-                </py-script>
+                </script>
             """
         )
         self.wait_for_console("DONE")
-        assert self.page.locator("py-script").inner_text() == "A"
+        assert self.page.locator("script-py").inner_text() == "A"
 
     def test_sync_and_async_order(self):
         """
         The order of execution is defined as follows:
-          1. first, we execute all the py-script tag in order
+          1. first, we execute all the script tags in order
           2. then, we start all the tasks which were scheduled with create_task
 
         Note that tasks are started *AFTER* all py-script tags have been
@@ -152,12 +152,12 @@ class TestAsync(PyScriptTest):
         executed after e.g. js.console.log("6").
         """
         src = """
-                <py-script>
+                <script type="py">
                     import js
                     js.console.log("1")
-                </py-script>
+                </script>
 
-                <py-script>
+                <script type="py">
                     import asyncio
                     import js
 
@@ -169,14 +169,14 @@ class TestAsync(PyScriptTest):
                     js.console.log("2")
                     asyncio.create_task(mytask1())
                     js.console.log("3")
-                </py-script>
+                </script>
 
-                <py-script>
+                <script type="py">
                     import js
                     js.console.log("4")
-                </py-script>
+                </script>
 
-                <py-script>
+                <script type="py">
                     import asyncio
                     import js
 
@@ -189,7 +189,7 @@ class TestAsync(PyScriptTest):
                     js.console.log("5")
                     asyncio.create_task(mytask2())
                     js.console.log("6")
-                </py-script>
+                </script>
             """
         self.pyscript_run(src, wait_for_pyscript=False)
         self.wait_for_console("DONE")

--- a/pyscript.core/tests/integration/test_event_handling.py
+++ b/pyscript.core/tests/integration/test_event_handling.py
@@ -15,12 +15,12 @@ class TestEventHandler(PyScriptTest):
         self.pyscript_run(
             """
             <button id="foo_id">foo_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").click()
@@ -36,12 +36,12 @@ class TestEventHandler(PyScriptTest):
         self.pyscript_run(
             """
             <button id="foo_id">foo_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 def foo():
                     print("The button was clicked")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").click()
@@ -54,7 +54,7 @@ class TestEventHandler(PyScriptTest):
             """
             <button id="foo_id">foo_button</button>
             <button id="bar_id">bar_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 def foo(evt):
@@ -62,7 +62,7 @@ class TestEventHandler(PyScriptTest):
                 @when("click", selector="#bar_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").click()
@@ -82,13 +82,13 @@ class TestEventHandler(PyScriptTest):
             """
             <button id="foo_id">foo_button</button>
             <button class="bar_class">bar_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 @when("mouseover", selector=".bar_class")
                 def foo(evt):
                     print(f"An event of type {evt.type} happened")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=bar_button").hover()
@@ -103,13 +103,13 @@ class TestEventHandler(PyScriptTest):
         self.pyscript_run(
             """
             <button id="foo_id">foo_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 @when("mouseover", selector="#foo_id")
                 def foo(evt):
                     print(f"An event of type {evt.type} happened")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").hover()
@@ -127,12 +127,12 @@ class TestEventHandler(PyScriptTest):
             """
             <button class="bar_class">button1</button>
             <button class="bar_class">button2</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector=".bar_class")
                 def foo(evt):
                     print(f"{evt.target.innerText} was clicked")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=button1").click()
@@ -147,13 +147,13 @@ class TestEventHandler(PyScriptTest):
         self.pyscript_run(
             """
             <button id="foo_id">foo_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#foo_id")
                 @when("click", selector="#foo_id")
                 def foo(evt):
                     print(f"I've clicked {evt.target} with id {evt.target.id}")
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").click()
@@ -170,12 +170,12 @@ class TestEventHandler(PyScriptTest):
         self.pyscript_run(
             """
             <button id="foo_id">foo_button</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#.bad")
                 def foo(evt):
                     ...
-            </py-script>
+            </script>
         """
         )
         self.page.locator("text=foo_button").click()

--- a/pyscript.core/tests/integration/test_importmap.py
+++ b/pyscript.core/tests/integration/test_importmap.py
@@ -28,10 +28,10 @@ class TestImportmap(PyScriptTest):
                 say_hello("JS");
             </script>
 
-            <py-script>
+            <script type="py">
                 import mymod
                 mymod.say_hello("Python")
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines == [
@@ -46,9 +46,9 @@ class TestImportmap(PyScriptTest):
             this is not valid JSON
             </script>
 
-            <py-script>
+            <script type="py">
                 print("hello world")
-            </py-script>
+            </script>
             """,
             wait_for_pyscript=False,
         )

--- a/pyscript.core/tests/integration/test_interpreter.py
+++ b/pyscript.core/tests/integration/test_interpreter.py
@@ -14,11 +14,11 @@ class TestInterpreterAccess(PyScriptTest):
     def test_interpreter_python_access(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 x = 1
                 def py_func():
                     return 2
-            </py-script>
+            </script>
             """
         )
 
@@ -74,11 +74,11 @@ class TestInterpreterAccess(PyScriptTest):
         """Test accessing Python objects from JS via pyscript.runtime"""
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 x = 1
                 def py_func():
                     return 2
-            </py-script>
+            </script>
             """
         )
 

--- a/pyscript.core/tests/integration/test_plugins.py
+++ b/pyscript.core/tests/integration/test_plugins.py
@@ -250,11 +250,11 @@ class TestPlugin(PyScriptTest):
     @prepare_test(
         "exec_test_logger",
         PYSCRIPT_HOOKS_PLUGIN_CODE,
-        template=HTML_TEMPLATE_NO_TAG + "\n<py-script id='pyid'>x=2; x</py-script>",
+        template=HTML_TEMPLATE_NO_TAG + "\n<script type='py' id='pyid'>x=2; x</script>",
     )
     def test_pyscript_exec_hooks(self):
         """Test that the beforePyScriptExec and afterPyScriptExec hooks work as intended"""
-        assert self.page.locator("py-script") is not None
+        assert self.page.locator("script") is not None
 
         log_lines: list[str] = self.console.log.lines
 

--- a/pyscript.core/tests/integration/test_py_config.py
+++ b/pyscript.core/tests/integration/test_py_config.py
@@ -66,7 +66,7 @@ class TestConfig(PyScriptTest):
         )
         assert self.console.log.lines[-1] == "config name: foobar"
 
-    @pytest.mark.skip("This fails, but works with <py-script>")
+    @pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
     def test_py_config_inline_scriptpy(self):
         self.pyscript_run(
             """
@@ -84,7 +84,7 @@ class TestConfig(PyScriptTest):
         assert self.console.log.lines[-1] == "config name: foobar"
 
 
-    @pytest.mark.skip("This fails, but works with <py-script>")
+    @pytest.mark.skip("ERROR_SCRIPT: works with <py-script> not with <script>")
     def test_py_config_external(self):
         pyconfig_toml = """
             name = "app with external config"

--- a/pyscript.core/tests/integration/test_py_config.py
+++ b/pyscript.core/tests/integration/test_py_config.py
@@ -50,7 +50,24 @@ def unzip(location, extract_to="."):
 #      of config
 @with_execution_thread(None)
 class TestConfig(PyScriptTest):
-    def test_py_config_inline(self):
+    def test_py_config_inline_pyscript(self):
+        self.pyscript_run(
+            """
+        <py-config>
+            name = "foobar"
+        </py-config>
+
+        <py-script async>
+            from pyscript import window, document
+            promise = await document.currentScript._pyodide.promise
+            window.console.log("config name:", promise.config.name)
+        </py-script>
+        """
+        )
+        assert self.console.log.lines[-1] == "config name: foobar"
+
+    @pytest.mark.skip("This fails, but works with <py-script>")
+    def test_py_config_inline_scriptpy(self):
         self.pyscript_run(
             """
         <py-config>
@@ -66,6 +83,8 @@ class TestConfig(PyScriptTest):
         )
         assert self.console.log.lines[-1] == "config name: foobar"
 
+
+    @pytest.mark.skip("This fails, but works with <py-script>")
     def test_py_config_external(self):
         pyconfig_toml = """
             name = "app with external config"

--- a/pyscript.core/tests/integration/test_py_config.py
+++ b/pyscript.core/tests/integration/test_py_config.py
@@ -57,11 +57,11 @@ class TestConfig(PyScriptTest):
             name = "foobar"
         </py-config>
 
-        <py-script async>
+        <script type="py" async>
             from pyscript import window, document
             promise = await document.currentScript._pyodide.promise
             window.console.log("config name:", promise.config.name)
-        </py-script>
+        </script>
         """
         )
         assert self.console.log.lines[-1] == "config name: foobar"
@@ -75,11 +75,11 @@ class TestConfig(PyScriptTest):
             """
         <py-config src="pyconfig.toml"></py-config>
 
-        <py-script async>
+        <script type="py" async>
             from pyscript import window, document
             promise = await document.currentScript._pyodide.promise
             window.console.log("config name:", promise.config.name)
-        </py-script>
+        </script>
         """
         )
         assert self.console.log.lines[-1] == "config name: app with external config"
@@ -105,11 +105,11 @@ class TestConfig(PyScriptTest):
                 }
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import sys, js
                 pyodide_version = sys.modules["pyodide"].__version__
                 js.console.log("version", pyodide_version)
-            </py-script>
+            </script>
         """,
         )
 
@@ -168,11 +168,11 @@ class TestConfig(PyScriptTest):
             this is ignored and won't even be parsed
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import js
                 config = js.pyscript_get_config()
                 js.console.log("config name:", config.name)
-            </py-script>
+            </script>
             """
         )
         banner = self.page.wait_for_selector(".py-warning")
@@ -217,10 +217,10 @@ class TestConfig(PyScriptTest):
             }
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import js
                 js.console.log("hello world");
-            </py-script>
+            </script>
         """
         self.pyscript_run(snippet)
         banner = self.page.wait_for_selector(".py-warning")
@@ -240,12 +240,12 @@ class TestConfig(PyScriptTest):
                 files = ["./a.py", "./b.py"]
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import js
                 import a, b
                 js.console.log(a.x)
                 js.console.log(b.x)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-2:] == [
@@ -284,11 +284,11 @@ class TestConfig(PyScriptTest):
                 files = ["__init__.py", "a.py"]
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import js
                 from pkg.a import x
                 js.console.log(x)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "hello from A"

--- a/pyscript.core/tests/integration/test_py_repl.py
+++ b/pyscript.core/tests/integration/test_py_repl.py
@@ -386,7 +386,7 @@ class TestPyRepl(PyScriptTest):
         self.pyscript_run(
             """
             <div id="repl-target"></div>
-            <py-script>
+            <script type="py">
                 import asyncio
                 import js
 
@@ -402,7 +402,7 @@ class TestPyRepl(PyScriptTest):
                 async def done():
                     await asyncio.sleep(3)
                     js.console.log("DONE")
-            </py-script>
+            </script>
 
             <py-repl output="repl-target">
                 asyncio.ensure_future(print_it());
@@ -544,7 +544,7 @@ class TestPyRepl(PyScriptTest):
 
                 this_tag.setAttribute("output", "third")
                 print("three.")
-            </py-script>
+            </script>
             """
         )
 

--- a/pyscript.core/tests/integration/test_py_terminal.py
+++ b/pyscript.core/tests/integration/test_py_terminal.py
@@ -22,12 +22,12 @@ class TestPyTerminal(PyScriptTest):
             """
             <py-terminal></py-terminal>
 
-            <py-script>
+            <script type="py">
                 import sys
                 print('hello world')
                 print('this goes to stderr', file=sys.stderr)
                 print('this goes to stdout')
-            </py-script>
+            </script>
             """
         )
         term = self.page.locator("py-terminal")
@@ -54,7 +54,7 @@ class TestPyTerminal(PyScriptTest):
             """
             <py-terminal id="term1"></py-terminal>
 
-            <py-script>
+            <script type="py">
                 import js
                 print('one')
                 term2 = js.document.createElement('py-terminal')
@@ -63,7 +63,7 @@ class TestPyTerminal(PyScriptTest):
 
                 print('two')
                 print('three')
-            </py-script>
+            </script>
             """
         )
         term1 = self.page.locator("#term1")
@@ -115,9 +115,9 @@ class TestPyTerminal(PyScriptTest):
                 terminal = true
             </py-config>
 
-            <py-script>
+            <script type="py">
                 print('hello world')
-            </py-script>
+            </script>
             """
         )
         term = self.page.locator("py-terminal")
@@ -167,13 +167,13 @@ class TestPyTerminal(PyScriptTest):
             <py-config>
                 xterm = true
             </py-config>
-            <py-script>
+            <script type="py">
                 print("\x1b[33mYellow\x1b[0m")
                 print("\x1b[4mUnderline\x1b[24m")
                 print("\x1b[1mBold\x1b[22m")
                 print("\x1b[3mItalic\x1b[23m")
                 print("done")
-            </py-script>
+            </script>
             """
         )
 
@@ -242,10 +242,10 @@ class TestPyTerminal(PyScriptTest):
             <py-config>
                 xterm = true
             </py-config>
-            <py-script>
+            <script type="py">
                 print("\x1b[33mYellow\x1b[0m")
                 print("done")
-            </py-script>
+            </script>
             <py-terminal id="a"></py-terminal>
             <py-terminal id="b" data-testid="b"></py-terminal>
             """

--- a/pyscript.core/tests/integration/test_runtime_attributes.py
+++ b/pyscript.core/tests/integration/test_runtime_attributes.py
@@ -9,7 +9,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
         self.pyscript_run(
             r"""
             <div id="py-button-container"></div>
-            <py-script>
+            <script type="py">
               import js
 
               py_button = Element("py-button-container")
@@ -17,7 +17,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
 
               def print_hello():
                 js.console.log("hello pyscript")
-            </py-script>
+            </script>
             """
         )
         self.page.locator("button").click()
@@ -28,7 +28,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
         self.pyscript_run(
             r"""
             <button id="py-button"></button>
-            <py-script>
+            <script type="py">
               import js
 
               py_button = Element("py-button")
@@ -36,7 +36,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
 
               def print_hello():
                 js.console.log("hello pyscript")
-            </py-script>
+            </script>
             """
         )
         self.page.locator("button").click()
@@ -47,7 +47,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
         self.pyscript_run(
             r"""
             <button id="py-button">live content</button>
-            <py-script>
+            <script type="py">
               import js
 
               py_button = Element("py-button")
@@ -56,7 +56,7 @@ class TestPyScriptRuntimeAttributes(PyScriptTest):
               def print_hello():
                 js.console.log("hello pyscript")
                 py_button.element.removeAttribute("py-click")
-            </py-script>
+            </script>
             """
         )
         self.page.locator("button").click()

--- a/pyscript.core/tests/integration/test_script_type.py
+++ b/pyscript.core/tests/integration/test_script_type.py
@@ -110,11 +110,11 @@ class TestScriptTypePyScript(PyScriptTest):
             """
             <div id="stdout-div"></div>
             <div id="stderr-div"></div>
-            <py-script output="stdout-div" stderr="stderr-div">
+            <script type="py" output="stdout-div" stderr="stderr-div">
                 import sys
                 print("one.", file=sys.stderr)
                 print("two.")
-            </py-script>
+            </script>
             """
         )
         assert self.page.locator("#stdout-div").text_content() == "one.two."

--- a/pyscript.core/tests/integration/test_shadow_root.py
+++ b/pyscript.core/tests/integration/test_shadow_root.py
@@ -24,10 +24,10 @@ class TestShadowRoot(PyScriptTest):
                 });
             </script>
             <s-r></s-r>
-            <py-script>
+            <script type="py">
                 import js
                 js.console.log(Element("shadowed").innerHtml)
-            </py-script>
+            </script>
             """
         )
         assert self.console.log.lines[-1] == "OK"

--- a/pyscript.core/tests/integration/test_splashscreen.py
+++ b/pyscript.core/tests/integration/test_splashscreen.py
@@ -22,9 +22,9 @@ class TestSplashscreen(PyScriptTest):
         """
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 print('hello pyscript')
-            </py-script>
+            </script>
             """,
             wait_for_pyscript=False,
         )
@@ -49,9 +49,9 @@ class TestSplashscreen(PyScriptTest):
                 [splashscreen]
                 autoclose = false
             </py-config>
-            <py-script>
+            <script type="py">
                 print('hello pyscript')
-            </py-script>
+            </script>
             """,
         )
         div = self.page.locator("py-splashscreen > div")
@@ -66,9 +66,9 @@ class TestSplashscreen(PyScriptTest):
             <py-config>
                 autoclose_loader = false
             </py-config>
-            <py-script>
+            <script type="py">
                 print('hello pyscript')
-            </py-script>
+            </script>
             """,
         )
         warning = self.page.locator(".py-warning")
@@ -89,11 +89,11 @@ class TestSplashscreen(PyScriptTest):
                 enabled = false
             </py-config>
 
-            <py-script>
+            <script type="py">
                 def test():
                     print("Hello pyscript!")
                 test()
-            </py-script>
+            </script>
             """,
         )
         assert self.page.locator("py-splashscreen").count() == 0
@@ -110,12 +110,12 @@ class TestSplashscreen(PyScriptTest):
                     autoclose = false
             </py-config>
 
-            <py-script>
+            <script type="py">
                 from js import document
 
                 splashscreen = document.querySelector("py-splashscreen")
                 splashscreen.log("Hello, world!")
-            </py-script>
+            </script>
             """,
         )
 

--- a/pyscript.core/tests/integration/test_stdio_handling.py
+++ b/pyscript.core/tests/integration/test_stdio_handling.py
@@ -20,11 +20,11 @@ class TestOutputHandling(PyScriptTest):
                 <div id="second"></div>
                 <div id="third"></div>
             </div>
-            <py-script output="first">print("first 1.")</py-script>
-            <py-script output="second">print("second.")</py-script>
-            <py-script output="third">print("third.")</py-script>
-            <py-script output="first">print("first 2.")</py-script>
-            <py-script>print("no output.")</py-script>
+            <script type="py" output="first">print("first 1.")</script>
+            <script type="py" output="second">print("second.")</script>
+            <script type="py" output="third">print("third.")</script>
+            <script type="py" output="first">print("first 2.")</script>
+            <script type="py">print("no output.")</script>
             """
         )
 
@@ -63,10 +63,10 @@ class TestOutputHandling(PyScriptTest):
         self.pyscript_run(
             """
             <div id="first"></div>
-            <py-script output="first">
+            <script type="py" output="first">
                 print("<p>Hello</p>")
                 print('<img src="https://example.net">')
-            </py-script>
+            </script>
             """
         )
 
@@ -81,16 +81,16 @@ class TestOutputHandling(PyScriptTest):
         self.pyscript_run(
             """
             <div id="first"></div>
-            <py-script output="first">
+            <script type="py" output="first">
                 print("one.")
                 print("two.")
                 print("three.")
-            </py-script>
+            </script>
 
             <div id="second"></div>
-            <py-script output="second">
+            <script type="py" output="second">
                 print("one.\\ntwo.\\nthree.")
-            </py-script>
+            </script>
             """
         )
 
@@ -106,7 +106,7 @@ class TestOutputHandling(PyScriptTest):
         # Test the behavior of stdio capture in async contexts
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 import asyncio
                 import js
 
@@ -114,36 +114,36 @@ class TestOutputHandling(PyScriptTest):
                     print(value)
                     await asyncio.sleep(delay)
                     js.console.log(f"DONE {value}")
-            </py-script>
+            </script>
 
             <div id="first"></div>
-            <py-script>
+            <script type="py">
                 asyncio.ensure_future(coro("first", 1))
-            </py-script>
+            </script>
 
             <div id="second"></div>
-            <py-script output="second">
+            <script type="py" output="second">
                 asyncio.ensure_future(coro("second", 1))
-            </py-script>
+            </script>
 
             <div id="third"></div>
-            <py-script output="third">
+            <script type="py" output="third">
                 asyncio.ensure_future(coro("third", 0))
-            </py-script>
+            </script>
 
-            <py-script output="third">
+            <script type="py" output="third">
                 asyncio.ensure_future(coro("DONE", 3))
-            </py-script>
+            </script>
             """
         )
 
         self.wait_for_console("DONE DONE")
 
-        # py-script tags without output parameter should not send
+        # script tags without output parameter should not send
         # stdout to element
         assert self.page.locator("#first").text_content() == ""
 
-        # py-script tags with output parameter not expected to send
+        # script tags with output parameter not expected to send
         # std to element in coroutine
         assert self.page.locator("#second").text_content() == ""
         assert self.page.locator("#third").text_content() == ""
@@ -157,7 +157,7 @@ class TestOutputHandling(PyScriptTest):
             """
             <div id="good"></div>
             <div id="bad"></div>
-            <py-script output="good">
+            <script type="py" output="good">
                 import asyncio
                 import js
 
@@ -172,7 +172,7 @@ class TestOutputHandling(PyScriptTest):
                 print("three.")
                 asyncio.ensure_future(coro_bad("badthree.", 0))
                 asyncio.ensure_future(coro_bad("DONE", 1))
-            </py-script>
+            </script>
             """
         )
 
@@ -196,7 +196,7 @@ class TestOutputHandling(PyScriptTest):
             """
             <div id="first"></div>
             <div id="second"></div>
-            <py-script output="first">
+            <script type="py" output="first">
                 print("first.")
 
                 import js
@@ -206,7 +206,7 @@ class TestOutputHandling(PyScriptTest):
                 js.document.body.appendChild(tag)
 
                 print("first.")
-            </py-script>
+            </script>
             """
         )
 
@@ -224,18 +224,18 @@ class TestOutputHandling(PyScriptTest):
         # Attribute creates exactly 1 warning banner per missing id
         self.pyscript_run(
             """
-            <py-script output="not-on-page">
+            <script type="py" output="not-on-page">
                 print("bad.")
-            </py-script>
+            </script>
 
             <div id="on-page"></div>
-            <py-script>
+            <script type="py">
                 print("good.")
-            </py-script>
+            </script>
 
-            <py-script output="not-on-page">
+            <script type="py" output="not-on-page">
                 print("bad.")
-            </py-script>
+            </script>
             """
         )
 
@@ -253,19 +253,19 @@ class TestOutputHandling(PyScriptTest):
         # attribute creates exactly 1 warning banner per missing id
         self.pyscript_run(
             """
-            <py-script stderr="not-on-page">
+            <script type="py" stderr="not-on-page">
                 import sys
                 print("bad.", file=sys.stderr)
-            </py-script>
+            </script>
 
             <div id="on-page"></div>
-            <py-script>
+            <script type="py">
                 print("good.", file=sys.stderr)
-            </py-script>
+            </script>
 
-            <py-script stderr="not-on-page">
+            <script type="py" stderr="not-on-page">
                 print("bad.", file=sys.stderr)
-            </py-script>
+            </script>
             """
         )
 
@@ -285,11 +285,11 @@ class TestOutputHandling(PyScriptTest):
             """
             <div id="stdout-div"></div>
             <div id="stderr-div"></div>
-            <py-script output="stdout-div" stderr="stderr-div">
+            <script type="py" output="stdout-div" stderr="stderr-div">
                 import sys
                 print("one.", file=sys.stderr)
                 print("two.")
-            </py-script>
+            </script>
             """
         )
 
@@ -299,14 +299,14 @@ class TestOutputHandling(PyScriptTest):
 
     @skip_worker("FIXME: js.document")
     def test_stdio_output_attribute_change(self):
-        # If the user changes the 'output' attribute of a <py-script> tag mid-execution,
+        # If the user changes the 'output' attribute of a <script type="py"> tag mid-execution,
         # Output should no longer go to the selected div and a warning should appear
         self.pyscript_run(
             """
             <div id="first"></div>
             <div id="second"></div>
             <!-- There is no tag with id "third" -->
-            <py-script id="pyscript-tag" output="first">
+            <script type="py" id="pyscript-tag" output="first">
                 print("one.")
 
                 # Change the 'output' attribute of this tag
@@ -318,7 +318,7 @@ class TestOutputHandling(PyScriptTest):
 
                 this_tag.setAttribute("output", "third")
                 print("three.")
-            </py-script>
+            </script>
             """
         )
 
@@ -340,7 +340,7 @@ class TestOutputHandling(PyScriptTest):
             <div id="first"></div>
             <div id="second"></div>
             <!-- There is no tag with id "third" -->
-            <py-script id="pyscript-tag" output="first">
+            <script type="py" id="pyscript-tag" output="first">
                 print("one.")
 
                 # Change the ID of the targeted DIV to something else
@@ -356,7 +356,7 @@ class TestOutputHandling(PyScriptTest):
                 target_tag.setAttribute("id", "third")
                 js.document.getElementById("pyscript-tag").setAttribute("output", "third")
                 print("three.")
-            </py-script>
+            </script>
             """
         )
 

--- a/pyscript.core/tests/integration/test_style.py
+++ b/pyscript.core/tests/integration/test_style.py
@@ -19,7 +19,7 @@ class TestStyle(PyScriptTest):
           </head>
           <body>
             <py-config>hello</py-config>
-            <py-script>hello</py-script>
+            <script type="py">hello</script>
             <py-repl>hello</py-repl>
           </body>
         </html>
@@ -38,7 +38,7 @@ class TestStyle(PyScriptTest):
             <py-config>
             name = "foo"
             </py-config>
-            <py-script>display("hello")</py-script>
+            <script type="py">display("hello")</script>
             <py-repl>display("hello")</py-repl>
             """
         )

--- a/pyscript.core/tests/integration/test_warnings_and_banners.py
+++ b/pyscript.core/tests/integration/test_warnings_and_banners.py
@@ -12,13 +12,13 @@ class TestWarningsAndBanners(PyScriptTest):
         # Use a script tag with an invalid output attribute to generate a warning, but only one
         self.pyscript_run(
             """
-            <py-script output="foo">
+            <script type="py" output="foo">
                 print("one.")
                 print("two.")
-            </py-script>
-            <py-script output="foo">
+            </script>
+            <script type="py" output="foo">
                 print("three.")
-            </py-script>
+            </script>
             """
         )
 

--- a/pyscript.core/tests/integration/test_zzz_docs_snippets.py
+++ b/pyscript.core/tests/integration/test_zzz_docs_snippets.py
@@ -19,7 +19,7 @@ class TestDocsSnippets(PyScriptTest):
             </button>
             <p id="current-time"></p>
 
-            <py-script>
+            <script type="py">
                 from pyscript import Element
                 import datetime
 
@@ -31,7 +31,7 @@ class TestDocsSnippets(PyScriptTest):
 
                     # Add current time to the paragraph element
                     paragraph.write(now.strftime("%Y-%m-%d %H:%M:%S"))
-            </py-script>
+            </script>
             """
         )
 
@@ -51,7 +51,7 @@ class TestDocsSnippets(PyScriptTest):
                 packages = ["requests", "pyodide-http"]
             </py-config>
 
-            <py-script>
+            <script type="py">
                 import requests
                 import pyodide_http
 
@@ -61,7 +61,7 @@ class TestDocsSnippets(PyScriptTest):
                 # Make a request to the JSON Placeholder API
                 response = requests.get("https://jsonplaceholder.typicode.com/todos")
                 print(response.json())
-            </py-script>
+            </script>
             """
         )
 
@@ -83,9 +83,9 @@ class TestDocsSnippets(PyScriptTest):
                 from = "https://gist.githubusercontent.com/FabioRosado/faba0b7f6ad4438b07c9ac567c73b864/raw/37603b76dc7ef7997bf36781ea0116150f727f44/"
                 files = ["todo.py"]
                 </py-config>
-                <py-script>
+                <script type="py">
                     from todo import add_task, add_task_event
-                </py-script>
+                </script>
                 <section>
                 <div class="text-center w-full mb-8">
                     <h1 class="text-3xl font-bold text-gray-800 uppercase tracking-tight">
@@ -143,10 +143,10 @@ class TestDocsSnippets(PyScriptTest):
                     name = "pyodide-0.23.0"
                     lang = "python"
             </py-config>
-            <py-script>
+            <script type="py">
                 import pyodide
                 print(pyodide.__version__)
-            </py-script>
+            </script>
             """
         )
 
@@ -167,7 +167,7 @@ class TestDocsSnippets(PyScriptTest):
             </div>
             <button py-click="print_to_page()" id="print">Print Things!</button>
 
-            <py-script>
+            <script type="py">
             def write_to_page():
                 manual_div = Element("manual-write")
                 manual_div.element.innerHTML = "<p><b>Hello World</b></p>"
@@ -177,7 +177,7 @@ class TestDocsSnippets(PyScriptTest):
 
             def print_to_page():
                 print("I print things!")
-            </py-script>
+            </script>
             """
         )
         btn_manual = self.page.wait_for_selector("#manual")
@@ -200,7 +200,7 @@ class TestDocsSnippets(PyScriptTest):
     def test_guides_asyncio(self):
         self.pyscript_run(
             """
-            <py-script>
+            <script type="py">
                 import asyncio
 
                 async def main():
@@ -208,7 +208,7 @@ class TestDocsSnippets(PyScriptTest):
                         print(i)
 
                 asyncio.ensure_future(main())
-            </py-script>
+            </script>
             """
         )
         py_terminal = self.page.wait_for_selector("py-terminal")
@@ -222,7 +222,7 @@ class TestDocsSnippets(PyScriptTest):
             <py-config>
                 xterm = true
             </py-config>
-            <py-script>
+            <script type="py">
                 print("HELLO!")
                 import js
                 import asyncio
@@ -233,7 +233,7 @@ class TestDocsSnippets(PyScriptTest):
                     print("test-done")
 
                 asyncio.ensure_future(adjust_term_size(40, 10))
-                </py-script>
+                </script>
             """
         )
         self.page.get_by_text("test-done").wait_for()
@@ -249,12 +249,12 @@ class TestDocsSnippets(PyScriptTest):
         self.pyscript_run(
             """
             <button id="my_btn">Click Me to Say Hi</button>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 @when("click", selector="#my_btn")
                 def say_hello():
                     print(f"Hello, world!")
-            </py-script>
+            </script>
             """
         )
         self.page.get_by_text("Click Me to Say Hi").click()
@@ -270,7 +270,7 @@ class TestDocsSnippets(PyScriptTest):
                 <button>Second</button>
                 <button>Third</button>
             </div>
-            <py-script>
+            <script type="py">
                 from pyscript import when
                 import js
 
@@ -285,7 +285,7 @@ class TestDocsSnippets(PyScriptTest):
                         button.style.backgroundColor = 'red'
 
                     print("set") # Test Only
-            </py-script>
+            </script>
             """
         )
 


### PR DESCRIPTION
## Description

To bring \<py-script\> and \<script type="py"\> tags closer together and closer to web standards, this deprecates the previous `srcCode` attributes in favor of encouraging users to use the `textContent` attribute. 

This is on top of #1723 and implements the [ideas from this comment](https://github.com/pyscript/pyscript/pull/1723#issuecomment-1723778975).

## Changes

  - Added deprecation warning for `srcCode` via getter and setter
  - Added test for deprecation warning in `test_getPySrc_returns_source_code`

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
