### PR TITLE
Fix #1841 - Provide a better error when input is used

### DIFF
--- a/pyscript.core/src/hooks.js
+++ b/pyscript.core/src/hooks.js
@@ -45,6 +45,19 @@ export const createFunction = (self, name) => {
 const SetFunction = typedSet({ typeof: "function" });
 const SetString = typedSet({ typeof: "string" });
 
+const inputFailure = `
+    import builtins
+    def input(prompt=""):
+        raise Exception("\\n           ".join([
+            "input() doesn't work when PyScript runs in the main thread.",
+            "Consider using the worker attribute: https://docs.pyscript.net/2023.11.1/user-guide/workers/"
+        ]))
+
+    builtins.input = input
+    del builtins
+    del input
+`;
+
 export const hooks = {
     main: {
         /** @type {Set<function>} */
@@ -60,7 +73,7 @@ export const hooks = {
         /** @type {Set<function>} */
         onAfterRunAsync: new SetFunction(),
         /** @type {Set<string>} */
-        codeBeforeRun: new SetString(),
+        codeBeforeRun: new SetString([inputFailure]),
         /** @type {Set<string>} */
         codeBeforeRunAsync: new SetString(),
         /** @type {Set<string>} */

--- a/pyscript.core/test/input.html
+++ b/pyscript.core/test/input.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>PyScript Next</title>
+        <script>
+            addEventListener("py:ready", console.log);
+        </script>
+        <link rel="stylesheet" href="../dist/core.css">
+        <script type="module" src="../dist/core.js"></script>
+    </head>
+    <body>
+        <py-script>
+            input("what's your name?")
+        </py-script>
+        <mpy-script>
+            input("what's your name?")
+        </mpy-script>
+    </body>
+</html>

--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -93,6 +93,19 @@ class TestBasic(PyScriptTest):
         )
         assert self.console.log.lines[-1] == "hello pyscript"
 
+    @only_main
+    def test_input_exception(self):
+        self.pyscript_run(
+            """
+            <script type="py">
+                input("what's your name?")
+            </script>
+            """
+        )
+        self.check_py_errors(
+            "Exception: input() doesn't work when PyScript runs in the main thread."
+        )
+
     @skip_worker("NEXT: exceptions should be displayed in the DOM")
     def test_python_exception(self):
         self.pyscript_run(


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1841 by providing a better error when `input` is used on the main thread.

## Changes

  * add a main `codeBeforeRun` hook that raises an error when no worker is used
  * smoke-test both pyodide and micropython
  * add an integration test to validate expectations (input is tested in workers too so it skips the worker test as it's pointless)

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
