### PR TITLE
Fix #1834 - Throw an error if more than a terminal exists

### DIFF
--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -1,9 +1,17 @@
 // PyScript py-terminal plugin
 import { TYPES, hooks } from "../core.js";
+import { notify } from "./error.js";
 
 const SELECTOR = [...TYPES.keys()]
     .map((type) => `script[type="${type}"][terminal],${type}-script[terminal]`)
     .join(",");
+
+// show the error on main and
+// stops the module from keep executing
+const notifyAndThrow = (message) => {
+    notify(message);
+    throw new Error(message);
+};
 
 const pyTerminal = async () => {
     const terminals = document.querySelectorAll(SELECTOR);
@@ -11,17 +19,17 @@ const pyTerminal = async () => {
     // no results will look further for runtime nodes
     if (!terminals.length) return;
 
-    // we currently support only one terminal as in "classic"
-    if (terminals.length > 1)
-        console.warn("Unable to satisfy multiple terminals");
-
     // if we arrived this far, let's drop the MutationObserver
+    // as we only support one terminal per page (right now).
     mo.disconnect();
+
+    // we currently support only one terminal as in "classic"
+    if (terminals.length > 1) notifyAndThrow("You can use at most 1 terminal.");
 
     const [element] = terminals;
     // hopefully to be removed in the near future!
     if (element.matches('script[type="mpy"],mpy-script'))
-        throw new Error("Unsupported terminal");
+        notifyAndThrow("Unsupported terminal.");
 
     // import styles lazily
     document.head.append(

--- a/pyscript.core/tests/integration/support.py
+++ b/pyscript.core/tests/integration/support.py
@@ -118,6 +118,20 @@ def only_main(fn):
     return decorated
 
 
+def only_worker(fn):
+    """
+    Decorator to mark a test which make sense only in the worker thread
+    """
+
+    @functools.wraps(fn)
+    def decorated(self, *args):
+        if self.execution_thread != "worker":
+            return
+        return fn(self, *args)
+
+    return decorated
+
+
 def filter_inner_text(text, exclude=None):
     return "\n".join(filter_page_content(text.splitlines(), exclude=exclude))
 

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -80,7 +80,7 @@ class TestBasic(PyScriptTest):
                 '"Cross-Origin-Opener-Policy":"same-origin"}. '
                 "The problem may be that one or both of these are missing."
             )
-            alert_banner = self.page.wait_for_selector(".alert-banner")
+            alert_banner = self.page.wait_for_selector(".py-error")
             assert expected_alert_banner_msg in alert_banner.inner_text()
 
     def test_print(self):


### PR DESCRIPTION
## Description

This MR goal is to stop PyScript execution if more than a terminal is present on the page, as we're still discussing what should happen there or even *if* it should.

## Changes

  * import *error* plugin to notify on the page something is wrong
  * throw regardless to "*stop the world*" hence avoid any further parsing of multiple terminals
  * update integration tests so that it's clear the error is shown

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
