### PR TITLE
Patch js.document out of the box

### DIFF
--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,6 +1,5 @@
 import js as globalThis
 from polyscript import js_modules
-
 from pyscript.util import NotSupported
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,10 +1,12 @@
 import js as globalThis
 from polyscript import js_modules
+
 from pyscript.util import NotSupported
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")
 
 if RUNNING_IN_WORKER:
+    import js
     import polyscript
 
     PyWorker = NotSupported(
@@ -13,6 +15,7 @@ if RUNNING_IN_WORKER:
     )
     window = polyscript.xworker.window
     document = window.document
+    js.document = document
     sync = polyscript.xworker.sync
 
     # in workers the display does not have a default ID

--- a/pyscript.core/test/worker.py
+++ b/pyscript.core/test/worker.py
@@ -1,5 +1,4 @@
 import a
-
 from pyscript import display, sync
 
 display("Hello World", target="test", append=True)

--- a/pyscript.core/test/worker.py
+++ b/pyscript.core/test/worker.py
@@ -1,4 +1,5 @@
 import a
+
 from pyscript import display, sync
 
 display("Hello World", target="test", append=True)
@@ -6,3 +7,7 @@ display("Hello World", target="test", append=True)
 print("sleeping")
 sync.sleep(1)
 print("awake")
+
+import js
+
+js.document.body.append("document patch ")


### PR DESCRIPTION
## Description

This MR solves the discussion we had in https://github.com/pyscript/pyscript/discussions/1878 by attaching to the worker `js` module the document from main out of the box.

## Changes

  * when running in worker, patch the `js` module with a document
  * smoke-test everything works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
