### PR TITLE
Fix #1764 - Unescape `innerHTML` artifacts

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.4.6"
+                "polyscript": "^0.4.7"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
                 "@rollup/plugin-terser": "^0.4.3",
                 "eslint": "^8.50.0",
-                "rollup": "^3.29.3",
+                "rollup": "^3.29.4",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.2",
@@ -49,9 +49,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.2.tgz",
-            "integrity": "sha512-0MGxAVt1m/ZK+LTJp/j0qF7Hz97D9O/FH9Ms3ltnyIdDD57cbb1ACIQTkbHvNXtWDv5TPq7w5Kq56+cNukbo7g==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+            "integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -410,9 +410,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.11",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
-            "integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
+            "integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
             "dev": true,
             "funding": [
                 {
@@ -429,8 +429,8 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001538",
-                "electron-to-chromium": "^1.4.526",
+                "caniuse-lite": "^1.0.30001539",
+                "electron-to-chromium": "^1.4.530",
                 "node-releases": "^2.0.13",
                 "update-browserslist-db": "^1.0.13"
             },
@@ -481,9 +481,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001539",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
-            "integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==",
+            "version": "1.0.30001541",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+            "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
             "dev": true,
             "funding": [
                 {
@@ -525,15 +525,15 @@
             }
         },
         "node_modules/coincident": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/coincident/-/coincident-0.11.6.tgz",
-            "integrity": "sha512-Ld82kMrjDwNjpi+WE2C1v5ADPvOa+NANBWL8o1ohj+UhFTzDX3OMQOE9NSnjbUuMh+U/WBp39+uO2WFs8vJ3sw==",
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-0.13.3.tgz",
+            "integrity": "sha512-S97aRYpTb0EOI1o0V3lgxPtvk1GNQqLew9IorDRNg/1sN6m8EdOgJtGt/dVwkWkDNNgG7xRIra6Yf9qHne67Dw==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0"
             },
             "optionalDependencies": {
-                "ws": "^8.13.0"
+                "ws": "^8.14.2"
             }
         },
         "node_modules/color-convert": {
@@ -851,9 +851,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.529",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz",
-            "integrity": "sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A==",
+            "version": "1.4.532",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.532.tgz",
+            "integrity": "sha512-piIR0QFdIGKmOJTSNg5AwxZRNWQSXlRYycqDB9Srstx4lip8KpcmRxVP6zuFWExWziHYZpJ0acX7TxqX95KBpg==",
             "dev": true
         },
         "node_modules/entities": {
@@ -1222,6 +1222,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "node_modules/icss-replace-symbols": {
             "version": "1.1.0",
@@ -1776,15 +1781,16 @@
             "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
         },
         "node_modules/polyscript": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.4.6.tgz",
-            "integrity": "sha512-yRL8iwa8NHCWYIkYIRZ7Ujwd69WaDKAoeFxhQRLkTmcdlKKFxoFJStwyb5PONWZUl+mb+oXGkrPPsRaAJHHipQ==",
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.4.7.tgz",
+            "integrity": "sha512-nkAKkhZBsyfxdRglIWmvyGsI54MsG2F0BwygkLWAseYBfs5dspB7plAg1tlckqWkUE01wr3Ha/kenwJkEUvbhQ==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
                 "codedent": "^0.1.2",
-                "coincident": "^0.11.6"
+                "coincident": "^0.13.3",
+                "html-escaper": "^3.0.3"
             }
         },
         "node_modules/postcss": {
@@ -2455,9 +2461,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.29.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz",
-            "integrity": "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==",
+            "version": "3.29.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+            "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -33,13 +33,13 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.4.6"
+        "polyscript": "^0.4.7"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.3",
         "eslint": "^8.50.0",
-        "rollup": "^3.29.3",
+        "rollup": "^3.29.4",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.2",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -9,7 +9,11 @@ import {
     XWorker,
 } from "../node_modules/polyscript/esm/index.js";
 import { queryTarget } from "../node_modules/polyscript/esm/script-handler.js";
-import { dedent, dispatch } from "../node_modules/polyscript/esm/utils.js";
+import {
+    dedent,
+    dispatch,
+    unescape,
+} from "../node_modules/polyscript/esm/utils.js";
 import { Hook } from "../node_modules/polyscript/esm/worker/hooks.js";
 
 import "./all-done.js";
@@ -108,12 +112,12 @@ for (const [TYPE, interpreter] of TYPES) {
 
         if (asText) return dedent(tag.textContent);
 
+        const code = dedent(unescape(tag.innerHTML));
         console.warn(
             `Deprecated: use <script type="${TYPE}"> for an always safe content parsing:\n`,
-            tag.innerHTML,
+            code,
         );
-
-        return dedent(tag.innerHTML);
+        return code;
     };
 
     // define the module as both `<script type="py">` and `<py-script>`

--- a/pyscript.core/test/html-decode.html
+++ b/pyscript.core/test/html-decode.html
@@ -7,7 +7,29 @@
   <body>
     <body>
       <py-script>import js; js.console.log(1<2, 1>2)</py-script>
-      <py-script>js.console.log("<div></div>")</py-script>
+      <py-script>import js; js.console.log("<div></div>")</py-script>
+      <script type="py">
+        import js
+        js.console.log("A", 1<2, 1>2)
+        js.console.log("B <div></div>")
+      </script>
+      <py-script>
+        import js
+        js.console.log("C", 1<2, 1>2)
+        js.console.log("D <div></div>")
+      </py-script>
+      <py-script worker>import js; js.console.log(1<2, 1>2)</py-script>
+      <py-script worker>import js; js.console.log("<div></div>")</py-script>
+      <script type="py" worker>
+        import js
+        js.console.log("A", 1<2, 1>2)
+        js.console.log("B <div></div>")
+      </script>
+      <py-script worker>
+        import js
+        js.console.log("C", 1<2, 1>2)
+        js.console.log("D <div></div>")
+      </py-script>
     </body>
   </body>
 </html>

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -43,7 +43,7 @@ class TestBasic(PyScriptTest):
         in_worker = str(in_worker).lower()
         assert self.console.log.lines[-1] == f"worker? {in_worker}"
 
-    @skip_worker('NEXT: it should show a nice error on the page')
+    @skip_worker("NEXT: it should show a nice error on the page")
     def test_no_cors_headers(self):
         self.disable_cors_headers()
         self.pyscript_run(
@@ -58,7 +58,7 @@ class TestBasic(PyScriptTest):
         assert self.headers == {}
         if self.execution_thread == "main":
             self.wait_for_pyscript()
-            assert self.console.log.lines == ['hello']
+            assert self.console.log.lines == ["hello"]
             self.assert_no_banners()
         else:
             # XXX adapt and fix the test
@@ -72,7 +72,6 @@ class TestBasic(PyScriptTest):
             )
             alert_banner = self.page.wait_for_selector(".alert-banner")
             assert expected_alert_banner_msg in alert_banner.inner_text()
-
 
     def test_print(self):
         self.pyscript_run(
@@ -159,18 +158,22 @@ class TestBasic(PyScriptTest):
             "four",
         ]
 
-    @skip_worker("NEXT: something very weird happens here")
     def test_escaping_of_angle_brackets(self):
         """
         Check that script tags escape angle brackets
         """
         self.pyscript_run(
             """
-            <script type="py">import js; js.console.log("A", 1<2, 1>2)</script>
-            <script type="py">import js; js.console.log("B <div></div>")</script>
-            <py-script>import js; js.console.log("C", 1<2, 1>2)</py-script>
-            <py-script>import js; js.console.log("D <div></div>")</py-script>
-
+            <script type="py">
+                import js
+                js.console.log("A", 1<2, 1>2)
+                js.console.log("B <div></div>")
+            </script>
+            <py-script>
+                import js
+                js.console.log("C", 1<2, 1>2)
+                js.console.log("D <div></div>")
+            </py-script>
         """
         )
         # in workers the order of execution is not guaranteed, better to play


### PR DESCRIPTION
## Description

This MR simply removes undesired, automatically returned, `innerHTML` artifacts from the source code.

## Changes

  * use a long-standing minimalistic escaper to be sure unintended HTML is removed
  * change smoke test to be sure everything works as expected
  * un-comment the skipped test to catch further issues in the future

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
