### PR TITLE
Fix #1814 - Basic mpy integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ clean:
 
 # Build PyScript.
 build:
-	cd pyscript.core && npm run build
+	cd pyscript.core && npx playwright install && npm run build
 
 # Run the precommit checks (run eslint).
 precommit-check:

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -17,6 +17,7 @@
                 "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
+                "@playwright/test": "^1.39.0",
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-terser": "^0.4.4",
                 "@webreflection/toml-j0.4": "^1.1.3",
@@ -218,6 +219,21 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+            "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+            "dev": true,
+            "dependencies": {
+                "playwright": "1.39.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
@@ -2059,6 +2075,50 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/plain-tag/-/plain-tag-0.1.3.tgz",
             "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
+        },
+        "node_modules/playwright": {
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+            "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+            "dev": true,
+            "dependencies": {
+                "playwright-core": "1.39.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+            "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+            "dev": true,
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/polyscript": {
             "version": "0.5.1",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -20,11 +20,12 @@
     },
     "scripts": {
         "server": "npx static-handler --coi .",
-        "build": "npm run build:toml && npm run build:stdlib && npm run build:plugins && npm run build:core && eslint src/ && npm run ts",
+        "build": "npm run build:toml && npm run build:stdlib && npm run build:plugins && npm run build:core && eslint src/ && npm run ts && npm run test:mpy",
         "build:core": "rm -rf dist && rollup --config rollup/core.config.js",
         "build:plugins": "node rollup/plugins.cjs",
         "build:stdlib": "node rollup/stdlib.cjs",
         "build:toml": "node rollup/toml.cjs",
+        "test:mpy": "static-handler --coi . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test --fully-parallel test/ || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
         "dev": "node dev.cjs",
         "release": "npm run build && npm run zip",
         "size": "echo -e \"\\033[1mdist/*.js file size\\033[0m\"; for js in $(ls dist/*.js); do echo -e \"\\033[2m$js:\\033[0m $(cat $js | brotli | wc -c) bytes\"; done",
@@ -46,6 +47,7 @@
         "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {
+        "@playwright/test": "^1.39.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@webreflection/toml-j0.4": "^1.1.3",

--- a/pyscript.core/test/hooks.html
+++ b/pyscript.core/test/hooks.html
@@ -6,28 +6,19 @@
   <title>PyScript Next Plugin Bug?</title>
   <link rel="stylesheet" href="../dist/core.css">
   <script type="module">
-    import { hooks } from "../dist/core.js";
+    addEventListener('mpy:done', () => {
+      document.documentElement.classList.add('done');
+    });
 
-    // Worker
-    hooks.worker.onReady.add((wrap, xworker) => {
-      console.log("worker", "onReady");
-      console.log("worker", "wrap", wrap);
-      console.log("worker", "xworker", xworker);
-    });
-    hooks.worker.onBeforeRun.add(() => {
-      console.log("worker", "onBeforeRun");
-    });
-    hooks.worker.codeBeforeRun.add('print("worker", "codeBeforeRun")');
-    hooks.worker.codeAfterRun.add('print("worker", "codeAfterRun")');
-    hooks.worker.onAfterRun.add(() => {
-      console.log("worker", "onAfterRun");
-    });
+    import { hooks } from "../dist/core.js";
 
     // Main
     hooks.main.onReady.add((wrap, element) => {
       console.log("main", "onReady");
-      console.log("main", "wrap", wrap);
-      console.log("main", "element", element);
+      if (location.search === '?debug') {
+        console.debug("main", "wrap", wrap);
+        console.debug("main", "element", element);
+      }
     });
     hooks.main.onBeforeRun.add(() => {
       console.log("main", "onBeforeRun");
@@ -37,13 +28,30 @@
     hooks.main.onAfterRun.add(() => {
       console.log("main", "onAfterRun");
     });
+
+    // Worker
+    hooks.worker.onReady.add((wrap, xworker) => {
+      console.log("worker", "onReady");
+      if (location.search === '?debug') {
+        console.debug("worker", "wrap", wrap);
+        console.debug("worker", "xworker", xworker);
+      }
+    });
+    hooks.worker.onBeforeRun.add(() => {
+      console.log("worker", "onBeforeRun");
+    });
+    hooks.worker.codeBeforeRun.add('print("worker", "codeBeforeRun")');
+    hooks.worker.codeAfterRun.add('print("worker", "codeAfterRun")');
+    hooks.worker.onAfterRun.add(() => {
+      console.log("worker", "onAfterRun");
+    });
   </script>
 </head>
 <body>
-  <script type="py" worker>
+  <script type="mpy" worker>
     print("actual code in worker")
   </script>
-  <script type="py">
+  <script type="mpy">
     print("actual code in main")
   </script>
 </body>

--- a/pyscript.core/test/mpy.html
+++ b/pyscript.core/test/mpy.html
@@ -5,7 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>PyScript Next</title>
         <script>
-            addEventListener("mpy:ready", console.log);
+            addEventListener('mpy:done', () => {
+                document.documentElement.classList.add('done');
+            });
         </script>
         <link rel="stylesheet" href="../dist/core.css">
         <script type="module" src="../dist/core.js"></script>
@@ -13,11 +15,15 @@
     <body>
         <script type="mpy">
             from pyscript import display
-            display("Hello", "M-PyScript Next", append=False)
+            display("Hello", "M-PyScript Main 1", append=False)
         </script>
+        <mpy-script>
+            from pyscript import display
+            display("Hello", "M-PyScript Main 2", append=False)
+        </mpy-script>
         <mpy-script worker>
             from pyscript import display
-            display("Hello", "M-PyScript Next Worker", append=False)
+            display("Hello", "M-PyScript Worker", append=False)
         </mpy-script>
     </body>
 </html>

--- a/pyscript.core/test/mpy.spec.js
+++ b/pyscript.core/test/mpy.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test('MicroPython display', async ({ page }) => {
+  await page.goto('http://localhost:8080/test/mpy.html');
+  await page.waitForSelector('html.done');
+  const body = await page.evaluate(() => document.body.innerText);
+  await expect(body.trim()).toBe([
+    'M-PyScript Main 1',
+    'M-PyScript Main 2',
+    'M-PyScript Worker',
+  ].join('\n'));
+});
+
+test('MicroPython hooks', async ({ page }) => {
+  const logs = [];
+  page.on('console', msg => {
+    const text = msg.text();
+    if (!text.startsWith('['))
+      logs.push(text);
+  });
+  await page.goto('http://localhost:8080/test/hooks.html');
+  await page.waitForSelector('html.done');
+  await expect(logs.join('\n')).toBe([
+    'main onReady',
+    'main onBeforeRun',
+    'main codeBeforeRun',
+    'actual code in main',
+    'main codeAfterRun',
+    'main onAfterRun',
+    'worker onReady',
+    'worker onBeforeRun',
+    'worker codeBeforeRun',
+    'actual code in worker',
+    'worker codeAfterRun',
+    'worker onAfterRun',
+  ].join('\n'));
+});


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1814 by providing a very simple, fast, yet reliable test around `mpy` custom type, hooks, and display.

This MR also fixes https://github.com/pyscript/pyscript/pull/1813#issuecomment-1781502909 so that multiple MicroPython on main work now without any issue.

## Changes

  * copied over the same script to run integration tests
  * changed smoke-test files to facilitate integration tests
  * slightly changed the *stdlib* bootstrap code to fix MicroPython path issues

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
