### PR TITLE
Update polyscript + coincident to their latest

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.22",
+    "version": "0.3.23",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.3.22",
+            "version": "0.3.23",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.6.16",
+                "polyscript": "^0.6.18",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -970,17 +970,17 @@
             }
         },
         "node_modules/coincident": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/coincident/-/coincident-1.1.0.tgz",
-            "integrity": "sha512-FXl7/KToJmtaWWEHOJljbco6NKuM9Hzo249p5gI+lvmxv1JRUCoS14SP195zeEW2WypBfTARGkmnE9MwJ1j0Yg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-1.1.1.tgz",
+            "integrity": "sha512-4i6bejrHuY6aOY8uhq56g/psUK2k99y5hImpavQz7yfPNCXuJkmtRYpvBOguC0mdYXPgQjvoz+Odw/WO6q4okg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
-                "gc-hook": "^0.2.5",
+                "gc-hook": "^0.3.0",
                 "proxy-target": "^3.0.1"
             },
             "optionalDependencies": {
-                "ws": "^8.14.2"
+                "ws": "^8.16.0"
             }
         },
         "node_modules/color-convert": {
@@ -1634,9 +1634,9 @@
             }
         },
         "node_modules/gc-hook": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.2.5.tgz",
-            "integrity": "sha512-808B9hJ1T7ak4HRYdXgQjDaHexlaUOBuNFuqOnYotxfKjOHTDxAy8r1Oe7LI+KBeb/H6XUBKzuYi626DjxhxIg=="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.3.0.tgz",
+            "integrity": "sha512-Qkp0HM3z839Ns0LpXFJBXqClNW23wQo6JpUdJAjuf1/2jB+oUWSOMzeMv2yFq8Ur45z8IWw9hpRhkSjxSt5RWg=="
         },
         "node_modules/generic-names": {
             "version": "4.0.0",
@@ -2403,26 +2403,21 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.6.16",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.16.tgz",
-            "integrity": "sha512-ri7tWBzsujlnltJ5jKjgpVes6eQWOkl9PdU0QS/EkaPAX406rGPE4/nRMQxI2iWoza6LrH5JpdUhgG6YTskEnA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.6.18.tgz",
+            "integrity": "sha512-naU5tisWCt/a12kl1lIdtphaGUCEDf4mmlzuOcvjayqkmfXUlxLdc9A5VEEZLcleWr5Wtx34aU9IBBG8hfSI6Q==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
                 "codedent": "^0.1.2",
-                "coincident": "^1.1.0",
+                "coincident": "^1.1.1",
                 "gc-hook": "^0.3.0",
                 "html-escaper": "^3.0.3",
                 "proxy-target": "^3.0.1",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1"
             }
-        },
-        "node_modules/polyscript/node_modules/gc-hook": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.3.0.tgz",
-            "integrity": "sha512-Qkp0HM3z839Ns0LpXFJBXqClNW23wQo6JpUdJAjuf1/2jB+oUWSOMzeMv2yFq8Ur45z8IWw9hpRhkSjxSt5RWg=="
         },
         "node_modules/postcss": {
             "version": "8.4.33",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.3.22",
+    "version": "0.3.23",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.6.16",
+        "polyscript": "^0.6.18",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"


### PR DESCRIPTION
## Description

This MR brings in latest [polyscript](https://github.com/pyscript/polyscript) with latest [coincident](https://github.com/WebReflection/coincident) which include a fix for an uncanny situation presented when heavy modules (i.e. pandas) interrupt the code execution in an *async* + *worker* environment / context.

The culprit of the issue is that in some circumstance the *FinalizationRegistry* could've run **after** the related *WeakRef* already dropped the retained reference so that the map would've held only the *WeakRef* but not its desired value.

In **coincident** this has been fixed by re-observing the value with a different new entry so that previous WeakRef can go while the ultimately needed one will provide the desired functionality.

## Changes

  * updated both polyscript and coincident to their latest versions

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
