### PR TITLE
Fix 404 in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 PyScript is a framework that allows users to create rich Python applications in the browser using HTML's interface and the power of [Pyodide](https://pyodide.org/en/stable/), [MicroPython](https://micropython.org/) and [WASM](https://webassembly.org/), and modern web technologies.
 
-To get started see the [getting started tutorial](docs/tutorials/getting-started.md).
+To get started see the [getting started tutorial](https://pyscript.github.io/docs/2023.11.1/beginning-pyscript/).
 
 For examples see [here](examples).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 PyScript is a framework that allows users to create rich Python applications in the browser using HTML's interface and the power of [Pyodide](https://pyodide.org/en/stable/), [MicroPython](https://micropython.org/) and [WASM](https://webassembly.org/), and modern web technologies.
 
-To get started see the [getting started tutorial](https://pyscript.github.io/docs/2023.11.1/beginning-pyscript/).
+To get started see the [getting started tutorial](https://pyscript.github.io/docs/latest/beginning-pyscript/).
 
 For examples see [here](examples).
 


### PR DESCRIPTION
## Description

Just redirected it to where I think it's meant to lead, instead of a 404.

The link uses `/latest/` so it will always lead to the newest version.

## Changes

Just doc fixes.

