### PR TITLE
Update MicroPython to its latest

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.7",
+            "version": "0.4.8",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.11.1",
+                "polyscript": "^0.11.2",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -35,7 +35,7 @@
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
-                "typescript": "^5.4.2",
+                "typescript": "^5.4.3",
                 "xterm": "^5.3.0",
                 "xterm-readline": "^1.1.1"
             }
@@ -2414,9 +2414,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.11.1.tgz",
-            "integrity": "sha512-zSmzaK55Wxe2tRNeX5cb/w1Swl63YNprhGGkUbtc1jCN6W8wsOjaChFh4blvfl/g+QiL/tf+/uX7mFnanREzsA==",
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.11.2.tgz",
+            "integrity": "sha512-ITDUPvb63iuew2PxET8UQV/NduCTMesB6EHdbuBtESapJ21+WFyDAyIttXKc0W9fzFRUn1j9udEEH7vDbz6MKg==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
@@ -3553,9 +3553,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.11.1",
+        "polyscript": "^0.11.2",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
@@ -66,7 +66,7 @@
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",
-        "typescript": "^5.4.2",
+        "typescript": "^5.4.3",
         "xterm": "^5.3.0",
         "xterm-readline": "^1.1.1"
     },


### PR DESCRIPTION
## Description

This MR brings in latest MicroPython with its PATH and PATH_FS back from Emscripten API and an even better support for Promise related tasks in the mixed JS <-> Python scenario.

## Changes

  * update polyscript with the latest MicroPython
  * tested everything is good

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
