### PR TITLE
Fix #1899 - Expose pyscript.js_modules as module

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.11",
+    "version": "0.3.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.11",
+            "version": "0.3.14",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.10",
+            "version": "0.3.11",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.6.2",
+                "polyscript": "^0.6.8",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -21,7 +21,7 @@
                 "@codemirror/lang-python": "^6.1.3",
                 "@codemirror/language": "^6.9.3",
                 "@codemirror/state": "^6.3.3",
-                "@codemirror/view": "^6.22.1",
+                "@codemirror/view": "^6.22.3",
                 "@playwright/test": "^1.40.1",
                 "@rollup/plugin-commonjs": "^25.0.7",
                 "@rollup/plugin-node-resolve": "^15.2.3",
@@ -30,8 +30,8 @@
                 "@xterm/addon-fit": "^0.9.0-beta.1",
                 "chokidar": "^3.5.3",
                 "codemirror": "^6.0.1",
-                "eslint": "^8.55.0",
-                "rollup": "^4.6.1",
+                "eslint": "^8.56.0",
+                "rollup": "^4.9.1",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -133,9 +133,9 @@
             "dev": true
         },
         "node_modules/@codemirror/view": {
-            "version": "6.22.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.1.tgz",
-            "integrity": "sha512-38BRn1nPqZqiHbmWfI8zri23IbRVbmSpSmh1E/Ysvc+lIGGdBC17K8zlK7ZU6fhfy9x4De9Zyj5JQqScPq5DkA==",
+            "version": "6.22.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.3.tgz",
+            "integrity": "sha512-rqnq+Zospwoi3x1vZ8BGV1MlRsaGljX+6qiGYmIpJ++M+LCC+wjfDaPklhwpWSgv7pr/qx29KiAKQBH5+DOn4w==",
             "dev": true,
             "dependencies": {
                 "@codemirror/state": "^6.1.4",
@@ -191,9 +191,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-            "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -509,9 +509,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
-            "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
+            "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
             "cpu": [
                 "arm"
             ],
@@ -522,9 +522,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
-            "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
+            "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
             "cpu": [
                 "arm64"
             ],
@@ -535,9 +535,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
-            "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
+            "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
             "cpu": [
                 "arm64"
             ],
@@ -548,9 +548,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
-            "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
+            "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
             "cpu": [
                 "x64"
             ],
@@ -561,9 +561,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
-            "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
+            "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
             "cpu": [
                 "arm"
             ],
@@ -574,9 +574,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
-            "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
+            "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -587,9 +587,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
-            "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
+            "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
             "cpu": [
                 "arm64"
             ],
@@ -599,10 +599,23 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
+            "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
-            "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
+            "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
             "cpu": [
                 "x64"
             ],
@@ -613,9 +626,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
-            "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
+            "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
             "cpu": [
                 "x64"
             ],
@@ -626,9 +639,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
-            "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
+            "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
             "cpu": [
                 "arm64"
             ],
@@ -639,9 +652,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
-            "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
+            "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
             "cpu": [
                 "ia32"
             ],
@@ -652,9 +665,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
-            "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
+            "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
             "cpu": [
                 "x64"
             ],
@@ -1390,15 +1403,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-            "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.55.0",
+                "@eslint/js": "8.56.0",
                 "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -2397,9 +2410,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.2.tgz",
-            "integrity": "sha512-JL3aIodfdXVQy65iPqjPxbSHzSGJdyf5Z9CuESZVJobcOcOvymjFgsZeoktz0e6PHqM4YSggtKQ9bN9HzlgMBg==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.8.tgz",
+            "integrity": "sha512-7HXhkWnVP4Qph2hYL85qQ+omIKA7yHTZJwphlMVLhZwvqpAKZEyPojrZMTg5j1sLLyyKsWSHSzZuklzS5qWgmA==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
@@ -3096,9 +3109,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
-            "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
+            "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -3108,18 +3121,19 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.6.1",
-                "@rollup/rollup-android-arm64": "4.6.1",
-                "@rollup/rollup-darwin-arm64": "4.6.1",
-                "@rollup/rollup-darwin-x64": "4.6.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.6.1",
-                "@rollup/rollup-linux-arm64-musl": "4.6.1",
-                "@rollup/rollup-linux-x64-gnu": "4.6.1",
-                "@rollup/rollup-linux-x64-musl": "4.6.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.6.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.6.1",
-                "@rollup/rollup-win32-x64-msvc": "4.6.1",
+                "@rollup/rollup-android-arm-eabi": "4.9.1",
+                "@rollup/rollup-android-arm64": "4.9.1",
+                "@rollup/rollup-darwin-arm64": "4.9.1",
+                "@rollup/rollup-darwin-x64": "4.9.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.9.1",
+                "@rollup/rollup-linux-arm64-musl": "4.9.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
+                "@rollup/rollup-linux-x64-gnu": "4.9.1",
+                "@rollup/rollup-linux-x64-musl": "4.9.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.9.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.9.1",
+                "@rollup/rollup-win32-x64-msvc": "4.9.1",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.6.2",
+        "polyscript": "^0.6.8",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
@@ -52,7 +52,7 @@
         "@codemirror/lang-python": "^6.1.3",
         "@codemirror/language": "^6.9.3",
         "@codemirror/state": "^6.3.3",
-        "@codemirror/view": "^6.22.1",
+        "@codemirror/view": "^6.22.3",
         "@playwright/test": "^1.40.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -61,8 +61,8 @@
         "@xterm/addon-fit": "^0.9.0-beta.1",
         "chokidar": "^3.5.3",
         "codemirror": "^6.0.1",
-        "eslint": "^8.55.0",
-        "rollup": "^4.6.1",
+        "eslint": "^8.56.0",
+        "rollup": "^4.9.1",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.11",
+    "version": "0.3.14",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,8 +1,24 @@
+import sys
 import js as globalThis
 from polyscript import js_modules
 from pyscript.util import NotSupported
+from types import ModuleType
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")
+
+# allow `from pyscript.js_modules.xxx import yyy`
+class JSModule(object):
+    def __init__(self, name):
+        self.name = name
+    def __getattr__(self, field):
+        # avoid pyodide looking for non existent fields
+        if field[0] != "_":
+            return getattr(getattr(js_modules, self.name), field)
+
+# generate N modules in the system that will proxy the real value
+for name in globalThis.Reflect.ownKeys(js_modules):
+    sys.modules[f"pyscript.js_modules.{name}"] = JSModule(name)
+sys.modules["pyscript.js_modules"] = js_modules
 
 if RUNNING_IN_WORKER:
     import js

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,5 +1,4 @@
 import sys
-from types import ModuleType
 
 import js as globalThis
 from polyscript import js_modules
@@ -15,7 +14,7 @@ class JSModule(object):
 
     def __getattr__(self, field):
         # avoid pyodide looking for non existent fields
-        if field[0] != "_":
+        if not field.startswith("_"):
             return getattr(getattr(js_modules, self.name), field)
 
 

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,19 +1,23 @@
 import sys
+from types import ModuleType
+
 import js as globalThis
 from polyscript import js_modules
 from pyscript.util import NotSupported
-from types import ModuleType
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")
+
 
 # allow `from pyscript.js_modules.xxx import yyy`
 class JSModule(object):
     def __init__(self, name):
         self.name = name
+
     def __getattr__(self, field):
         # avoid pyodide looking for non existent fields
         if field[0] != "_":
             return getattr(getattr(js_modules, self.name), field)
+
 
 # generate N modules in the system that will proxy the real value
 for name in globalThis.Reflect.ownKeys(js_modules):

--- a/pyscript.core/test/js_modules.html
+++ b/pyscript.core/test/js_modules.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../dist/core.css">
+    <script type="module" src="../dist/core.js"></script>
+</head>
+<body>
+    <mpy-config>
+        [js_modules.main]
+        "./js_modules.js" = "random_js"
+    </mpy-config>
+    <mpy-script>
+        from pyscript.js_modules.random_js import default as value
+        from pyscript.js_modules import random_js
+        from pyscript import js_modules
+
+        print("mpy", value)
+        print("mpy", random_js.default)
+        print("mpy", js_modules.random_js.default)
+    </mpy-script>
+    <py-config>
+        [js_modules.main]
+        "./js_modules.js" = "random_js"
+    </py-config>
+    <py-script>
+        from pyscript.js_modules.random_js import default as value
+        from pyscript.js_modules import random_js
+        from pyscript import js_modules, document
+
+        print("py", value)
+        print("py", random_js.default)
+        print("py", js_modules.random_js.default)
+
+        document.documentElement.classList.add('done')
+    </py-script>
+</body>
+</html>

--- a/pyscript.core/test/js_modules.js
+++ b/pyscript.core/test/js_modules.js
@@ -1,0 +1,1 @@
+export default Math.random();

--- a/pyscript.core/test/mpy.spec.js
+++ b/pyscript.core/test/mpy.spec.js
@@ -35,3 +35,19 @@ test('MicroPython hooks', async ({ page }) => {
     'worker onAfterRun',
   ].join('\n'));
 });
+
+test('MicroPython + Pyodide js_modules', async ({ page }) => {
+  const logs = [];
+  page.on('console', msg => {
+    const text = msg.text();
+    if (!text.startsWith('['))
+      logs.push(text);
+  });
+  await page.goto('http://localhost:8080/test/js_modules.html');
+  await page.waitForSelector('html.done');
+  await expect(logs.length).toBe(6);
+  await expect(logs[0]).toBe(logs[1]);
+  await expect(logs[1]).toBe(logs[2]);
+  await expect(logs[3]).toBe(logs[4]);
+  await expect(logs[4]).toBe(logs[5]);
+});


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1899 by registering a fake `pyscript.js_modules` within the *stdlib* so that both imports are valid:

```python
from pyscript import js_modules
js_modules.xxx

from pyscript.js_modules import xxx
```

## Changes

  * update all dependencies to have latest *polyscript* in
  * register an explicit `pyscript.js_modules` as *sys* module
  * register all known sub-modules as explicit `pyscript.js_modules.xxx`
  * add integration + smoke test to be sure all ways to import JS modules work

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
