### PR TITLE
a temporary fix

### DIFF
--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -148,7 +148,7 @@ const init = async (script, type, interpreter) => {
     if (!target.id) target.id = getID(type);
     if (!target.hasAttribute("exec-id")) target.setAttribute("exec-id", 0);
     if (!target.hasAttribute("root")) target.setAttribute("root", target.id);
-    if (target.hasChildNodes()){
+    if (target.hasChildNodes()) {
         // A temporary fix to prevent the object from loading multiple times..
         return;
     }

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -148,6 +148,10 @@ const init = async (script, type, interpreter) => {
     if (!target.id) target.id = getID(type);
     if (!target.hasAttribute("exec-id")) target.setAttribute("exec-id", 0);
     if (!target.hasAttribute("root")) target.setAttribute("root", target.id);
+    if (target.hasChildNodes()){
+        // A temporary fix to prevent the object from loading multiple times..
+        return;
+    }
 
     const env = `${interpreter}-${script.getAttribute("env") || getID(type)}`;
     const context = {


### PR DESCRIPTION
Prevent py-editor from being created repeatedly.

see [issues/1946](https://github.com/pyscript/pyscript/issues/1946)

## Description

Add a `target.hasChildNodes()` check inside the `init` function to prevent creating multiple `py-editor`.

## Changes

- Prevent creating multiple `py-editor` instances during network latency.

## Checklist

-   [ ] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
