### PR TITLE
Updated Polyscript to its latest

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,23 +1,23 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.6.0",
+                "polyscript": "^0.6.2",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
-                "@playwright/test": "^1.40.0",
+                "@playwright/test": "^1.40.1",
                 "@rollup/plugin-commonjs": "^25.0.7",
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-terser": "^0.4.4",
@@ -25,7 +25,7 @@
                 "@xterm/addon-fit": "^0.9.0-beta.1",
                 "chokidar": "^3.5.3",
                 "eslint": "^8.54.0",
-                "rollup": "^4.5.1",
+                "rollup": "^4.6.1",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -226,12 +226,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.0.tgz",
-            "integrity": "sha512-PdW+kn4eV99iP5gxWNSDQCbhMaDVej+RXL5xr6t04nbKLCBwYtA046t7ofoczHOm8u6c+45hpDKQVZqtqwkeQg==",
+            "version": "1.40.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+            "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.40.0"
+                "playwright": "1.40.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -375,9 +375,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.5.1.tgz",
-            "integrity": "sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
+            "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
             "cpu": [
                 "arm"
             ],
@@ -388,9 +388,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.5.1.tgz",
-            "integrity": "sha512-n1bX+LCGlQVuPlCofO0zOKe1b2XkFozAVRoczT+yxWZPGnkEAKTTYVOGZz8N4sKuBnKMxDbfhUsB1uwYdup/sw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
+            "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
             "cpu": [
                 "arm64"
             ],
@@ -401,9 +401,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.5.1.tgz",
-            "integrity": "sha512-QqJBumdvfBqBBmyGHlKxje+iowZwrHna7pokj/Go3dV1PJekSKfmjKrjKQ/e6ESTGhkfPNLq3VXdYLAc+UtAQw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
+            "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
             "cpu": [
                 "arm64"
             ],
@@ -414,9 +414,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.5.1.tgz",
-            "integrity": "sha512-RrkDNkR/P5AEQSPkxQPmd2ri8WTjSl0RYmuFOiEABkEY/FSg0a4riihWQGKDJ4LnV9gigWZlTMx2DtFGzUrYQw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
+            "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
             "cpu": [
                 "x64"
             ],
@@ -427,9 +427,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.5.1.tgz",
-            "integrity": "sha512-ZFPxvUZmE+fkB/8D9y/SWl/XaDzNSaxd1TJUSE27XAKlRpQ2VNce/86bGd9mEUgL3qrvjJ9XTGwoX0BrJkYK/A==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
+            "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
             "cpu": [
                 "arm"
             ],
@@ -440,9 +440,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.5.1.tgz",
-            "integrity": "sha512-FEuAjzVIld5WVhu+M2OewLmjmbXWd3q7Zcx+Rwy4QObQCqfblriDMMS7p7+pwgjZoo9BLkP3wa9uglQXzsB9ww==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
+            "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
             "cpu": [
                 "arm64"
             ],
@@ -453,9 +453,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.5.1.tgz",
-            "integrity": "sha512-f5Gs8WQixqGRtI0Iq/cMqvFYmgFzMinuJO24KRfnv7Ohi/HQclwrBCYkzQu1XfLEEt3DZyvveq9HWo4bLJf1Lw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
+            "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
             "cpu": [
                 "arm64"
             ],
@@ -466,9 +466,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.5.1.tgz",
-            "integrity": "sha512-CWPkPGrFfN2vj3mw+S7A/4ZaU3rTV7AkXUr08W9lNP+UzOvKLVf34tWCqrKrfwQ0NTk5GFqUr2XGpeR2p6R4gw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
+            "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
             "cpu": [
                 "x64"
             ],
@@ -479,9 +479,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.5.1.tgz",
-            "integrity": "sha512-ZRETMFA0uVukUC9u31Ed1nx++29073goCxZtmZARwk5aF/ltuENaeTtRVsSQzFlzdd4J6L3qUm+EW8cbGt0CKQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
+            "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
             "cpu": [
                 "x64"
             ],
@@ -492,9 +492,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.5.1.tgz",
-            "integrity": "sha512-ihqfNJNb2XtoZMSCPeoo0cYMgU04ksyFIoOw5S0JUVbOhafLot+KD82vpKXOurE2+9o/awrqIxku9MRR9hozHQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
+            "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
             "cpu": [
                 "arm64"
             ],
@@ -505,9 +505,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.5.1.tgz",
-            "integrity": "sha512-zK9MRpC8946lQ9ypFn4gLpdwr5a01aQ/odiIJeL9EbgZDMgbZjjT/XzTqJvDfTmnE1kHdbG20sAeNlpc91/wbg==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
+            "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
             "cpu": [
                 "ia32"
             ],
@@ -518,9 +518,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.5.1.tgz",
-            "integrity": "sha512-5I3Nz4Sb9TYOtkRwlH0ow+BhMH2vnh38tZ4J4mggE48M/YyJyp/0sPSxhw1UeS1+oBgQ8q7maFtSeKpeRJu41Q==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
+            "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
             "cpu": [
                 "x64"
             ],
@@ -859,14 +859,14 @@
             }
         },
         "node_modules/coincident": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/coincident/-/coincident-1.0.0.tgz",
-            "integrity": "sha512-tSAuLMLMzAPOb2B8tAiANLZ3LeB7dbueYxSV6Y9l/2FNZ8loBIc0jS1jEkrQK0g8UAslxLTd7+NCtpDr8YxNDQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-1.1.0.tgz",
+            "integrity": "sha512-FXl7/KToJmtaWWEHOJljbco6NKuM9Hzo249p5gI+lvmxv1JRUCoS14SP195zeEW2WypBfTARGkmnE9MwJ1j0Yg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "gc-hook": "^0.2.5",
-                "proxy-target": "^2.0.4"
+                "proxy-target": "^3.0.1"
             },
             "optionalDependencies": {
                 "ws": "^8.14.2"
@@ -2198,12 +2198,12 @@
             "integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
         },
         "node_modules/playwright": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-            "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+            "version": "1.40.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+            "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.40.0"
+                "playwright-core": "1.40.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -2216,9 +2216,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-            "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+            "version": "1.40.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+            "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
@@ -2242,16 +2242,17 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.0.tgz",
-            "integrity": "sha512-e9nR1770DaJXMPV7fjhM7wh7sfeMAHfDIx16V1UtU3p1QoV2Z+jxZq+LuKumKlgsN82Yl56D1rP9qriie9omHQ==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.2.tgz",
+            "integrity": "sha512-JL3aIodfdXVQy65iPqjPxbSHzSGJdyf5Z9CuESZVJobcOcOvymjFgsZeoktz0e6PHqM4YSggtKQ9bN9HzlgMBg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
                 "codedent": "^0.1.2",
-                "coincident": "^1.0.0",
+                "coincident": "^1.1.0",
                 "html-escaper": "^3.0.3",
+                "proxy-target": "^3.0.1",
                 "sticky-module": "^0.1.1"
             }
         },
@@ -2834,9 +2835,9 @@
             }
         },
         "node_modules/proxy-target": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-target/-/proxy-target-2.1.0.tgz",
-            "integrity": "sha512-kgF20JQr+2uRX1024gAn/PV36IiOU1Rcmsphf6nHWh+d5XmkMOOMIoqYjLw7qe+iN0ix1lVMAYtJERlP3DQLiQ=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/proxy-target/-/proxy-target-3.0.1.tgz",
+            "integrity": "sha512-EGskR5UV9bsY3eFXBFJqq/rsDUXw/WAjeuW5YuyYaxd+0F2zgMpuZ/l5NQtju4FBHKIJnBXNGEptGqyisUgdcg=="
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -2940,9 +2941,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.5.1.tgz",
-            "integrity": "sha512-0EQribZoPKpb5z1NW/QYm3XSR//Xr8BeEXU49Lc/mQmpmVVG5jPUVrpc2iptup/0WMrY9mzas0fxH+TjYvG2CA==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
+            "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -2952,18 +2953,18 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.5.1",
-                "@rollup/rollup-android-arm64": "4.5.1",
-                "@rollup/rollup-darwin-arm64": "4.5.1",
-                "@rollup/rollup-darwin-x64": "4.5.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.5.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.5.1",
-                "@rollup/rollup-linux-arm64-musl": "4.5.1",
-                "@rollup/rollup-linux-x64-gnu": "4.5.1",
-                "@rollup/rollup-linux-x64-musl": "4.5.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.5.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.5.1",
-                "@rollup/rollup-win32-x64-msvc": "4.5.1",
+                "@rollup/rollup-android-arm-eabi": "4.6.1",
+                "@rollup/rollup-android-arm64": "4.6.1",
+                "@rollup/rollup-darwin-arm64": "4.6.1",
+                "@rollup/rollup-darwin-x64": "4.6.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.6.1",
+                "@rollup/rollup-linux-arm64-musl": "4.6.1",
+                "@rollup/rollup-linux-x64-gnu": "4.6.1",
+                "@rollup/rollup-linux-x64-musl": "4.6.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.6.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.6.1",
+                "@rollup/rollup-win32-x64-msvc": "4.6.1",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -41,13 +41,13 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.6.0",
+        "polyscript": "^0.6.2",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {
-        "@playwright/test": "^1.40.0",
+        "@playwright/test": "^1.40.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -55,7 +55,7 @@
         "@xterm/addon-fit": "^0.9.0-beta.1",
         "chokidar": "^3.5.3",
         "eslint": "^8.54.0",
-        "rollup": "^4.5.1",
+        "rollup": "^4.6.1",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",


### PR DESCRIPTION
## Description

This MR updates Polyscript to its latest, bringing in latest *coincident* `Symbol.for('...')` capability and the `[js_modules.main/worker]` config parser goodness.

## Changes

  * updated Polyscript to its latest

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
