### PR TITLE
Fix #1799 - Avoid multiple bootstraps when embedded

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,18 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.2.9",
+            "version": "0.2.10",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
                 "polyscript": "^0.4.20",
+                "sticky-module": "^0.1.0",
                 "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
@@ -1015,9 +1016,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.548",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.548.tgz",
-            "integrity": "sha512-R77KD6mXv37DOyKLN/eW1rGS61N6yHOfapNSX9w+y9DdPG83l9Gkuv7qkCFZ4Ta4JPhrjgQfYbv4Y3TnM1Hi2Q==",
+            "version": "1.4.549",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.549.tgz",
+            "integrity": "sha512-gpXfJslSi4hYDkA0mTLEpYKRv9siAgSUgZ+UWyk+J5Cttpd1ThCVwdclzIwQSclz3hYn049+M2fgrP1WpvF8xg==",
             "dev": true
         },
         "node_modules/entities": {
@@ -2566,9 +2567,9 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-            "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dev": true,
             "dependencies": {
                 "is-core-module": "^2.13.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -34,6 +34,7 @@
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
         "polyscript": "^0.4.20",
+        "sticky-module": "^0.1.0",
         "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {

--- a/pyscript.core/src/exceptions.js
+++ b/pyscript.core/src/exceptions.js
@@ -1,3 +1,5 @@
+import { assign } from "polyscript/exports";
+
 const CLOSEBUTTON =
     "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='currentColor' width='12px'><path d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/></svg>";
 
@@ -87,13 +89,13 @@ export function _createAlertBanner(
     }
 
     const content = messageType === "html" ? "innerHTML" : "textContent";
-    const banner = Object.assign(document.createElement("div"), {
+    const banner = assign(document.createElement("div"), {
         className: `alert-banner py-${level}`,
         [content]: message,
     });
 
     if (level === "warning") {
-        const closeButton = Object.assign(document.createElement("button"), {
+        const closeButton = assign(document.createElement("button"), {
             id: "alert-close-button",
             innerHTML: CLOSEBUTTON,
         });

--- a/pyscript.core/src/fetch.js
+++ b/pyscript.core/src/fetch.js
@@ -1,5 +1,5 @@
 import { FetchError, ErrorCode } from "./exceptions.js";
-import { getText } from "../node_modules/polyscript/esm/fetch-utils.js";
+import { getText } from "polyscript/exports";
 
 export { getText };
 

--- a/pyscript.core/types/core.d.ts
+++ b/pyscript.core/types/core.d.ts
@@ -1,16 +1,4 @@
-/**
- * A `Worker` facade able to bootstrap on the worker thread only a PyScript module.
- * @param {string} file the python file to run ina worker.
- * @param {{config?: string | object, async?: boolean}} [options] optional configuration for the worker.
- * @returns {Worker & {sync: ProxyHandler<object>}}
- */
-export function PyWorker(file: string, options?: {
-    config?: string | object;
-    async?: boolean;
-}): Worker & {
-    sync: ProxyHandler<object>;
-};
-import sync from "./sync.js";
-declare const exportedConfig: {};
-import hooks from "./hooks.js";
-export { exportedConfig as config, hooks };
+declare const exportedPyWorker: any;
+declare const exportedHooks: any;
+declare const exportedConfig: any;
+export { exportedPyWorker as PyWorker, exportedHooks as hooks, exportedConfig as config };


### PR DESCRIPTION
## Description

This MR is a follow up of the *polyscript* approach https://github.com/pyscript/polyscript/pull/59 to avoid ever dealing with multiple versions of the project in the wild, as discussed in https://github.com/pyscript/pyscript/issues/1799 + it uses the latest polyscript to also stop having issues when embedded by other tools.

## Changes

  * use the latest `polyscript/exports` to import all utilities and internal needed to make PyScript work
  * use the same global, Symbol based, guard to avoid ever registering or bootstrapping PyScript twice, allowing multiple embedded projects to effectively share hooks too

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
