### PR TITLE
Fix #1777 - Export also PyWorker and current_target

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.5",
+    "version": "0.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.2.5",
+            "version": "0.2.7",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.5",
+    "version": "0.2.7",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -29,7 +29,7 @@
 #     pyscript.magic_js. This is the blessed way to access them from pyscript,
 #     as it works transparently in both the main thread and worker cases.
 
-from pyscript.magic_js import RUNNING_IN_WORKER, window, document, sync
+from pyscript.magic_js import RUNNING_IN_WORKER, PyWorker, window, document, sync, current_target
 from pyscript.display import HTML, display
 
 try:

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -6,6 +6,16 @@ from .support import PyScriptTest, skip_worker, only_main
 
 
 class TestBasic(PyScriptTest):
+    def test_pyscript_exports(self):
+        self.pyscript_run(
+            """
+            <script type="py">
+                from pyscript import RUNNING_IN_WORKER, PyWorker, window, document, sync, current_target
+            </script>
+            """
+        )
+        assert self.console.error.lines == []
+
     def test_script_py_hello(self):
         self.pyscript_run(
             """


### PR DESCRIPTION
## Description

This MR simply exports stuff that used to be exported and it's also documented so that it fixes #1777.

## Changes

  * export all fields from `magic_js.py`
  * add a test to check those exports don't throw out of the box

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
