### PR TITLE
Fix #1840 - Do not bootstrap interactive shell

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -98,12 +98,6 @@ const pyTerminal = async () => {
             });
         };
 
-        // at the end of the code, make the terminal interactive
-        const codeAfter = `
-            import code as _code
-            _code.interact()
-        `;
-
         // add a hook on the main thread to setup all sync helpers
         // also bootstrapping the XTerm target on main
         hooks.main.onWorker.add(function worker(_, xworker) {
@@ -118,14 +112,12 @@ const pyTerminal = async () => {
             // allow a worker to drop main thread hooks ASAP
             xworker.sync.pyterminal_drop_hooks = () => {
                 hooks.worker.onReady.delete(workerReady);
-                hooks.worker.codeAfterRun.delete(codeAfter);
             };
         });
 
         // setup remote thread JS/Python code for whenever the
         // worker is ready to become a terminal
         hooks.worker.onReady.add(workerReady);
-        hooks.worker.codeAfterRun.add(codeAfter);
     } else {
         // in the main case, just bootstrap XTerm without
         // allowing any input as that's not possible / awkward

--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -15,13 +15,14 @@
         </script>
         <py-script worker terminal>
             import sys
-            from pyscript import display
+            from pyscript import display, document
             display("Hello", "PyScript Next - PyTerminal", append=False)
             print("this should go to the terminal")
             print("another line")
 
             # this works as expected
             print("this goes to stderr", file=sys.stderr)
+            document.addEventListener('click', lambda event: print(event.type));
         </py-script>
         <button id="my-button" py-click="greetings">Click me</button>
     </body>

--- a/pyscript.core/tests/integration/test_py_terminal.py
+++ b/pyscript.core/tests/integration/test_py_terminal.py
@@ -24,21 +24,22 @@ class TestPyTerminal(PyScriptTest):
         with pytest.raises(PageErrors, match="You can use at most 1 terminal"):
             self.check_js_errors()
 
-    @only_worker
-    def test_py_terminal_input(self):
-        """
-        Only worker py-terminal accepts an input
-        """
-        self.pyscript_run(
-            """
-            <script type="py" terminal></script>
-            """,
-            wait_for_pyscript=False,
-        )
-        self.page.get_by_text(">>> ", exact=True).wait_for()
-        self.page.keyboard.type("'the answer is ' + str(6 * 7)")
-        self.page.keyboard.press("Enter")
-        self.page.get_by_text("the answer is 42").wait_for()
+    # TODO: interactive shell still unclear
+    # @only_worker
+    # def test_py_terminal_input(self):
+    #     """
+    #     Only worker py-terminal accepts an input
+    #     """
+    #     self.pyscript_run(
+    #         """
+    #         <script type="py" terminal></script>
+    #         """,
+    #         wait_for_pyscript=False,
+    #     )
+    #     self.page.get_by_text(">>> ", exact=True).wait_for()
+    #     self.page.keyboard.type("'the answer is ' + str(6 * 7)")
+    #     self.page.keyboard.press("Enter")
+    #     self.page.get_by_text("the answer is 42").wait_for()
 
     @only_worker
     def test_py_terminal_os_write(self):


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1840 by not bootstrapping users into an interactive shell by default.

## Changes

  * remove the Python hook that bootstraps the interactive shell
  * comment out the integration test without removing the test as that will be helpful later on
  * updated the smoke test with a listener after the code that will still run without issues when `worker terminal` attributes are used

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `docs/changelog.md`
-   [ ] I have created documentation for this(if applicable)
