### PR TITLE
Improve README and and mention the community calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PyScript is a meta project that aims to combine multiple open technologies into 
 
 ## Try PyScript
 
-To try PyScript, import the appropriate pyscript files into the `<head>` tag of your html page with:
+To try PyScript, import the appropriate pyscript files into the `<head>` tag of your html page:
 
 ```html
 <head>
@@ -29,20 +29,39 @@ To try PyScript, import the appropriate pyscript files into the `<head>` tag of 
         src="https://pyscript.net/releases/2023.11.1/core.js"
     ></script>
 </head>
+<body>
+    <script type="py" terminal>
+        from pyscript import display
+        display("Hello World!") # this goes to the DOM
+        print("Hello terminal") # this goes to the terminal
+    </script>
+</body>
 ```
 
-You can then use PyScript components in your html page. PyScript currently implements the following elements:
+You can then use PyScript components in your html page. PyScript currently offers various ways of running Python code:
 
--   `<py-script>`: can be used to define python code that is executable within the web page. The element itself is not rendered to the page and is only used to add logic
--   `<py-repl>`: creates a REPL component that is rendered to the page as a code editor and allows users to write executable code
+-   `<script type="py">`: can be used to define python code that is executable within the web page.
+-   `<script type="py" src="hello.py">`: same as above, but the python source is fetched from the given URL.
+-   `<script type="py" terminal>`: same as above, but also creates a terminal where to display stdout and stderr (e.g., the output of `print()`); `input()` does not work.
+-   `<script type="py" terminal worker>`: run Python inside a web worker: the terminal if fully functional and `input()` works.
+-   `<py-script>`: same as `<script type="py">`, but it is not recommended because if the code contains HTML tags, they could be parsed wrongly.
+-   `<script type="mpy">`: same as above but use MicroPython instead of Python.
 
-Check out the [the examples directory](examples) folder for more examples on how to use it, all you need to do is open them in Chrome.
+Check out the [official docs](https://docs.pyscript.net) for more detailed documentation.
 
 ## How to Contribute
 
 Read the [contributing guide](CONTRIBUTING.md) to learn about our development process, reporting bugs and improvements, creating issues and asking questions.
 
 Check out the [developing process](https://docs.pyscript.net/latest/contributing) documentation for more information on how to setup your development environment.
+
+## Community calls and events
+
+Every Tuesday at 15:30 UTC there is the *PyScript Community Call* on zoom, where we can talk about PyScript development in the open. Most of the maintainers regularly participate in the call, and everybody is welcome to join.
+
+Every other Thurday at 16:00 UTC there is the *PyScript FUN* call: this is a call in which everybody is encouraged to show what they did with PyScript.
+
+For more details on how to join the calls and up to date schedule, consult the official [Google calendar](https://calendar.google.com/calendar/u/0/embed?src=d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0@group.calendar.google.com&ctz=Europe/Berlin) page (also available in [iCal format](https://calendar.google.com/calendar/ical/d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0%40group.calendar.google.com/public/basic.ics)).
 
 ## Resources
 


### PR DESCRIPTION
Improve the readme in two ways:

1. remove the mention to `<py-repl>`, and shows a quick summary of the various ways of running Python code
2. add a link to the google calendar which contains the community calls