### PR TITLE
Wait for plugins before defining the custom type

### DIFF
--- a/pyscript.core/src/config.js
+++ b/pyscript.core/src/config.js
@@ -50,7 +50,7 @@ const syntaxError = (type, url, { message }) => {
 const configs = new Map();
 
 for (const [TYPE] of TYPES) {
-    /** @type {Promise<any> | undefined} A Promise wrapping any plugins which should be loaded. */
+    /** @type {Promise<[...any]>} A Promise wrapping any plugins which should be loaded. */
     let plugins;
 
     /** @type {any} The PyScript configuration parsed from the JSON or TOML object*. May be any of the return types of JSON.parse() or toml-j0.4's parse() ( {number | string | boolean | null | object | Array} ) */
@@ -119,7 +119,7 @@ for (const [TYPE] of TYPES) {
     }
 
     // assign plugins as Promise.all only if needed
-    if (toBeAwaited.length) plugins = Promise.all(toBeAwaited);
+    plugins = Promise.all(toBeAwaited);
 
     configs.set(TYPE, { config: parsed, plugins, error });
 }


### PR DESCRIPTION
## Description

This MR ensure once that plugins are awaited before custom types are defined, granting somehow that plugins code can run and guarantee all hooks are actually used when custom types bootstrap.

This is needed to also eventually improve plugins support within *workers*.

## Changes

  * await for plugins *without* blocking current module execution so that exports are still available to plugins
  * define custom elements and custom types only after all plugins have been resolved
  * minor cleanup here and there, most notably removed the `_pyodide` ugly and undesired getter

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
