### PR TITLE
Fix #1812 - Avoid duplicated pyscript module

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -21,7 +21,6 @@ import "./all-done.js";
 import TYPES from "./types.js";
 import configs from "./config.js";
 import sync from "./sync.js";
-import stdlib from "./stdlib.js";
 import bootstrapNodeAndPlugins from "./plugins-helper.js";
 import { ErrorCode } from "./exceptions.js";
 import { robustFetch as fetch, getText } from "./fetch.js";
@@ -52,8 +51,6 @@ const registerModule = ({ XWorker: $XWorker, interpreter, io }) => {
                 : currentElement.id;
         },
     });
-
-    interpreter.runPython(stdlib, { globals: interpreter.runPython("{}") });
 };
 
 // avoid multiple initialization of the same library

--- a/pyscript.core/src/stdlib.js
+++ b/pyscript.core/src/stdlib.js
@@ -10,16 +10,16 @@ import pyscript from "./stdlib/pyscript.js";
 
 const { entries } = Object;
 
-const python = ["from pathlib import Path as _Path"];
+const python = ["from pathlib import Path as _Path", "_path = None"];
 
 const write = (base, literal) => {
     for (const [key, value] of entries(literal)) {
-        const path = `_Path("${base}/${key}")`;
+        python.push(`_path = _Path("${base}/${key}")`);
         if (typeof value === "string") {
             const code = JSON.stringify(value);
-            python.push(`${path}.write_text(${code})`);
+            python.push(`_path.write_text(${code})`);
         } else {
-            python.push(`${path}.mkdir(parents=True, exist_ok=True)`);
+            python.push("_path.mkdir(parents=True, exist_ok=True)");
             write(`${base}/${key}`, value);
         }
     }
@@ -28,6 +28,7 @@ const write = (base, literal) => {
 write(".", pyscript);
 
 python.push("del _Path");
+python.push("del _path");
 python.push("\n");
 
 export default python.join("\n");


### PR DESCRIPTION
## Description

This MR avoids duplicated FileSystem module pollution on main, as that's already part of the code in main hooks story and as that fails, actually rightly so somehow, in MicroPython only.

## Changes

  * remove the manual need to pollute the main thread with code that already runs on `codeBeforeRun` thanks to the shared dance and behavior of latest changes.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
