### PR TITLE
Fix #1946 - Do not hold while bootstrapping

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.20",
+    "version": "0.3.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.20",
+            "version": "0.3.21",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.20",
+    "version": "0.3.21",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/test/multiple-editors.html
+++ b/pyscript.core/test/multiple-editors.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>PyScript Test</title>
+  <link rel="stylesheet" href="../dist/core.css">
+  <script type="module" src="../dist/core.js"></script>
+</head>
+<body>
+  <script type="py-editor">
+    0
+  </script>
+  <script type="py-editor">
+    1
+  </script>
+  <script type="py-editor">
+    2
+  </script>
+  <script type="py-editor">
+    3
+  </script>
+  <script type="py-editor">
+    4
+  </script>
+  <script type="py-editor">
+    5
+  </script>
+  <!-- more... -->
+</body>
+</html>


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1946 by not holding while looping to activate editors.

Here a basic, pseudo code, representation of the issue that is solved:

```js
async function init() {
  for (const script of document.querySelectorAll("script[type='editor']")) {
    // here the script type is changed to avoid being part of this loop
    script.type += '-activated';
    // but if in here we hold anything async ...
    await bootstrap(script);
    // the loop will execute before giving a chance to other, already discovered,
    // scripts to initialize themselves and get a new `type`
  }
}

// one call ASAP
init();

// MutationObserver calls triggered by first script bootstrap
init();

// any other reason to call init again
init();
```

As summary, this MR fixes in one single loop the type and queue bootstraps instead of waiting per each of them so that even if invoked multiple consecutive times, each script is guaranteed to be bootstrapped only once.

## Changes

  * use a *queue* instead of holding on every `init` call
  * create a smoke-test that present no issue whatsoever with or without cache enabled

<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
