### PR TITLE
Small tweaks to main demo page

### DIFF
--- a/pyscript.core/src/stdlib/pyweb/ui/elements.py
+++ b/pyscript.core/src/stdlib/pyweb/ui/elements.py
@@ -257,6 +257,9 @@ class div(TextElementBase):
     tag = "div"
 
 
+class main(TextElementBase):
+    tag = 'main'
+
 class img(ElementBase):
     tag = "img"
     src = js_property("src")

--- a/pyscript.core/src/stdlib/pyweb/ui/elements.py
+++ b/pyscript.core/src/stdlib/pyweb/ui/elements.py
@@ -258,7 +258,8 @@ class div(TextElementBase):
 
 
 class main(TextElementBase):
-    tag = 'main'
+    tag = "main"
+
 
 class img(ElementBase):
     tag = "img"

--- a/pyscript.core/test/ui/demo.py
+++ b/pyscript.core/test/ui/demo.py
@@ -143,7 +143,18 @@ def create_main_area():
         ]
     )
 
-    main = el.main(style={'padding-top': '4rem', 'padding-bottom': '7rem', 'max-width': '52rem', 'margin-left': 'auto', 'margin-right': 'auto', 'padding-left': '1.5rem', 'padding-right': '1.5rem', 'width': '100%'})
+    main = el.main(
+        style={
+            "padding-top": "4rem",
+            "padding-bottom": "7rem",
+            "max-width": "52rem",
+            "margin-left": "auto",
+            "margin-right": "auto",
+            "padding-left": "1.5rem",
+            "padding-right": "1.5rem",
+            "width": "100%",
+        }
+    )
     main.append(div)
 
     return main
@@ -274,7 +285,8 @@ def markdown_components():
 
 def create_new_section(title, parent_div):
     basic_components_text = el.h3(
-        title, style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"}
+        title,
+        style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"},
     )
     parent_div.append(basic_components_text)
     parent_div.append(
@@ -295,7 +307,8 @@ when("click", left_panel_title)(restore_home)
 
 # BASIC COMPONENTS
 basic_components_text = el.h3(
-    "Basic Components", style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"}
+    "Basic Components",
+    style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"},
 )
 left_div.append(basic_components_text)
 left_div.append(shoelace.Divider(style={"margin-top": "5px", "margin-bottom": "30px"}))
@@ -309,7 +322,8 @@ when("click", markdown_title)(markdown_components)
 
 # SHOELACE COMPONENTS
 shoe_components_text = el.h3(
-    "Shoe Components", style={"text-align": "left", "margin": "20px auto 0", "pointer": "cursor"}
+    "Shoe Components",
+    style={"text-align": "left", "margin": "20px auto 0", "pointer": "cursor"},
 )
 left_div.append(shoe_components_text)
 left_div.append(shoelace.Divider(style={"margin-top": "5px", "margin-bottom": "30px"}))

--- a/pyscript.core/test/ui/demo.py
+++ b/pyscript.core/test/ui/demo.py
@@ -143,7 +143,10 @@ def create_main_area():
         ]
     )
 
-    return div
+    main = el.main(style={'padding-top': '4rem', 'padding-bottom': '7rem', 'max-width': '52rem', 'margin-left': 'auto', 'margin-right': 'auto', 'padding-left': '1.5rem', 'padding-right': '1.5rem', 'width': '100%'})
+    main.append(div)
+
+    return main
 
 
 def create_markdown_components_page():
@@ -271,7 +274,7 @@ def markdown_components():
 
 def create_new_section(title, parent_div):
     basic_components_text = el.h3(
-        title, style={"text-align": "left", "margin": "20px auto 0"}
+        title, style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"}
     )
     parent_div.append(basic_components_text)
     parent_div.append(
@@ -292,7 +295,7 @@ when("click", left_panel_title)(restore_home)
 
 # BASIC COMPONENTS
 basic_components_text = el.h3(
-    "Basic Components", style={"text-align": "left", "margin": "20px auto 0"}
+    "Basic Components", style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"}
 )
 left_div.append(basic_components_text)
 left_div.append(shoelace.Divider(style={"margin-top": "5px", "margin-bottom": "30px"}))
@@ -306,7 +309,7 @@ when("click", markdown_title)(markdown_components)
 
 # SHOELACE COMPONENTS
 shoe_components_text = el.h3(
-    "Shoe Components", style={"text-align": "left", "margin": "20px auto 0"}
+    "Shoe Components", style={"text-align": "left", "margin": "20px auto 0", "pointer": "cursor"}
 )
 left_div.append(shoe_components_text)
 left_div.append(shoelace.Divider(style={"margin-top": "5px", "margin-bottom": "30px"}))

--- a/pyscript.core/test/ui/demo.py
+++ b/pyscript.core/test/ui/demo.py
@@ -110,6 +110,7 @@ def create_component_example(widget, code):
 
     return grid_
 
+
 def create_main_area():
     """Create the main area of the right side of page, with the description of the
     demo itself and how to use it.
@@ -140,6 +141,7 @@ def create_main_area():
     main.append(div_)
 
     return main
+
 
 def create_basic_components_page(label, kit_name):
     """Create the basic components page.
@@ -209,7 +211,8 @@ when("click", left_panel_title)(restore_home)
 
 # BASIC COMPONENTS
 basic_components_text = h3(
-    "Basic Components", style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"},
+    "Basic Components",
+    style={"text-align": "left", "margin": "20px auto 0", "cursor": "pointer"},
 )
 left_div.append(basic_components_text)
 left_div.append(shoelace.Divider(style={"margin-top": "5px", "margin-bottom": "30px"}))


### PR DESCRIPTION
This PR is just a small one for tweaks to the visual on the demo page:
- added a `main` element so we can have a main and divs inside them
- added styling for the main section
- Added cursor: pointer to left section

<img width="1589" alt="Screenshot 2024-02-01 at 17 01 00" src="https://github.com/pyscript/pyscript/assets/3131401/a025ba27-a04c-444d-9fe7-241ff712bb20">
<img width="1691" alt="Screenshot 2024-02-01 at 17 00 54" src="https://github.com/pyscript/pyscript/assets/3131401/5abc5c4f-5013-4465-b0a0-6f571d4b2ec9">
