### PR TITLE
Use <py-terminal> as default target

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -57,7 +57,7 @@ const pyTerminal = async () => {
                 document.querySelector(selector);
             if (!target) throw new Error(`Unknown target ${selector}`);
         } else {
-            target = document.createElement(`${element.type}-terminal`);
+            target = document.createElement("py-terminal");
             target.style.display = "block";
             element.after(target);
         }


### PR DESCRIPTION
## Description

This MR is a quick amend for the latest PyTerminal one, as when `<py-script>` is used, instead of `<script type="py">`, the terminal is created as `undefined-terminal` due lack of `type` for the element.

As we only support *pyodide* terminal for the time being, I think this is the easiest way to support both cases without ugly names used as terminal targets.

## Changes

  * remove the usage of `element.type` to define the element name
  * use always `py-terminal` as element name to help CSS too

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
