### PR TITLE
Add experimental files config parser

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.4.7"
+                "polyscript": "^0.4.8"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
@@ -1781,9 +1781,9 @@
             "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
         },
         "node_modules/polyscript": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.4.7.tgz",
-            "integrity": "sha512-nkAKkhZBsyfxdRglIWmvyGsI54MsG2F0BwygkLWAseYBfs5dspB7plAg1tlckqWkUE01wr3Ha/kenwJkEUvbhQ==",
+            "version": "0.4.8",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.4.8.tgz",
+            "integrity": "sha512-YlgjdMeEnv/i6WOqkh7gc52iSPY1l/psA+egu7z1GNrjwq6udw4WuQPz3rHRbaFhTUdYsVulLd8SBugjbVH6sQ==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -33,7 +33,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.4.7"
+        "polyscript": "^0.4.8"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",


### PR DESCRIPTION
## Description

This MR simply brings in the latest *polyscript* which `config` parser understands the `files` field too as discussed in https://github.com/pyscript/pyscript/discussions/1755

## Changes

  * update *polyscript* to its latest after testing it does what it's supposed to do

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
