### PR TITLE
PyTerminal - expose the reference through the element

### DIFF
--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -77,7 +77,7 @@ const pyTerminal = async () => {
         terminal.open(target);
         fitAddon.fit();
         terminal.focus();
-        defineProperty(element, 'terminal', { value: terminal });
+        defineProperty(element, "terminal", { value: terminal });
     };
 
     // branch logic for the worker

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -1,6 +1,7 @@
 // PyScript py-terminal plugin
 import { TYPES, hooks } from "../core.js";
 import { notify } from "./error.js";
+import { defineProperty } from "polyscript/exports";
 
 const SELECTOR = [...TYPES.keys()]
     .map((type) => `script[type="${type}"][terminal],${type}-script[terminal]`)
@@ -76,6 +77,7 @@ const pyTerminal = async () => {
         terminal.open(target);
         fitAddon.fit();
         terminal.focus();
+        defineProperty(element, 'terminal', { value: terminal });
     };
 
     // branch logic for the worker


### PR DESCRIPTION
## Description

This MR solves the fact the XTerm reference used by any `py-terminal` is not exposes, hence it's hard to fully interact with it, or customize it.

## Changes

  * attach to the `<py-script terminal>` or `<script type="py" terminal>` the *terminal* reference
  * test live that `script.terminal.clear()` works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
