### PR TITLE
[next] Add `mpy` as custom type with PyScript magic attached

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,14 @@ repos:
       rev: v0.0.257
       hooks:
           - id: ruff
-            exclude: pyscript\.core/test|pyscript\.core/dist|pyscript.core/src/stdlib/pyscript.py
+            exclude: pyscript\.core/src/stdlib/pyscript/__init__\.py|pyscript\.core/test|pyscript\.core/dist|pyscript\.core/src/stdlib/pyscript\.py
             args: [--fix]
 
     - repo: https://github.com/psf/black
       rev: 23.1.0
       hooks:
           - id: black
+            exclude: pyscript\.core/src/stdlib/pyscript/__init__\.py
 
     - repo: https://github.com/codespell-project/codespell
       rev: v2.2.4

--- a/pyscript.core/src/core.css
+++ b/pyscript.core/src/core.css
@@ -1,4 +1,6 @@
 py-script,
-py-config {
+py-config,
+mpy-script,
+mpy-config {
     display: none;
 }

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -31,4 +31,13 @@
 
 from pyscript.magic_js import RUNNING_IN_WORKER, window, document, sync
 from pyscript.display import HTML, display
-from pyscript.event_handling import when
+
+try:
+    from pyscript.event_handling import when
+except:
+    from pyscript.util import NotSupported
+
+    when = NotSupported(
+        "pyscript.when",
+        "pyscript.when currently not available with this interpreter"
+    )

--- a/pyscript.core/src/stdlib/pyscript/util.py
+++ b/pyscript.core/src/stdlib/pyscript/util.py
@@ -5,12 +5,11 @@ class NotSupported:
     """
 
     def __init__(self, name, error):
-        # we set attributes using self.__dict__ to bypass the __setattr__
-        self.__dict__['name'] = name
-        self.__dict__['error'] = error
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "error", error)
 
     def __repr__(self):
-        return f'<NotSupported {self.name} [{self.error}]>'
+        return f"<NotSupported {self.name} [{self.error}]>"
 
     def __getattr__(self, attr):
         raise AttributeError(self.error)

--- a/pyscript.core/test/mpy.html
+++ b/pyscript.core/test/mpy.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>PyScript Next</title>
+        <script>
+            addEventListener("mpy:ready", console.log);
+        </script>
+        <link rel="stylesheet" href="../dist/core.css">
+        <script type="module" src="../dist/core.js"></script>
+    </head>
+    <body>
+        <script type="mpy">
+            from pyscript import display
+            display("Hello", "M-PyScript Next", append=False)
+        </script>
+        <mpy-script worker>
+            from pyscript import display
+            display("Hello", "M-PyScript Next Worker", append=False)
+        </mpy-script>
+    </body>
+</html>


### PR DESCRIPTION
## Description

This MR also provide *MicroPython* as *Pyodide* alternative by reusing 100% exact same code and successfully smoke-tested in both main and workers without issues.

### Caveats

  * the `<py-config>` is used also by `<mpy-script>` and `<script type="mpy">` so we need to improve the config story and separate the two interpreters config (follow up issue? this is a non-blocking gotcha easy to document for an RC)
  * the *PyWorker* module export still exposes `pyodide` as default interpreter as that's manual JS worker instantiation but it seems sensible as default export as *MicroPython* in workers makes (so far) little sense
  * I haven't tried `pyweb` module at all

## Changes

  * wrapped *type* and *interpreter* as `Map` and registered both using exact same code as before (some minor internal change that makes sense anyway for the future)
  * changed the `__init__.py` to avoid throwing on `pyodide` import so that `when` is not available in *MicroPython* (the rest seems to work as expected but not fully tested)
  * changed the `NotSupported` class as sugested by @antocuni as previous one was not supported by *MicroPython*
  * dropped the `__init__.py` from a couple of pre-commit hooks as these were **erasing part of the code** breaking all the things (the shared imports outside the try/catch were removed ... what a nasty thing to do, imho)

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
