### PR TITLE
Fix #1974 - Use utf-8 encoding to bootstrap stdlib

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
@@ -31,7 +31,7 @@
                 "chokidar": "^3.6.0",
                 "codemirror": "^6.0.1",
                 "eslint": "^8.56.0",
-                "rollup": "^4.9.6",
+                "rollup": "^4.10.0",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -472,9 +472,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
-            "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.10.0.tgz",
+            "integrity": "sha512-/MeDQmcD96nVoRumKUljsYOLqfv1YFJps+0pTrb2Z9Nl/w5qNUysMaWQsrd1mvAlNT4yza1iVyIu4Q4AgF6V3A==",
             "cpu": [
                 "arm"
             ],
@@ -485,9 +485,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
-            "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.10.0.tgz",
+            "integrity": "sha512-lvu0jK97mZDJdpZKDnZI93I0Om8lSDaiPx3OiCk0RXn3E8CMPJNS/wxjAvSJJzhhZpfjXsjLWL8LnS6qET4VNQ==",
             "cpu": [
                 "arm64"
             ],
@@ -498,9 +498,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
-            "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.10.0.tgz",
+            "integrity": "sha512-uFpayx8I8tyOvDkD7X6n0PriDRWxcqEjqgtlxnUA/G9oS93ur9aZ8c8BEpzFmsed1TH5WZNG5IONB8IiW90TQg==",
             "cpu": [
                 "arm64"
             ],
@@ -511,9 +511,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
-            "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.10.0.tgz",
+            "integrity": "sha512-nIdCX03qFKoR/MwQegQBK+qZoSpO3LESurVAC6s6jazLA1Mpmgzo3Nj3H1vydXp/JM29bkCiuF7tDuToj4+U9Q==",
             "cpu": [
                 "x64"
             ],
@@ -524,9 +524,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
-            "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.10.0.tgz",
+            "integrity": "sha512-Fz7a+y5sYhYZMQFRkOyCs4PLhICAnxRX/GnWYReaAoruUzuRtcf+Qnw+T0CoAWbHCuz2gBUwmWnUgQ67fb3FYw==",
             "cpu": [
                 "arm"
             ],
@@ -537,9 +537,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
-            "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.10.0.tgz",
+            "integrity": "sha512-yPtF9jIix88orwfTi0lJiqINnlWo6p93MtZEoaehZnmCzEmLL0eqjA3eGVeyQhMtxdV+Mlsgfwhh0+M/k1/V7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -550,9 +550,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
-            "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.10.0.tgz",
+            "integrity": "sha512-9GW9yA30ib+vfFiwjX+N7PnjTnCMiUffhWj4vkG4ukYv1kJ4T9gHNg8zw+ChsOccM27G9yXrEtMScf1LaCuoWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -563,9 +563,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
-            "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.10.0.tgz",
+            "integrity": "sha512-X1ES+V4bMq2ws5fF4zHornxebNxMXye0ZZjUrzOrf7UMx1d6wMQtfcchZ8SqUnQPPHdOyOLW6fTcUiFgHFadRA==",
             "cpu": [
                 "riscv64"
             ],
@@ -576,9 +576,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
-            "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.10.0.tgz",
+            "integrity": "sha512-w/5OpT2EnI/Xvypw4FIhV34jmNqU5PZjZue2l2Y3ty1Ootm3SqhI+AmfhlUYGBTd9JnpneZCDnt3uNOiOBkMyw==",
             "cpu": [
                 "x64"
             ],
@@ -589,9 +589,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
-            "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.10.0.tgz",
+            "integrity": "sha512-q/meftEe3QlwQiGYxD9rWwB21DoKQ9Q8wA40of/of6yGHhZuGfZO0c3WYkN9dNlopHlNT3mf5BPsUSxoPuVQaw==",
             "cpu": [
                 "x64"
             ],
@@ -602,9 +602,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
-            "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.10.0.tgz",
+            "integrity": "sha512-NrR6667wlUfP0BHaEIKgYM/2va+Oj+RjZSASbBMnszM9k+1AmliRjHc3lJIiOehtSSjqYiO7R6KLNrWOX+YNSQ==",
             "cpu": [
                 "arm64"
             ],
@@ -615,9 +615,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
-            "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.10.0.tgz",
+            "integrity": "sha512-FV0Tpt84LPYDduIDcXvEC7HKtyXxdvhdAOvOeWMWbQNulxViH2O07QXkT/FffX4FqEI02jEbCJbr+YcuKdyyMg==",
             "cpu": [
                 "ia32"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
-            "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.10.0.tgz",
+            "integrity": "sha512-OZoJd+o5TaTSQeFFQ6WjFCiltiYVjIdsXxwu/XZ8qRpsvMQr4UsVrE5UyT9RIvsnuF47DqkJKhhVZ2Q9YW9IpQ==",
             "cpu": [
                 "x64"
             ],
@@ -3123,9 +3123,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
-            "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.10.0.tgz",
+            "integrity": "sha512-t2v9G2AKxcQ8yrG+WGxctBes1AomT0M4ND7jTFBCVPXQ/WFTvNSefIrNSmLKhIKBrvN8SG+CZslimJcT3W2u2g==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -3138,19 +3138,19 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.9.6",
-                "@rollup/rollup-android-arm64": "4.9.6",
-                "@rollup/rollup-darwin-arm64": "4.9.6",
-                "@rollup/rollup-darwin-x64": "4.9.6",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
-                "@rollup/rollup-linux-arm64-gnu": "4.9.6",
-                "@rollup/rollup-linux-arm64-musl": "4.9.6",
-                "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
-                "@rollup/rollup-linux-x64-gnu": "4.9.6",
-                "@rollup/rollup-linux-x64-musl": "4.9.6",
-                "@rollup/rollup-win32-arm64-msvc": "4.9.6",
-                "@rollup/rollup-win32-ia32-msvc": "4.9.6",
-                "@rollup/rollup-win32-x64-msvc": "4.9.6",
+                "@rollup/rollup-android-arm-eabi": "4.10.0",
+                "@rollup/rollup-android-arm64": "4.10.0",
+                "@rollup/rollup-darwin-arm64": "4.10.0",
+                "@rollup/rollup-darwin-x64": "4.10.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.10.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.10.0",
+                "@rollup/rollup-linux-arm64-musl": "4.10.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.10.0",
+                "@rollup/rollup-linux-x64-gnu": "4.10.0",
+                "@rollup/rollup-linux-x64-musl": "4.10.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.10.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.10.0",
+                "@rollup/rollup-win32-x64-msvc": "4.10.0",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -62,7 +62,7 @@
         "chokidar": "^3.6.0",
         "codemirror": "^6.0.1",
         "eslint": "^8.56.0",
-        "rollup": "^4.9.6",
+        "rollup": "^4.10.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",

--- a/pyscript.core/src/stdlib.js
+++ b/pyscript.core/src/stdlib.js
@@ -21,7 +21,7 @@ const write = (base, literal) => {
         python.push(`_path = _Path("${base}/${key}")`);
         if (typeof value === "string") {
             const code = JSON.stringify(value);
-            python.push(`_path.write_text(${code})`);
+            python.push(`_path.write_text(${code},encoding="utf-8")`);
         } else {
             // @see https://github.com/pyscript/pyscript/pull/1813#issuecomment-1781502909
             python.push(`if not _os.path.exists("${base}/${key}"):`);

--- a/pyscript.core/types/3rd-party/codemirror.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "codemirror";

--- a/pyscript.core/types/3rd-party/codemirror_commands.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror_commands.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@codemirror/commands";

--- a/pyscript.core/types/3rd-party/codemirror_lang-python.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror_lang-python.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@codemirror/lang-python";

--- a/pyscript.core/types/3rd-party/codemirror_language.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror_language.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@codemirror/language";

--- a/pyscript.core/types/3rd-party/codemirror_state.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror_state.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@codemirror/state";

--- a/pyscript.core/types/3rd-party/codemirror_view.d.ts
+++ b/pyscript.core/types/3rd-party/codemirror_view.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@codemirror/view";


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/1974 by explicitly setting `utf-8` as text encoding.

**Please ignore TypeScript entries** as these were a leftover from another version and should not affect the project at all.

## Changes

  * apply the suggested and tested patch from the issue

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
