### PR TITLE
Fix #1765 - Pass the optional config `interpreter` value

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -130,6 +130,7 @@ for (const [TYPE, interpreter] of TYPES) {
             config,
             interpreter,
             env: `${TYPE}-script`,
+            version: config?.interpreter,
             onerror(error, element) {
                 errors.set(element, error);
             },


### PR DESCRIPTION
## Description

This MR simply passes along whatever `interpreter` value was set in the `<py-config>` or `<mpy-config>` allowing anyone to test different versions of their interpreters without needing upstream changes in *polyscript*.

## Changes

  * pass the `version` property to *polyscript* on custom type definition (as it's tested and working in there) via the `interpreter` config field
  * smoke test *polyscript* behind the scene to be sure both versions and interpreter versions match

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
