### PR TITLE
Fix #2007 - fallback to zero-width-char on empty input

### DIFF
--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -180,7 +180,8 @@ const pyTerminal = async () => {
                     isatty: true,
                     write(buffer) {
                         data = decoder.decode(buffer);
-                        readline.write(data);
+                        // @see https://github.com/pyscript/pyscript/issues/2007
+                        readline.write(data || "​");
                         return buffer.length;
                     },
                 };

--- a/pyscript.core/test/input.html
+++ b/pyscript.core/test/input.html
@@ -3,19 +3,14 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>PyScript Next</title>
-        <script>
-            addEventListener("py:ready", console.log);
-        </script>
         <link rel="stylesheet" href="../dist/core.css">
         <script type="module" src="../dist/core.js"></script>
     </head>
     <body>
-        <py-script>
-            input("what's your name?")
-        </py-script>
-        <mpy-script>
-            input("what's your name?")
-        </mpy-script>
+        <script type="py" terminal worker>
+            print('enter your name')
+            a = input('​')
+            print(f'Hello, {a}')
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Description

This MR goal is to fix https://github.com/pyscript/pyscript/issues/2007 as that's the second time our users complain that an empty input returns the previous output ... this is actually (to me) an upstream *readline* module issue, but until that gets fixed, we can at least make our users' expectations work as expected!

Related (and no answer): https://github.com/strtok/xterm-readline/issues/9

## Changes

  * fallback to [zero width space](https://en.wikipedia.org/wiki/Zero-width_space) on empty inputs or strings so that `input()` works as expected
  * smoke test that's the case already and it works

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
