### PR TITLE
Fix #1766 - Ensure correct hooks types

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,7 +11,8 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.4.8"
+                "polyscript": "^0.4.8",
+                "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.1",
@@ -2801,6 +2802,11 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/type-checked-collections": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/type-checked-collections/-/type-checked-collections-0.1.7.tgz",
+            "integrity": "sha512-fLIydlJy7IG9XL4wjRwEcKhxx/ekLXiWiMvcGo01cOMF+TN+5ZqajM1mRNRz2bNNi1bzou2yofhjZEQi7kgl9A=="
         },
         "node_modules/type-fest": {
             "version": "0.20.2",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -33,7 +33,8 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.4.8"
+        "polyscript": "^0.4.8",
+        "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -137,6 +137,8 @@ for (const [TYPE, interpreter] of TYPES) {
             ...workerHooks,
             onWorkerReady(_, xworker) {
                 assign(xworker.sync, sync);
+                for (const callback of hooks.onWorkerReady)
+                    callback(_, xworker);
             },
             onBeforeRun(wrap, element) {
                 currentElement = element;

--- a/pyscript.core/src/hooks.js
+++ b/pyscript.core/src/hooks.js
@@ -1,21 +1,28 @@
+import { typedSet } from "type-checked-collections";
+
+const SetFunction = typedSet({ typeof: "function" });
+const SetString = typedSet({ typeof: "string" });
+
 export default {
     /** @type {Set<function>} */
-    onBeforeRun: new Set(),
+    onInterpreterReady: new SetFunction(),
     /** @type {Set<function>} */
-    onBeforeRunAsync: new Set(),
+    onBeforeRun: new SetFunction(),
     /** @type {Set<function>} */
-    onAfterRun: new Set(),
+    onBeforeRunAsync: new SetFunction(),
     /** @type {Set<function>} */
-    onAfterRunAsync: new Set(),
+    onAfterRun: new SetFunction(),
     /** @type {Set<function>} */
-    onInterpreterReady: new Set(),
+    onAfterRunAsync: new SetFunction(),
 
+    /** @type {Set<function>} */
+    onWorkerReady: new SetFunction(),
     /** @type {Set<string>} */
-    codeBeforeRunWorker: new Set(),
+    codeBeforeRunWorker: new SetString(),
     /** @type {Set<string>} */
-    codeBeforeRunWorkerAsync: new Set(),
+    codeBeforeRunWorkerAsync: new SetString(),
     /** @type {Set<string>} */
-    codeAfterRunWorker: new Set(),
+    codeAfterRunWorker: new SetString(),
     /** @type {Set<string>} */
-    codeAfterRunWorkerAsync: new Set(),
+    codeAfterRunWorkerAsync: new SetString(),
 };

--- a/pyscript.core/types/hooks.d.ts
+++ b/pyscript.core/types/hooks.d.ts
@@ -1,9 +1,10 @@
 declare namespace _default {
+    let onInterpreterReady: Set<Function>;
     let onBeforeRun: Set<Function>;
     let onBeforeRunAsync: Set<Function>;
     let onAfterRun: Set<Function>;
     let onAfterRunAsync: Set<Function>;
-    let onInterpreterReady: Set<Function>;
+    let onWorkerReady: Set<Function>;
     let codeBeforeRunWorker: Set<string>;
     let codeBeforeRunWorkerAsync: Set<string>;
     let codeAfterRunWorker: Set<string>;


### PR DESCRIPTION
## Description

This MR brings in the [type-checked-collections](https://github.com/WebReflection/type-checked-collections#readme) module so that our hooks are now guarded to be of correct types.

This MR also adds the `onWorkerReady` hook which was missing.

## Changes

  * used two different typed *Set* a `function` one and a `string` one
  * add logic for `onWorkerReady` as we were not exposing it before

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
