### PR TITLE
Update Polyscript to its latest w/ experimental

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.21",
+    "version": "0.3.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.21",
+            "version": "0.3.22",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.6.15",
+                "polyscript": "^0.6.16",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -2403,20 +2403,26 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.6.15",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.15.tgz",
-            "integrity": "sha512-ppkcEgNlH+/+S4+bxSy+oda/V9Qo/M7IA4ddhoCeVUObRMZBiOrvWkStZDI/xs/Mw3nbAZ4L772+TIz/RgfU2Q==",
+            "version": "0.6.16",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.16.tgz",
+            "integrity": "sha512-ri7tWBzsujlnltJ5jKjgpVes6eQWOkl9PdU0QS/EkaPAX406rGPE4/nRMQxI2iWoza6LrH5JpdUhgG6YTskEnA==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
                 "codedent": "^0.1.2",
                 "coincident": "^1.1.0",
+                "gc-hook": "^0.3.0",
                 "html-escaper": "^3.0.3",
                 "proxy-target": "^3.0.1",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1"
             }
+        },
+        "node_modules/polyscript/node_modules/gc-hook": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.3.0.tgz",
+            "integrity": "sha512-Qkp0HM3z839Ns0LpXFJBXqClNW23wQo6JpUdJAjuf1/2jB+oUWSOMzeMv2yFq8Ur45z8IWw9hpRhkSjxSt5RWg=="
         },
         "node_modules/postcss": {
             "version": "8.4.33",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.21",
+    "version": "0.3.22",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.6.15",
+        "polyscript": "^0.6.16",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"


### PR DESCRIPTION
## Description

This MR brings in latest polyscript version with `experimental_create_once` config feature that could, only if present, change the way *Pyodide* on the main thread behaves and help us better analyze or measure the performance or memory impact of such flag, if ever enabled, to eventually use that data to convince *Pyodide* team that's a way forward too.

## Changes

  * update *Polyscript* to its latest

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
