### PR TITLE
[next] Fix #1730 - Make `worker` an empty attribute only

### DIFF
--- a/pyscript.core/.npmignore
+++ b/pyscript.core/.npmignore
@@ -1,6 +1,7 @@
 node_modules/
 rollup/
 test/
+tests/
 src/stdlib/_pyscript
 src/stdlib/pyscript.py
 package-lock.json

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.22",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.1.22",
+            "version": "0.2.0",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.3.10"
+                "polyscript": "^0.4.2"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
@@ -948,9 +948,9 @@
             "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
         },
         "node_modules/polyscript": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.3.10.tgz",
-            "integrity": "sha512-uO9vg0oIbyjo2n7B3/PtOFSWGjpW9WfIVf02aWSkQ6eUrWDmfrB13R03oLofsQoDDfaMZ+odKh3HqoDWqXd99Q==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.4.2.tgz",
+            "integrity": "sha512-3mM5Y/DdpYND8/INAUmgF5VL4InVc04xADB+of129t8RjXi3eZK4xoGRPZdTYzW+wM56WNptnC8fC9Zt7jKLoA==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.1.22",
+    "version": "0.2.0",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -33,7 +33,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.3.10"
+        "polyscript": "^0.4.2"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",

--- a/pyscript.core/src/plugins/error.js
+++ b/pyscript.core/src/plugins/error.js
@@ -1,9 +1,9 @@
 // PyScript Error Plugin
 import { hooks } from "../core.js";
 
-hooks.onBeforeRun.add(function override(pyScript) {
+hooks.onInterpreterReady.add(function override(pyScript) {
     // be sure this override happens only once
-    hooks.onBeforeRun.delete(override);
+    hooks.onInterpreterReady.delete(override);
 
     // trap generic `stderr` to propagate to it regardless
     const { stderr } = pyScript.io;

--- a/pyscript.core/test/error.html
+++ b/pyscript.core/test/error.html
@@ -18,5 +18,6 @@
     print(4, 5, 6)
     second()
   </py-script>
+  <py-script src="main.py" worker="worker.py"></py-script>
 </head>
 </html>


### PR DESCRIPTION
## Description

This MR addresses the decision made in #1730 to delegate to *polyscript* some ambiguous element parsing so that:

  * *polyscript* still handles `worker` related elements without bootstrapping interpreters on main ... but ...
    * if the `worker` attribute exists and has some value, it throws an `Invalid worker attribute` *SyntaxError*
    * if the `worker` attribute exists and it's empty, but also an `src` exists, it throws an `Invalid src attribute` *SyntaxError*
    * if the `src` attribute exists and the content is not empty or it doesn't contain just comments, it throws an `Invalid content` *SyntaxError*
  * if any of the previous errors is thrown, and the element is a custom one, *polyscript* passes the error to the custom type via a newly `onerror` callback

## Changes

  * move all expectations into *polyscript* as it parses way earlier than any interpreter elements content
  * make *polyscript* expectations and errors consistent across all regular scripts and custom types
  * bootstrap the interpreter and pass along errors to the custom type definition via `onerror` callback *before* the `onInterpreterReady` is triggered
  * instrument the `onerror` callback to register errors by elements
  * ensure regardless the interpreter is register once and wait regardless for plugins to setup
  * **fixed** a typo with plugins hooks as `onBeforeRun` was used within `onInterpreterReady` callback ... plugins need to use `onInterpreterReady` if they want to be available ASAP like the *error* one does, or need
  * bail out on elements initialization if the current element caused errors (and delete it to keep the RAM clean), passing the right *PyScript* error code (ambiguity in this case as that's all we receive right now) plus the node representation without its content when the error is not about the content but attributes (see the picture)
  * checked manually everything works as expected (see the picture)

![Screenshot from 2023-09-20 16-19-57](https://github.com/pyscript/pyscript/assets/85749/d9e6f440-1bbc-44f4-a642-2eb0755fa90e)


## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
