### PR TITLE
FIX to display function handling null element reference, and wrong target parameter values

### DIFF
--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -29,7 +29,14 @@
 #     pyscript.magic_js. This is the blessed way to access them from pyscript,
 #     as it works transparently in both the main thread and worker cases.
 
-from pyscript.magic_js import RUNNING_IN_WORKER, PyWorker, window, document, sync, current_target
+from pyscript.magic_js import (
+    RUNNING_IN_WORKER,
+    PyWorker,
+    window,
+    document,
+    sync,
+    current_target,
+)
 from pyscript.display import HTML, display
 
 try:
@@ -38,6 +45,5 @@ except:
     from pyscript.util import NotSupported
 
     when = NotSupported(
-        "pyscript.when",
-        "pyscript.when currently not available with this interpreter"
+        "pyscript.when", "pyscript.when currently not available with this interpreter"
     )

--- a/pyscript.core/src/stdlib/pyscript/display.py
+++ b/pyscript.core/src/stdlib/pyscript/display.py
@@ -148,8 +148,22 @@ def _write(element, value, append=False):
 def display(*values, target=None, append=True):
     if target is None:
         target = current_target()
+    elif not isinstance(target, str):
+        raise TypeError(f"target must be str or None, not {target.__class__.__name__}")
+    elif target == "":
+        raise ValueError("Cannot have an empty target")
+    elif target.startswith("#"):
+        # note: here target is str and not None!
+        # align with @when behavior
+        target = target[1:]
 
     element = document.getElementById(target)
+
+    # If target cannot be found on the page, a ValueError is raised
+    if element is None:
+        raise ValueError(
+            f"Invalid selector with id={target}. Cannot be found in the page."
+        )
 
     # if element is a <script type="py">, it has a 'target' attribute which
     # points to the visual element holding the displayed values. In that case,

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -7,8 +7,9 @@ if RUNNING_IN_WORKER:
     import polyscript
 
     PyWorker = NotSupported(
-        'pyscript.PyWorker',
-        'pyscript.PyWorker works only when running in the main thread')
+        "pyscript.PyWorker",
+        "pyscript.PyWorker works only when running in the main thread",
+    )
     window = polyscript.xworker.window
     document = window.document
     sync = polyscript.xworker.sync
@@ -21,11 +22,12 @@ if RUNNING_IN_WORKER:
 else:
     import _pyscript
     from _pyscript import PyWorker
+
     window = globalThis
     document = globalThis.document
     sync = NotSupported(
-        'pyscript.sync',
-        'pyscript.sync works only when running in a worker')
+        "pyscript.sync", "pyscript.sync works only when running in a worker"
+    )
 
     # in MAIN the current element target exist, just use it
     def current_target():

--- a/pyscript.core/tests/integration/support.py
+++ b/pyscript.core/tests/integration/support.py
@@ -362,9 +362,6 @@ class PyScriptTest:
         See the docstring for _check_page_errors for more details.
         """
         self._check_page_errors("Python", expected_messages)
-        # Check Console error
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
     def clear_js_errors(self):
         """

--- a/pyscript.core/tests/integration/support.py
+++ b/pyscript.core/tests/integration/support.py
@@ -362,6 +362,9 @@ class PyScriptTest:
         See the docstring for _check_page_errors for more details.
         """
         self._check_page_errors("Python", expected_messages)
+        # Check Console error
+        tb_lines = self.console.error.lines[-1].splitlines()
+        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
     def clear_js_errors(self):
         """

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -106,10 +106,6 @@ class TestBasic(PyScriptTest):
         assert "hello pyscript" in self.console.log.lines
         self.check_py_errors("Exception: this is an error")
         #
-        # check that we sent the traceback to the console
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
-        #
         # check that we show the traceback in the page. Note that here we
         # display the "raw" python traceback, without the "[pyexec] Python
         # exception:" line (which is useful in the console, but not for the
@@ -137,10 +133,6 @@ class TestBasic(PyScriptTest):
         )
 
         self.check_py_errors("Exception: this is an error inside handler")
-
-        ## error in console
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
         ## error in DOM
         tb_lines = self.page.locator(".py-error").inner_text().splitlines()

--- a/pyscript.core/tests/integration/test_02_display.py
+++ b/pyscript.core/tests/integration/test_02_display.py
@@ -99,9 +99,6 @@ class TestDisplay(PyScriptTest):
             f"Invalid selector with id=non-existing. Cannot be found in the page."
         )
         self.check_py_errors(f"ValueError: {error_msg}")
-        # Check Console error
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
     def test_empty_string_target_raises_value_error(self):
         self.pyscript_run(
@@ -113,9 +110,6 @@ class TestDisplay(PyScriptTest):
             """
         )
         self.check_py_errors(f"ValueError: Cannot have an empty target")
-        # Check Console error
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
     def test_non_string_target_values_raise_typerror(self):
         self.pyscript_run(
@@ -128,9 +122,6 @@ class TestDisplay(PyScriptTest):
         )
         error_msg = f"target must be str or None, not bool"
         self.check_py_errors(f"TypeError: {error_msg}")
-        # Check Console error
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
         self.pyscript_run(
             """
@@ -142,9 +133,6 @@ class TestDisplay(PyScriptTest):
         )
         error_msg = f"target must be str or None, not int"
         self.check_py_errors(f"TypeError: {error_msg}")
-        # Check Console error
-        tb_lines = self.console.error.lines[-1].splitlines()
-        assert tb_lines[0] == "PythonError: Traceback (most recent call last):"
 
     @skip_worker("NEXT: display(target=...) does not work")
     def test_tag_target_attribute(self):


### PR DESCRIPTION
## Description

<!--Please describe the changes in your pull request in few words here. -->

This PR includes a more robust implementation of the `display` function, and appropriate exception raised. 
All changes to code are corroborated by corresponding test cases (see `tests/integration/test_02_display.py`)

In more details. 
First, the`target` parameter is checked to be of type `str` or `None`. If that's not the case, a `TypeError` exception is raised. This is in line with similar implementations in the Python language (e.g. `str.split` with an integer separator).
Then, if `target` is an empty string, a `ValueError` is raised.

Afterwards, if `target` starts with `#`, the initial `#` is removed so that the next `document.getElementById` would still be capturing the intended target. 
This change would _align_ with the default behaviour of the `@when` decorator where selector is expected to be provided. 
This comes from personal experience of using the wrong selector/target in both cases. Possibly, another PR for `@when` could also be discussed. 

Last but by no means least (and indeed the very first reason why I worked on this! 😄 ) - a `ValueError` exception is now raised if `element` does not exist.

<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->

- Specialised initial `if-elif` branches w/ new cases & exceptions
- added new if branch to check whether `element is None` (as returned by `document.getElementById`
- added corresponding tests to check new cases. 

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
