### PR TITLE
Fix broken links, and put community information at the top of our READE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,25 @@
 
 PyScript is a framework that allows users to create rich Python applications in the browser using HTML's interface and the power of [Pyodide](https://pyodide.org/en/stable/), [MicroPython](https://micropython.org/) and [WASM](https://webassembly.org/), and modern web technologies.
 
-To get started see the [Beginning PyScript tutorial](https://pyscript.github.io/docs/latest/beginning-pyscript/).
+To get started see the [Beginning PyScript tutorial](https://docs.pyscript.net/latest/beginning-pyscript/).
 
-For examples see [here](examples).
+For examples see [here](https://pyscript.com/@examples).
+
+Other useful resources:
+
+- The [official technical docs](https://docs.pyscript.net/).
+- Our current [Home Page](https://pyscript.net/) on the web.
+- A free-to-use [online editor](https://pyscript.com/) for trying PyScript.
+- Our community [Discord Channel](https://discord.gg/BYB2kvyFwm), to keep in touch .
+
+Every Tuesday at 15:30 UTC there is the _PyScript Community Call_ on zoom, where we can talk about PyScript development in the open. Most of the maintainers regularly participate in the call, and everybody is welcome to join.
+
+Every other Thursday at 16:00 UTC there is the _PyScript FUN_ call: this is a call in which everybody is encouraged to show what they did with PyScript.
+
+For more details on how to join the calls and up to date schedule, consult the official calendar:
+
+-   [Google calendar](https://calendar.google.com/calendar/u/0/embed?src=d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0@group.calendar.google.com&ctz=UTC) in UTC time;
+-   [iCal format](https://calendar.google.com/calendar/ical/d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0%40group.calendar.google.com/public/basic.ics).
 
 ### Longer Version
 
@@ -47,37 +63,13 @@ You can then use PyScript components in your html page. PyScript currently offer
 -   `<py-script>`: same as `<script type="py">`, but it is not recommended because if the code contains HTML tags, they could be parsed wrongly.
 -   `<script type="mpy">`: same as above but use MicroPython instead of Python.
 
-Check out the [official docs](https://pyscript.github.io) for more detailed documentation.
+Check out the [official docs](https://docs.pyscript.net/) for more detailed documentation.
 
 ## How to Contribute
 
 Read the [contributing guide](CONTRIBUTING.md) to learn about our development process, reporting bugs and improvements, creating issues and asking questions.
 
 Check out the [developing process](https://pyscript.github.io/docs/latest/contributing) documentation for more information on how to setup your development environment.
-
-## Community calls and events
-
-Every Tuesday at 15:30 UTC there is the _PyScript Community Call_ on zoom, where we can talk about PyScript development in the open. Most of the maintainers regularly participate in the call, and everybody is welcome to join.
-
-Every other Thursday at 16:00 UTC there is the _PyScript FUN_ call: this is a call in which everybody is encouraged to show what they did with PyScript.
-
-For more details on how to join the calls and up to date schedule, consult the official calendar:
-
--   [Google calendar](https://calendar.google.com/calendar/u/0/embed?src=d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0@group.calendar.google.com&ctz=UTC) in UTC time;
--   [iCal format](https://calendar.google.com/calendar/ical/d3afdd81f9c132a8c8f3290f5cc5966adebdf61017fca784eef0f6be9fd519e0%40group.calendar.google.com/public/basic.ics).
-
-## Resources
-
--   [Official docs](https://pyscript.github.io)
--   [Discussion board](https://community.anaconda.cloud/c/tech-topics/pyscript)
--   [Home Page](https://pyscript.net/)
--   [Blog Post](https://engineering.anaconda.com/2022/04/welcome-pyscript.html)
--   [Discord Channel](https://discord.gg/BYB2kvyFwm)
-
-## Notes
-
--   This is an extremely experimental project, so expect things to break!
--   PyScript has been only tested on Chrome at the moment.
 
 ## Governance
 


### PR DESCRIPTION
## Description

Fix broken links, and put community information at the top of our READE

## Changes

* Fix broken links to our official docs and examples.
* Move the sections on community engagement to the top.
* Remove a couple of old / stale links to Anaconda discussion forum about PyScript (I didn't even know this was a thing) and an old blog post.

This is a work in progress.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
