### PR TITLE
Fix #1780 - Clean up elements before writing

### DIFF
--- a/pyscript.core/src/stdlib/pyscript/display.py
+++ b/pyscript.core/src/stdlib/pyscript/display.py
@@ -3,7 +3,7 @@ import html
 import io
 import re
 
-from pyscript.magic_js import document, window, current_target
+from pyscript.magic_js import current_target, document, window
 
 _MIME_METHODS = {
     "__repr__": "text/plain",
@@ -154,8 +154,10 @@ def display(*values, target=None, append=True):
     # if element is a <script type="py">, it has a 'target' attribute which
     # points to the visual element holding the displayed values. In that case,
     # use that.
-    if element.tagName == 'SCRIPT' and hasattr(element, 'target'):
+    if element.tagName == "SCRIPT" and hasattr(element, "target"):
         element = element.target
 
     for v in values:
+        if not append:
+            element.replaceChildren()
         _write(element, v, append=append)


### PR DESCRIPTION
## Description

This MR takes the *easy* approach on issue #1780 by simply cleaning up target elements when `append=False` or any explicit `not append` is passed along.

## Changes

  * cleanup the target before any operation when `append=False` or `append=None` is passed

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
