### PR TITLE
pyscript.ffi - expose most essential utilities

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/stdlib/pyscript/ffi.py
+++ b/pyscript.core/src/stdlib/pyscript/ffi.py
@@ -1,0 +1,15 @@
+try:
+    from pyodide.ffi import create_proxy as _cp, to_js as _py_tjs
+    import js
+    from_entries = js.Object.fromEntries
+
+    def _tjs(value, **kw):
+      if not hasattr(kw, "dict_converter"):
+        kw["dict_converter"] = from_entries
+      return _py_tjs(value, **kw)
+
+except:
+    from jsffi import create_proxy as _cp, to_js as _tjs
+
+create_proxy = _cp
+to_js = _tjs

--- a/pyscript.core/src/stdlib/pyscript/ffi.py
+++ b/pyscript.core/src/stdlib/pyscript/ffi.py
@@ -1,15 +1,18 @@
 try:
-    from pyodide.ffi import create_proxy as _cp, to_js as _py_tjs
     import js
+    from pyodide.ffi import create_proxy as _cp
+    from pyodide.ffi import to_js as _py_tjs
+
     from_entries = js.Object.fromEntries
 
     def _tjs(value, **kw):
-      if not hasattr(kw, "dict_converter"):
-        kw["dict_converter"] = from_entries
-      return _py_tjs(value, **kw)
+        if not hasattr(kw, "dict_converter"):
+            kw["dict_converter"] = from_entries
+        return _py_tjs(value, **kw)
 
 except:
-    from jsffi import create_proxy as _cp, to_js as _tjs
+    from jsffi import create_proxy as _cp
+    from jsffi import to_js as _tjs
 
 create_proxy = _cp
 to_js = _tjs

--- a/pyscript.core/test/ffi.html
+++ b/pyscript.core/test/ffi.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>PyScript FFI</title>
+        <link rel="stylesheet" href="../dist/core.css">
+        <script type="module" src="../dist/core.js"></script>
+    </head>
+    <body>
+      <script type="mpy">
+          from pyscript import document
+          from pyscript.ffi import to_js
+          document.documentElement.classList.add(
+            to_js({"ok": "mpy"}).ok
+          )
+      </script>
+      <script type="py">
+          from pyscript import document
+          from pyscript.ffi import to_js
+          document.documentElement.classList.add(
+            to_js({"ok": "py"}).ok
+          )
+      </script>
+    </body>
+</html>

--- a/pyscript.core/test/index.html
+++ b/pyscript.core/test/index.html
@@ -13,6 +13,9 @@
     <body>
         <script type="py">
             from pyscript import display
+            from pyscript.ffi import to_js
+            import js
+            js.console.log(to_js({"a": 1}))
             display("Hello", "PyScript Next", append=False)
         </script>
     </body>

--- a/pyscript.core/test/index.html
+++ b/pyscript.core/test/index.html
@@ -13,9 +13,6 @@
     <body>
         <script type="py">
             from pyscript import display
-            from pyscript.ffi import to_js
-            import js
-            js.console.log(to_js({"a": 1}))
             display("Hello", "PyScript Next", append=False)
         </script>
     </body>

--- a/pyscript.core/test/mpy.spec.js
+++ b/pyscript.core/test/mpy.spec.js
@@ -83,3 +83,8 @@ test('MicroPython + Pyodide fetch', async ({ page }) => {
   await page.goto('http://localhost:8080/test/fetch.html');
   await page.waitForSelector('html.mpy.py');
 });
+
+test('MicroPython + Pyodide ffi', async ({ page }) => {
+  await page.goto('http://localhost:8080/test/ffi.html');
+  await page.waitForSelector('html.mpy.py');
+});

--- a/pyscript.core/types/stdlib/pyscript.d.ts
+++ b/pyscript.core/types/stdlib/pyscript.d.ts
@@ -4,6 +4,7 @@ declare namespace _default {
         "display.py": string;
         "event_handling.py": string;
         "fetch.py": string;
+        "ffi.py": string;
         "magic_js.py": string;
         "util.py": string;
     };


### PR DESCRIPTION
## Description

After updating to latest MicroPython we needed to find a better story for the `ffi` utilities because `pyodide` namespace is gone (for good) in MicroPython side of affairs.

This MR exposes our own `ffi` namespace with currently the following 2 utilities:

  * a `to_js` utility to convert Python references to JS counterparts, where by default dictionaries in Python are converted as *object literals* (and **not Map**) in JS
  * a `create_proxy` utility for other cases where callbacks need to explicitly "*leak*" until some further condition happens (listeners or other things not automatically destroyed once executed)

## Changes

  * add our own `pyscript.ffi` module that exports `pyodide.ffi.to_js` with a default `dict_converter=Object.fromEntries` and `pyodide.ffi.create_proxy` as is + `jsffi.to_js` and `jsffi.create_proxy` as is from MicroPython
  * create an integration test for both runtimes

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
