### PR TITLE
Add a selector to the HTML tag + export config

### DIFF
--- a/pyscript.core/tests/integration/support.py
+++ b/pyscript.core/tests/integration/support.py
@@ -471,9 +471,7 @@ class PyScriptTest:
         self.logger.log(
             "wait_for_pyscript", f"Waited for {elapsed_ms/1000:.2f} s", color="yellow"
         )
-        # We still don't know why this wait is necessary, but without it
-        # events aren't being triggered in the tests.
-        self.page.wait_for_timeout(100)
+        self.page.wait_for_selector("html.all-done")
 
     SCRIPT_TAG_REGEX = re.compile('(<script type="py"|<py-script)')
 
@@ -487,15 +485,15 @@ class PyScriptTest:
         <html>
           <head>
               <link rel="stylesheet" href="{self.http_server_addr}/build/core.css">
-              <script
-                    type="module"
-                    src="{self.http_server_addr}/build/core.js"
-                ></script>
               <script type="module">
+                import {{ config }} from "{self.http_server_addr}/build/core.js";
+                globalThis.pyConfig = config.py;
+                globalThis.mpyConfig = config.mpy;
                 addEventListener(
                   'py:all-done',
                   () => {{
-                    console.debug('---py:all-done---')
+                    console.debug('---py:all-done---');
+                    document.documentElement.classList.add('all-done');
                   }},
                   {{ once: true }}
                 );

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -461,4 +461,4 @@ class TestDisplay(PyScriptTest):
         )
 
         img_src = self.page.locator("img").get_attribute("src")
-        assert img_src.startswith('data:image/png;charset=utf-8;base64')
+        assert img_src.startswith("data:image/png;charset=utf-8;base64")

--- a/pyscript.core/tests/integration/test_py_config.py
+++ b/pyscript.core/tests/integration/test_py_config.py
@@ -23,9 +23,8 @@ class TestConfig(PyScriptTest):
         </py-config>
 
         <py-script async>
-            from pyscript import window, document
-            promise = await document.currentScript._pyodide.promise
-            window.console.log("config name:", promise.config.name)
+            from pyscript import window
+            window.console.log("config name:", window.pyConfig.name)
         </py-script>
         """
         )
@@ -40,9 +39,8 @@ class TestConfig(PyScriptTest):
         </py-config>
 
         <script type="py" async>
-            from pyscript import window, document
-            promise = await document.currentScript._pyodide.promise
-            window.console.log("config name:", promise.config.name)
+            from pyscript import window
+            window.console.log("config name:", window.pyConfig.name)
         </script>
         """
         )
@@ -59,9 +57,8 @@ class TestConfig(PyScriptTest):
         <py-config src="pyconfig.toml"></py-config>
 
         <script type="py" async>
-            from pyscript import window, document
-            promise = await document.currentScript._pyodide.promise
-            window.console.log("config name:", promise.config.name)
+            from pyscript import window
+            window.console.log("config name:", window.pyConfig.name)
         </script>
         """
         )


### PR DESCRIPTION
## Description

This MR adds an easy to wait for HTML class selector on `py:all-done` event + it exports `pyConfig` and `mpyConfig` globally to let us easily test anything we'd like to test.

## Changes

  * leak globally `config.py` as `pyConfig` and `config.mpy` as `mpyConfig`
  * use the HTML selector to be sure DOM changes are applied

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
