### PR TITLE
Instrumented the `io.stderr` too when terminal exists

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.15",
+    "version": "0.3.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.15",
+            "version": "0.3.16",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.15",
+    "version": "0.3.16",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1939 by adding a generic interpreter `stderr` handler when a terminal is bootstrapped in either the main or the worker thread, fixing a regression recently introduced by bootstrapping the terminal only via Pyodide API.

## Changes

  * provided the right `io.stderr` to both main and worker
  * smoke test everything is fine

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
