### PR TITLE
Adding JS Types

### DIFF
--- a/pyscript.core/src/config.js
+++ b/pyscript.core/src/config.js
@@ -46,16 +46,14 @@ const syntaxError = (type, url, { message }) => {
 };
 
 // find the shared config for all py-script elements
-let config;
+let config, type;
 
-/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded */
+/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded. */
 let plugins;
-/** @type {any} The configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array}*/
+/** @type {any} The PyScript configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array} */
 let parsed;
-/** @type {SyntaxError | undefined} The error thrown when parsing the config, if any.*/
+/** @type {SyntaxError | undefined} The error thrown when parsing the PyScript config, if any.*/
 let error;
-/** @type {string | null} The Custom Type or Interpreter Type specified in the config, if any*/
-let type;
 
 let pyConfig = $("py-config");
 if (pyConfig) {

--- a/pyscript.core/src/config.js
+++ b/pyscript.core/src/config.js
@@ -50,7 +50,7 @@ let config, type;
 
 /** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded. */
 let plugins;
-/** @type {any} The PyScript configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array} */
+/** @type {any} The PyScript configuration parsed from the JSON or TOML object*. May be any of the return types of JSON.parse() or toml-j0.4's parse() ( {number | string | boolean | null | object | Array} ) */
 let parsed;
 /** @type {SyntaxError | undefined} The error thrown when parsing the PyScript config, if any.*/
 let error;

--- a/pyscript.core/src/config.js
+++ b/pyscript.core/src/config.js
@@ -46,7 +46,17 @@ const syntaxError = (type, url, { message }) => {
 };
 
 // find the shared config for all py-script elements
-let config, plugins, parsed, error, type;
+let config;
+
+/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded */
+let plugins;
+/** @type {any} The configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array}*/
+let parsed;
+/** @type {SyntaxError | undefined} The error thrown when parsing the config, if any.*/
+let error;
+/** @type {string | null} The Custom Type or Interpreter Type specified in the config, if any*/
+let type;
+
 let pyConfig = $("py-config");
 if (pyConfig) {
     config = pyConfig.getAttribute("src") || pyConfig.textContent;

--- a/pyscript.core/src/exceptions.js
+++ b/pyscript.core/src/exceptions.js
@@ -66,11 +66,10 @@ export class InstallError extends UserError {
 
 /**
  * Internal function for creating alert banners on the page
- * @param {string} message
- * @param {string} level
- * @param {string} messageType="text"
- * @param {any} logMessage=true
- * @returns {undefined}
+ * @param {string} message The message to be displayed to the user
+ * @param {string} level The alert level of the message. Can be any string; 'error' or 'warning' cause matching messages to be emitted to the console
+ * @param {string} [messageType="text"] If set to "html", the message content will be assigned to the banner's innerHTML directly, instead of its textContent
+ * @param {any} [logMessage=true] An additional flag for whether the message should be sent to the console log.
  */
 export function _createAlertBanner(
     message,

--- a/pyscript.core/src/exceptions.js
+++ b/pyscript.core/src/exceptions.js
@@ -23,7 +23,17 @@ export const ErrorCode = {
     FETCH_UNAVAILABLE_ERROR: "PY0503",
 };
 
+/**
+ * Keys of the ErrorCode 'enum'
+ * @typedef {keyof ErrorCode} ErrorCodes
+ * */
+
 export class UserError extends Error {
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * @param {string} messageType
+     * */
     constructor(errorCode, message = "", messageType = "text") {
         super(`(${errorCode}): ${message}`);
         this.errorCode = errorCode;
@@ -33,6 +43,10 @@ export class UserError extends Error {
 }
 
 export class FetchError extends UserError {
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * */
     constructor(errorCode, message) {
         super(errorCode, message);
         this.name = "FetchError";
@@ -40,12 +54,24 @@ export class FetchError extends UserError {
 }
 
 export class InstallError extends UserError {
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * */
     constructor(errorCode, message) {
         super(errorCode, message);
         this.name = "InstallError";
     }
 }
 
+/**
+ * Internal function for creating alert banners on the page
+ * @param {string} message
+ * @param {string} level
+ * @param {string} messageType="text"
+ * @param {any} logMessage=true
+ * @returns {undefined}
+ */
 export function _createAlertBanner(
     message,
     level,

--- a/pyscript.core/src/exceptions.js
+++ b/pyscript.core/src/exceptions.js
@@ -24,7 +24,7 @@ export const ErrorCode = {
 };
 
 /**
- * Keys of the ErrorCode 'enum'
+ * Keys of the ErrorCode object
  * @typedef {keyof ErrorCode} ErrorCodes
  * */
 

--- a/pyscript.core/src/plugins/error.js
+++ b/pyscript.core/src/plugins/error.js
@@ -28,7 +28,6 @@ hooks.onInterpreterReady.add(function override(pyScript) {
 /**
  * Add a banner to the top of the page, notifying the user of an error
  * @param {string} message
- * @returns {undefined}
  */
 export function notify(message) {
     const div = document.createElement("div");

--- a/pyscript.core/src/plugins/error.js
+++ b/pyscript.core/src/plugins/error.js
@@ -24,6 +24,12 @@ hooks.onInterpreterReady.add(function override(pyScript) {
 // Error hook utilities
 
 // Custom function to show notifications
+
+/**
+ * Add a banner to the top of the page, notifying the user of an error
+ * @param {string} message
+ * @returns {undefined}
+ */
 export function notify(message) {
     const div = document.createElement("div");
     div.className = "py-error";

--- a/pyscript.core/src/sync.js
+++ b/pyscript.core/src/sync.js
@@ -2,7 +2,6 @@ export default {
     /**
      * 'Sleep' for the given number of seconds. Used to implement Python's time.sleep in Worker threads.
      * @param {number} seconds The number of seconds to sleep.
-     * @returns {undefined}
      */
     sleep(seconds) {
         return new Promise(($) => setTimeout($, seconds * 1000));

--- a/pyscript.core/src/sync.js
+++ b/pyscript.core/src/sync.js
@@ -1,4 +1,9 @@
 export default {
+    /**
+     * 'Sleep' for the given number of seconds. Used to implement Python's time.sleep in Worker threads.
+     * @param {number} seconds The number of seconds to sleep.
+     * @returns {undefined}
+     */
     sleep(seconds) {
         return new Promise(($) => setTimeout($, seconds * 1000));
     },

--- a/pyscript.core/types/config.d.ts
+++ b/pyscript.core/types/config.d.ts
@@ -1,4 +1,7 @@
+/** @type {any} The configuration parsed as a JSON object or similar. (Return type of JSON.parse is something like {number | string | boolean | null | object | Array}; TS by default gives up and says 'any')*/
 declare let parsed: any;
-export let plugins: any;
-export let error: any;
+/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded */
+export let plugins: Promise<any> | undefined;
+/** @type {SyntaxError | undefined} The error thrown when parsing the config, if any.*/
+export let error: SyntaxError | undefined;
 export { parsed as config };

--- a/pyscript.core/types/config.d.ts
+++ b/pyscript.core/types/config.d.ts
@@ -1,4 +1,4 @@
-/** @type {any} The PyScript configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array} */
+/** @type {any} The PyScript configuration parsed from the JSON or TOML object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array} */
 declare let parsed: any;
 /** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded. */
 export let plugins: Promise<any> | undefined;

--- a/pyscript.core/types/config.d.ts
+++ b/pyscript.core/types/config.d.ts
@@ -1,7 +1,7 @@
-/** @type {any} The configuration parsed as a JSON object or similar. (Return type of JSON.parse is something like {number | string | boolean | null | object | Array}; TS by default gives up and says 'any')*/
+/** @type {any} The PyScript configuration parsed as a JSON object*. May be any of the return types of JSON.parse() ( {number | string | boolean | null | object | Array} */
 declare let parsed: any;
-/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded */
+/** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded. */
 export let plugins: Promise<any> | undefined;
-/** @type {SyntaxError | undefined} The error thrown when parsing the config, if any.*/
+/** @type {SyntaxError | undefined} The error thrown when parsing the PyScript config, if any.*/
 export let error: SyntaxError | undefined;
 export { parsed as config };

--- a/pyscript.core/types/exceptions.d.ts
+++ b/pyscript.core/types/exceptions.d.ts
@@ -1,4 +1,12 @@
-export function _createAlertBanner(message: any, level: any, messageType?: string, logMessage?: boolean): void;
+/**
+ * Internal function for creating alert banners on the page
+ * @param {string} message
+ * @param {string} level
+ * @param {string} messageType="text"
+ * @param {any} logMessage=true
+ * @returns {undefined}
+ */
+export function _createAlertBanner(message: string, level: string, messageType?: string, logMessage?: any): undefined;
 export namespace ErrorCode {
     let GENERIC: string;
     let CONFLICTING_CODE: string;
@@ -15,14 +23,50 @@ export namespace ErrorCode {
     let FETCH_SERVER_ERROR: string;
     let FETCH_UNAVAILABLE_ERROR: string;
 }
+/**
+ * Keys of the ErrorCode 'enum'
+ * @typedef {keyof ErrorCode} ErrorCodes
+ * */
 export class UserError extends Error {
-    constructor(errorCode: any, message?: string, messageType?: string);
-    errorCode: any;
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * @param {string} messageType
+     * */
+    constructor(errorCode: ErrorCodes, message?: string, messageType?: string);
+    errorCode: "GENERIC" | "CONFLICTING_CODE" | "BAD_CONFIG" | "MICROPIP_INSTALL_ERROR" | "BAD_PLUGIN_FILE_EXTENSION" | "NO_DEFAULT_EXPORT" | "TOP_LEVEL_AWAIT" | "FETCH_ERROR" | "FETCH_NAME_ERROR" | "FETCH_UNAUTHORIZED_ERROR" | "FETCH_FORBIDDEN_ERROR" | "FETCH_NOT_FOUND_ERROR" | "FETCH_SERVER_ERROR" | "FETCH_UNAVAILABLE_ERROR";
     messageType: string;
 }
 export class FetchError extends UserError {
-    constructor(errorCode: any, message: any);
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * */
+    constructor(errorCode: ErrorCodes, message: string);
 }
 export class InstallError extends UserError {
-    constructor(errorCode: any, message: any);
+    /**
+     * @param {ErrorCodes} errorCode
+     * @param {string} message
+     * */
+    constructor(errorCode: ErrorCodes, message: string);
 }
+/**
+ * Keys of the ErrorCode 'enum'
+ */
+export type ErrorCodes = keyof {
+    GENERIC: string;
+    CONFLICTING_CODE: string;
+    BAD_CONFIG: string;
+    MICROPIP_INSTALL_ERROR: string;
+    BAD_PLUGIN_FILE_EXTENSION: string;
+    NO_DEFAULT_EXPORT: string;
+    TOP_LEVEL_AWAIT: string;
+    FETCH_ERROR: string;
+    FETCH_NAME_ERROR: string;
+    FETCH_UNAUTHORIZED_ERROR: string;
+    FETCH_FORBIDDEN_ERROR: string;
+    FETCH_NOT_FOUND_ERROR: string;
+    FETCH_SERVER_ERROR: string;
+    FETCH_UNAVAILABLE_ERROR: string;
+};

--- a/pyscript.core/types/exceptions.d.ts
+++ b/pyscript.core/types/exceptions.d.ts
@@ -24,7 +24,7 @@ export namespace ErrorCode {
     let FETCH_UNAVAILABLE_ERROR: string;
 }
 /**
- * Keys of the ErrorCode 'enum'
+ * Keys of the ErrorCode object
  * @typedef {keyof ErrorCode} ErrorCodes
  * */
 export class UserError extends Error {
@@ -52,7 +52,7 @@ export class InstallError extends UserError {
     constructor(errorCode: ErrorCodes, message: string);
 }
 /**
- * Keys of the ErrorCode 'enum'
+ * Keys of the ErrorCode object
  */
 export type ErrorCodes = keyof {
     GENERIC: string;

--- a/pyscript.core/types/exceptions.d.ts
+++ b/pyscript.core/types/exceptions.d.ts
@@ -1,12 +1,11 @@
 /**
  * Internal function for creating alert banners on the page
- * @param {string} message
- * @param {string} level
- * @param {string} messageType="text"
- * @param {any} logMessage=true
- * @returns {undefined}
+ * @param {string} message The message to be displayed to the user
+ * @param {string} level The alert level of the message. Can be any string; 'error' or 'warning' cause matching messages to be emitted to the console
+ * @param {string} [messageType="text"] If set to "html", the message content will be assigned to the banner's innerHTML directly, instead of its textContent
+ * @param {any} [logMessage=true] An additional flag for whether the message should be sent to the console log.
  */
-export function _createAlertBanner(message: string, level: string, messageType?: string, logMessage?: any): undefined;
+export function _createAlertBanner(message: string, level: string, messageType?: string, logMessage?: any): void;
 export namespace ErrorCode {
     let GENERIC: string;
     let CONFLICTING_CODE: string;

--- a/pyscript.core/types/plugins/error.d.ts
+++ b/pyscript.core/types/plugins/error.d.ts
@@ -1,1 +1,6 @@
-export function notify(message: any): void;
+/**
+ * Add a banner to the top of the page, notifying the user of an error
+ * @param {string} message
+ * @returns {undefined}
+ */
+export function notify(message: string): undefined;

--- a/pyscript.core/types/plugins/error.d.ts
+++ b/pyscript.core/types/plugins/error.d.ts
@@ -1,6 +1,5 @@
 /**
  * Add a banner to the top of the page, notifying the user of an error
  * @param {string} message
- * @returns {undefined}
  */
-export function notify(message: string): undefined;
+export function notify(message: string): void;

--- a/pyscript.core/types/sync.d.ts
+++ b/pyscript.core/types/sync.d.ts
@@ -2,8 +2,7 @@ declare namespace _default {
     /**
      * 'Sleep' for the given number of seconds. Used to implement Python's time.sleep in Worker threads.
      * @param {number} seconds The number of seconds to sleep.
-     * @returns {undefined}
      */
-    function sleep(seconds: number): undefined;
+    function sleep(seconds: number): Promise<any>;
 }
 export default _default;

--- a/pyscript.core/types/sync.d.ts
+++ b/pyscript.core/types/sync.d.ts
@@ -1,4 +1,9 @@
 declare namespace _default {
-    function sleep(seconds: any): Promise<any>;
+    /**
+     * 'Sleep' for the given number of seconds. Used to implement Python's time.sleep in Worker threads.
+     * @param {number} seconds The number of seconds to sleep.
+     * @returns {undefined}
+     */
+    function sleep(seconds: number): undefined;
 }
 export default _default;


### PR DESCRIPTION
## Description

Adds a few additional types/removes a few `any`s in:
  - config.js
  - exceptions.js
  - plugins/error.js
  - sync.js

Not critical for nor important for the `2023.09.1` release. Just a little housekeeping.

[Edit] I didn't add the [Next] prefix because Next is now Main... hope that was right!

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
