### PR TITLE
Update Polyscript with its latest untar.gz and unzip abilities

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.11.2",
+                "polyscript": "^0.11.3",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -2414,9 +2414,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.11.2.tgz",
-            "integrity": "sha512-ITDUPvb63iuew2PxET8UQV/NduCTMesB6EHdbuBtESapJ21+WFyDAyIttXKc0W9fzFRUn1j9udEEH7vDbz6MKg==",
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.11.3.tgz",
+            "integrity": "sha512-0wzunsH9b/h+EoB0tZKMRUg0YoFHraRuBuPK+cJsmUmNr1bVM1LvzFk21grDstXjo6Ah78dEC7SjaA0sSBsJeQ==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.11.2",
+        "polyscript": "^0.11.3",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"


### PR DESCRIPTION
## Description

This MR brings in both MicroPython and Pyodide ability to unpack `.tar.gz` and `.zip` files out of the box in the wild via its Virtual FileSystem.

## Changes

  * update polyscript to its latest
  * test all the things

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
