### PR TITLE
Fix `target` attribute lookup on `<script type="py">`

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -205,7 +205,7 @@ for (const [TYPE, interpreter] of TYPES) {
                     } = element;
                     const hasTarget = !!target?.value;
                     const show = hasTarget
-                        ? queryTarget(target.value)
+                        ? queryTarget(element, target.value)
                         : document.createElement("script-py");
 
                     if (!hasTarget) {

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -54,7 +54,7 @@ class TestDisplay(PyScriptTest):
         lines = [line for line in filter_page_content(lines)]  # remove empty lines
         assert lines == ["hello 1", "hello 2", "hello 3"]
 
-    def test_target_attribute(self):
+    def test_target_parameter(self):
         self.pyscript_run(
             """
             <script type="py">
@@ -66,6 +66,25 @@ class TestDisplay(PyScriptTest):
         )
         mydiv = self.page.locator("#mydiv")
         assert mydiv.inner_text() == "hello world"
+
+    def test_tag_target_attribute(self):
+        self.pyscript_run(
+            """
+            <script type="py" target="hello">
+                from pyscript import display
+                display('hello')
+                display("goodbye world", target="goodbye")
+                display('world')
+            </script>
+            <div id="hello"></div>
+            <div id="goodbye"></div>
+            """
+        )
+        hello = self.page.locator("#hello")
+        assert hello.inner_text() == "hello\nworld"
+
+        goodbye = self.page.locator("#goodbye")
+        assert goodbye.inner_text() == "goodbye world"
 
     def test_target_script_py(self):
         self.pyscript_run(
@@ -83,7 +102,7 @@ class TestDisplay(PyScriptTest):
             """
         )
         text = self.page.inner_text("body")
-        assert text == 'ONE\nTWO\nTHREE'
+        assert text == "ONE\nTWO\nTHREE"
 
     def test_consecutive_display_target(self):
         self.pyscript_run(
@@ -200,8 +219,8 @@ class TestDisplay(PyScriptTest):
             </script>
         """
         )
-        output = self.page.locator('script-py')
-        assert output.inner_text() == 'AAA\nBBB'
+        output = self.page.locator("script-py")
+        assert output.inner_text() == "AAA\nBBB"
 
     def test_append_false(self):
         self.pyscript_run(
@@ -213,8 +232,8 @@ class TestDisplay(PyScriptTest):
             </script>
         """
         )
-        output = self.page.locator('script-py')
-        assert output.inner_text() == 'BBB'
+        output = self.page.locator("script-py")
+        assert output.inner_text() == "BBB"
 
     def test_display_multiple_values(self):
         self.pyscript_run(
@@ -227,7 +246,7 @@ class TestDisplay(PyScriptTest):
             </script>
             """
         )
-        output = self.page.locator('script-py')
+        output = self.page.locator("script-py")
         assert output.inner_text() == "hello\nworld"
 
     def test_display_multiple_append_false(self):
@@ -240,7 +259,7 @@ class TestDisplay(PyScriptTest):
             </script>
         """
         )
-        output = self.page.locator('script-py')
+        output = self.page.locator("script-py")
         assert output.inner_text() == "world"
 
     # TODO: this is a display.py issue to fix when append=False is used


### PR DESCRIPTION
## Description

Fixes an error when the `target` attribute is used with `<script type="py">`. Fixes #1750 .

## Changes

- Ensure that `queryTarget` is passed both the element and the selector
- Add a test (`test_tag_target_attribute`)
- Rename `test_target_attribute` (which tests `display(..., target="...")` ---> `test_target_parameter` to help distinguish the two.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [x] I have created documentation for this(if applicable)
