### PR TITLE
Fix #1861 - Use addon to fit lines instead of truncating

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -22,6 +22,7 @@
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-terser": "^0.4.4",
                 "@webreflection/toml-j0.4": "^1.1.3",
+                "@xterm/addon-fit": "^0.9.0-beta.1",
                 "chokidar": "^3.5.3",
                 "eslint": "^8.54.0",
                 "rollup": "^4.5.1",
@@ -565,6 +566,15 @@
             "resolved": "https://registry.npmjs.org/@webreflection/toml-j0.4/-/toml-j0.4-1.1.3.tgz",
             "integrity": "sha512-ragv0U1Hy9JTyFpUqApu/UwF4Qhn0Y5GnQR4Bmy/+wYLKbHNS6hLN6bJR44v5DumaocJ4vpF6HVtYWeDJVs3qg==",
             "dev": true
+        },
+        "node_modules/@xterm/addon-fit": {
+            "version": "0.9.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.9.0-beta.1.tgz",
+            "integrity": "sha512-HmGRUMMamUpQYuQBF2VP1LJ0xzqF85LMFfpaNu84t1Tsrl1lPKJWtqX9FDZ22Rf5q6bnKdbj44TRVAUHgDRbLA==",
+            "dev": true,
+            "peerDependencies": {
+                "xterm": "^5.0.0"
+            }
         },
         "node_modules/acorn": {
             "version": "8.10.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -52,6 +52,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@webreflection/toml-j0.4": "^1.1.3",
+        "@xterm/addon-fit": "^0.9.0-beta.1",
         "chokidar": "^3.5.3",
         "eslint": "^8.54.0",
         "rollup": "^4.5.1",

--- a/pyscript.core/rollup/3rd-party.cjs
+++ b/pyscript.core/rollup/3rd-party.cjs
@@ -42,6 +42,9 @@ const modules = {
         (b) => b.text(),
     ),
     "xterm-readline.js": resolve("xterm-readline"),
+    "xterm_addon-fit.js": fetch(`${CDN}/@xterm/addon-fit/+esm`).then((b) =>
+        b.text(),
+    ),
 };
 
 for (const [target, source] of Object.entries(modules)) {

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -40,9 +40,10 @@ const pyTerminal = async () => {
     );
 
     // lazy load these only when a valid terminal is found
-    const [{ Terminal }, { Readline }] = await Promise.all([
+    const [{ Terminal }, { Readline }, { FitAddon }] = await Promise.all([
         import(/* webpackIgnore: true */ "../3rd-party/xterm.js"),
         import(/* webpackIgnore: true */ "../3rd-party/xterm-readline.js"),
+        import(/* webpackIgnore: true */ "../3rd-party/xterm_addon-fit.js"),
     ]);
 
     const readline = new Readline();
@@ -69,8 +70,11 @@ const pyTerminal = async () => {
             },
             ...options,
         });
+        const fitAddon = new FitAddon();
+        terminal.loadAddon(fitAddon);
         terminal.loadAddon(readline);
         terminal.open(target);
+        fitAddon.fit();
         terminal.focus();
     };
 

--- a/pyscript.core/types/3rd-party/xterm_addon-fit.d.ts
+++ b/pyscript.core/types/3rd-party/xterm_addon-fit.d.ts
@@ -1,0 +1,4 @@
+declare var i: any;
+declare var o: any;
+declare var s: {};
+export { i as FitAddon, o as __esModule, s as default };


### PR DESCRIPTION
## Description

This MR tries to fix https://github.com/pyscript/pyscript/issues/1861 by using an [addon](https://github.com/xtermjs/xterm.js/tree/master/addons/addon-fit) that makes the text fit into as much available space as possible, removing truncation at X cols.

## Changes

  * pre-fetch the add-on on build time
  * bootstrap the addon after opening the element in a terminal

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
