### PR TITLE
Add correct copyright and attribution to main license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,11 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   
+   Copyright (c) 2022-present, PyScript Development Team
+
+   Originated at Anaconda, Inc. in 2022
+
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   
+
    Copyright (c) 2022-present, PyScript Development Team
 
    Originated at Anaconda, Inc. in 2022


### PR DESCRIPTION
## Description

Our license file was missing the copyright and attribution section

## Changes

Add the missing info, aligning to the file we have in pyscript.core

