### PR TITLE
PyTerminal: use Pyodide instead of Python

### DIFF
--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -13,7 +13,7 @@
             def greetings(event):
                 print('hello world')
         </script>
-        <py-script terminal>
+        <py-script worker terminal>
             import sys
             from pyscript import display
             display("Hello", "PyScript Next - PyTerminal", append=False)

--- a/pyscript.core/tests/integration/test_py_terminal.py
+++ b/pyscript.core/tests/integration/test_py_terminal.py
@@ -40,6 +40,24 @@ class TestPyTerminal(PyScriptTest):
         self.page.keyboard.press("Enter")
         self.page.get_by_text("the answer is 42").wait_for()
 
+    @only_worker
+    def test_py_terminal_os_write(self):
+        """
+        An `os.write("text")` should land in the terminal
+        """
+        self.pyscript_run(
+            """
+            <script type="py" terminal>
+                import os
+                os.write(1, str.encode("hello\\n"))
+                os.write(2, str.encode("world\\n"))
+            </script>
+            """,
+            wait_for_pyscript=False,
+        )
+        self.page.get_by_text("hello\n").wait_for()
+        self.page.get_by_text("world\n").wait_for()
+
     def test_py_terminal(self):
         """
         1. <py-terminal> should redirect stdout and stderr to the DOM


### PR DESCRIPTION
## Description

This MR specifically addresses [this comment](https://github.com/pyscript/pyscript/pull/1816#discussion_r1378085503) and while everything seems to be fine I'd love to have @hoodmane or @antocuni reading the changes and tell me if this is the best way forward, thank you!

## Changes

  * drop the Python `builtins.input = ...` workaround and use Pyodide directly
  * update the smoke-test page to be sure everything is fine

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
