### PR TITLE
Update polyscript to fix a try/catch issue

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.7.0",
+                "polyscript": "^0.7.1",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -19,7 +19,7 @@
             "devDependencies": {
                 "@codemirror/commands": "^6.3.3",
                 "@codemirror/lang-python": "^6.1.3",
-                "@codemirror/language": "^6.10.0",
+                "@codemirror/language": "^6.10.1",
                 "@codemirror/state": "^6.4.0",
                 "@codemirror/view": "^6.23.1",
                 "@playwright/test": "^1.41.2",
@@ -91,9 +91,9 @@
             }
         },
         "node_modules/@codemirror/language": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.0.tgz",
-            "integrity": "sha512-2vaNn9aPGCRFKWcHPFksctzJ8yS5p7YoaT+jHpc0UGKzNuAIx4qy6R5wiqbP+heEEdyaABA582mNqSHzSoYdmg==",
+            "version": "6.10.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.1.tgz",
+            "integrity": "sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==",
             "dev": true,
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -2403,9 +2403,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.7.0.tgz",
-            "integrity": "sha512-cvxpvYY5JnHL59tE3Njje1sdDPcqHP7GITJnC8AsAOFAwZb+ucqyyS8gacyNEoyRArK0P3g50pZ4rcl/ojafow==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.7.1.tgz",
+            "integrity": "sha512-wyexafAFyJM/lL5U1SXOcsUUlfN1uJizAqo+TxmmdjaIZATX836RZVr/ymazcIAkwUK5BChNQfUIggLXQodnxg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.7.0",
+        "polyscript": "^0.7.1",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
@@ -50,7 +50,7 @@
     "devDependencies": {
         "@codemirror/commands": "^6.3.3",
         "@codemirror/lang-python": "^6.1.3",
-        "@codemirror/language": "^6.10.0",
+        "@codemirror/language": "^6.10.1",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.23.1",
         "@playwright/test": "^1.41.2",

--- a/pyscript.core/types/core.d.ts
+++ b/pyscript.core/types/core.d.ts
@@ -38,7 +38,11 @@ declare const exportedHooks: {
     };
     worker: {
         onReady: Set<Function>;
-        onBeforeRun: Set<Function>;
+        onBeforeRun: Set<Function>; /**
+         * Given a generic DOM Element, tries to fetch the 'src' attribute, if present.
+         * It either throws an error if the 'src' can't be fetched or it returns a fallback
+         * content as source.
+         */
         onBeforeRunAsync: Set<Function>;
         onAfterRun: Set<Function>;
         onAfterRunAsync: Set<Function>;


### PR DESCRIPTION
## Description

This MR simply brings in latest polyscript where the `try/catch` for the *SharedArrayBuffer* happens only **after** the config has been fully resolved and never before (as it was in 0.7.0 🤦).

This does not affect the procedural worker but it does affect other means to pass along a config, especially the URL and the manual JSON one.

The related *polyscript* MR, if interested: https://github.com/pyscript/polyscript/commit/35da4422facbcbdc2476b8a9170ab4272ac1fe7f

## Changes

  * check the flag **after** the config has been fully parsed, not before
  * test that everything now works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
