### PR TITLE
Fix #1997 - Bring pyscript stdlib to the PyEditor

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -31,7 +31,7 @@
                 "chokidar": "^3.6.0",
                 "codemirror": "^6.0.1",
                 "eslint": "^8.57.0",
-                "rollup": "^4.13.0",
+                "rollup": "^4.13.1",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -472,9 +472,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
-            "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.1.tgz",
+            "integrity": "sha512-4C4UERETjXpC4WpBXDbkgNVgHyWfG3B/NKY46e7w5H134UDOFqUJKpsLm0UYmuupW+aJmRgeScrDNfvZ5WV80A==",
             "cpu": [
                 "arm"
             ],
@@ -485,9 +485,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
-            "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.1.tgz",
+            "integrity": "sha512-TrTaFJ9pXgfXEiJKQ3yQRelpQFqgRzVR9it8DbeRzG0RX7mKUy0bqhCFsgevwXLJepQKTnLl95TnPGf9T9AMOA==",
             "cpu": [
                 "arm64"
             ],
@@ -498,9 +498,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
-            "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.1.tgz",
+            "integrity": "sha512-fz7jN6ahTI3cKzDO2otQuybts5cyu0feymg0bjvYCBrZQ8tSgE8pc0sSNEuGvifrQJWiwx9F05BowihmLxeQKw==",
             "cpu": [
                 "arm64"
             ],
@@ -511,9 +511,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
-            "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.1.tgz",
+            "integrity": "sha512-WTvdz7SLMlJpektdrnWRUN9C0N2qNHwNbWpNo0a3Tod3gb9leX+yrYdCeB7VV36OtoyiPAivl7/xZ3G1z5h20g==",
             "cpu": [
                 "x64"
             ],
@@ -524,9 +524,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
-            "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.1.tgz",
+            "integrity": "sha512-dBHQl+7wZzBYcIF6o4k2XkAfwP2ks1mYW2q/Gzv9n39uDcDiAGDqEyml08OdY0BIct0yLSPkDTqn4i6czpBLLw==",
             "cpu": [
                 "arm"
             ],
@@ -537,9 +537,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
-            "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.1.tgz",
+            "integrity": "sha512-bur4JOxvYxfrAmocRJIW0SADs3QdEYK6TQ7dTNz6Z4/lySeu3Z1H/+tl0a4qDYv0bCdBpUYM0sYa/X+9ZqgfSQ==",
             "cpu": [
                 "arm64"
             ],
@@ -550,9 +550,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
-            "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.1.tgz",
+            "integrity": "sha512-ssp77SjcDIUSoUyj7DU7/5iwM4ZEluY+N8umtCT9nBRs3u045t0KkW02LTyHouHDomnMXaXSZcCSr2bdMK63kA==",
             "cpu": [
                 "arm64"
             ],
@@ -563,9 +563,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
-            "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.1.tgz",
+            "integrity": "sha512-Jv1DkIvwEPAb+v25/Unrnnq9BO3F5cbFPT821n3S5litkz+O5NuXuNhqtPx5KtcwOTtaqkTsO+IVzJOsxd11aQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -575,10 +575,23 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.13.1.tgz",
+            "integrity": "sha512-U564BrhEfaNChdATQaEODtquCC7Ez+8Hxz1h5MAdMYj0AqD0GA9rHCpElajb/sQcaFL6NXmHc5O+7FXpWMa73Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
-            "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.1.tgz",
+            "integrity": "sha512-zGRDulLTeDemR8DFYyFIQ8kMP02xpUsX4IBikc7lwL9PrwR3gWmX2NopqiGlI2ZVWMl15qZeUjumTwpv18N7sQ==",
             "cpu": [
                 "x64"
             ],
@@ -589,9 +602,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
-            "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.1.tgz",
+            "integrity": "sha512-VTk/MveyPdMFkYJJPCkYBw07KcTkGU2hLEyqYMsU4NjiOfzoaDTW9PWGRsNwiOA3qI0k/JQPjkl/4FCK1smskQ==",
             "cpu": [
                 "x64"
             ],
@@ -602,9 +615,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
-            "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.1.tgz",
+            "integrity": "sha512-L+hX8Dtibb02r/OYCsp4sQQIi3ldZkFI0EUkMTDwRfFykXBPptoz/tuuGqEd3bThBSLRWPR6wsixDSgOx/U3Zw==",
             "cpu": [
                 "arm64"
             ],
@@ -615,9 +628,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
-            "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.1.tgz",
+            "integrity": "sha512-+dI2jVPfM5A8zme8riEoNC7UKk0Lzc7jCj/U89cQIrOjrZTCWZl/+IXUeRT2rEZ5j25lnSA9G9H1Ob9azaF/KQ==",
             "cpu": [
                 "ia32"
             ],
@@ -628,9 +641,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
-            "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.1.tgz",
+            "integrity": "sha512-YY1Exxo2viZ/O2dMHuwQvimJ0SqvL+OAWQLLY6rvXavgQKjhQUzn7nc1Dd29gjB5Fqi00nrBWctJBOyfVMIVxw==",
             "cpu": [
                 "x64"
             ],
@@ -3136,9 +3149,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
-            "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.1.tgz",
+            "integrity": "sha512-hFi+fU132IvJ2ZuihN56dwgpltpmLZHZWsx27rMCTZ2sYwrqlgL5sECGy1eeV2lAihD8EzChBVVhsXci0wD4Tg==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -3151,19 +3164,20 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.13.0",
-                "@rollup/rollup-android-arm64": "4.13.0",
-                "@rollup/rollup-darwin-arm64": "4.13.0",
-                "@rollup/rollup-darwin-x64": "4.13.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.13.0",
-                "@rollup/rollup-linux-arm64-musl": "4.13.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
-                "@rollup/rollup-linux-x64-gnu": "4.13.0",
-                "@rollup/rollup-linux-x64-musl": "4.13.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.13.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.13.0",
-                "@rollup/rollup-win32-x64-msvc": "4.13.0",
+                "@rollup/rollup-android-arm-eabi": "4.13.1",
+                "@rollup/rollup-android-arm64": "4.13.1",
+                "@rollup/rollup-darwin-arm64": "4.13.1",
+                "@rollup/rollup-darwin-x64": "4.13.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.13.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.13.1",
+                "@rollup/rollup-linux-arm64-musl": "4.13.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.13.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.13.1",
+                "@rollup/rollup-linux-x64-gnu": "4.13.1",
+                "@rollup/rollup-linux-x64-musl": "4.13.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.13.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.13.1",
+                "@rollup/rollup-win32-x64-msvc": "4.13.1",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.10",
+            "version": "0.4.11",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -62,7 +62,7 @@
         "chokidar": "^3.6.0",
         "codemirror": "^6.0.1",
         "eslint": "^8.57.0",
-        "rollup": "^4.13.0",
+        "rollup": "^4.13.1",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -26,6 +26,9 @@ import { ErrorCode } from "./exceptions.js";
 import { robustFetch as fetch, getText } from "./fetch.js";
 import { hooks, main, worker, codeFor, createFunction } from "./hooks.js";
 
+import stdlib from "./stdlib.js";
+export { stdlib };
+
 // generic helper to disambiguate between custom element and script
 const isScript = ({ tagName }) => tagName === "SCRIPT";
 

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -1,6 +1,6 @@
 // PyScript py-editor plugin
 import { Hook, XWorker, dedent } from "polyscript/exports";
-import { TYPES } from "../core.js";
+import { TYPES, stdlib } from "../core.js";
 
 const RUN_BUTTON = `<svg style="height:20px;width:20px;vertical-align:-.125em;transform-origin:center;overflow:visible;color:green" viewBox="0 0 384 512" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg"><g transform="translate(192 256)" transform-origin="96 0"><g transform="translate(0,0) scale(1,1)"><path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" fill="currentColor" transform="translate(-192 -256)"></path></g></g></svg>`;
 
@@ -11,6 +11,7 @@ const envs = new Map();
 
 const hooks = {
     worker: {
+        codeBeforeRun: () => stdlib,
         // works on both Pyodide and MicroPython
         onReady: ({ runAsync, io }, { sync }) => {
             io.stdout = (line) => sync.write(line);

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -155,7 +155,7 @@ const init = async (script, type, interpreter) => {
         throw new SyntaxError(
             configs.get(env)
                 ? `duplicated config for env: ${env}`
-                : `unable to add a config to the env env: ${env}`
+                : `unable to add a config to the env: ${env}`,
         );
     }
 

--- a/pyscript.core/test/py-editor/config.toml
+++ b/pyscript.core/test/py-editor/config.toml
@@ -1,0 +1,2 @@
+[js_modules.worker]
+"https://cdn.jsdelivr.net/npm/html-escaper/+esm" = "html_escaper"

--- a/pyscript.core/test/py-editor/index.html
+++ b/pyscript.core/test/py-editor/index.html
@@ -11,9 +11,10 @@
   <script type="mpy-editor" env="task1">
     print(a)
   </script>
-  <script type="mpy-editor" env="task2" setup>
+  <script type="mpy-editor" config="./config.toml" env="task2" setup>
     from pyscript import window
-    window.console.log("OK")
+    from pyscript.js_modules.html_escaper import escape, unescape
+    window.console.log(unescape(escape("<OK>")))
     b = 2
   </script>
   <script type="mpy-editor" env="task2">

--- a/pyscript.core/test/py-editor/index.html
+++ b/pyscript.core/test/py-editor/index.html
@@ -7,18 +7,35 @@
   <script type="module" src="../../dist/core.js"></script>
 </head>
 <body>
-  <script type="mpy-editor" src="task1.py" env="task1" setup></script>
+  <!-- a setup node with a config for an env -->
+  <script type="mpy-editor" src="task1.py" config="./config.toml" env="task1" setup></script>
   <script type="mpy-editor" env="task1">
-    print(a)
-  </script>
-  <script type="mpy-editor" config="./config.toml" env="task2" setup>
-    from pyscript import window
     from pyscript.js_modules.html_escaper import escape, unescape
-    window.console.log(unescape(escape("<OK>")))
+    print(unescape(escape("<OK>")))
+    a = 1
+  </script>
+  <!-- a share-nothing micropython editor -->
+  <script type="mpy-editor" config="./config.toml">
+    from pyscript.js_modules.html_escaper import escape, unescape
+    print(unescape(escape("<OK>")))
     b = 2
+    try:
+      print(a)
+    except:
+      print("all good")
+  </script>
+  <!-- a config once micropython env -->
+  <script type="mpy-editor" env="task2" config="./config.toml">
+    from pyscript.js_modules.html_escaper import escape, unescape
+    print(unescape(escape("<OK>")))
+    c = 3
+    try:
+      print(b)
+    except:
+      print("all good")
   </script>
   <script type="mpy-editor" env="task2">
-    print(b)
+    print(c)
   </script>
 </body>
 </html>

--- a/pyscript.core/test/py-editor/index.html
+++ b/pyscript.core/test/py-editor/index.html
@@ -12,6 +12,8 @@
     print(a)
   </script>
   <script type="mpy-editor" env="task2" setup>
+    from pyscript import window
+    window.console.log("OK")
     b = 2
   </script>
   <script type="mpy-editor" env="task2">

--- a/pyscript.core/test/py-editor/task1.py
+++ b/pyscript.core/test/py-editor/task1.py
@@ -1,4 +1,5 @@
 from pyscript import window
+
 window.console.log("OK")
 
 a = 1

--- a/pyscript.core/test/py-editor/task1.py
+++ b/pyscript.core/test/py-editor/task1.py
@@ -1,1 +1,4 @@
+from pyscript import window
+window.console.log("OK")
+
 a = 1

--- a/pyscript.core/types/core.d.ts
+++ b/pyscript.core/types/core.d.ts
@@ -1,3 +1,4 @@
+import stdlib from "./stdlib.js";
 import TYPES from "./types.js";
 /**
  * A `Worker` facade able to bootstrap on the worker thread only a PyScript module.
@@ -38,11 +39,7 @@ declare const exportedHooks: {
     };
     worker: {
         onReady: Set<Function>;
-        onBeforeRun: Set<Function>; /**
-         * Given a generic DOM Element, tries to fetch the 'src' attribute, if present.
-         * It either throws an error if the 'src' can't be fetched or it returns a fallback
-         * content as source.
-         */
+        onBeforeRun: Set<Function>;
         onBeforeRunAsync: Set<Function>;
         onAfterRun: Set<Function>;
         onAfterRunAsync: Set<Function>;
@@ -55,4 +52,4 @@ declare const exportedHooks: {
 declare const exportedConfig: {};
 declare const exportedWhenDefined: (type: string) => Promise<any>;
 import sync from "./sync.js";
-export { TYPES, exportedPyWorker as PyWorker, exportedMPWorker as MPWorker, exportedHooks as hooks, exportedConfig as config, exportedWhenDefined as whenDefined };
+export { stdlib, TYPES, exportedPyWorker as PyWorker, exportedMPWorker as MPWorker, exportedHooks as hooks, exportedConfig as config, exportedWhenDefined as whenDefined };


### PR DESCRIPTION
## Description

Fixes https://github.com/pyscript/pyscript/discussions/1997

- - -

This MR should fully solve this discussion https://github.com/pyscript/pyscript/discussions/1997 by providing, from *core* itself, our *stdlib* within the *PyEditor* custom type (both `py-editor` and `mpy-editor`).

All concerns are likely premature as users never had a chance to use our module in there, so this is a starting point that still will require some documentation update.

## Changes

  * use a `codeBeforeRun` hook that executes on XWorker bootstrap once and includes our stdlib artifact, as that's exactly what any other PyScript tags uses anyway
  * add a check for `config` attribute, and, if there:
    * if no *env* was specified, use that *config*
    * if an *env* was specified and known:
      * if the env had a *config*, throw an `duplicated config for env: ...`
      * if the env had no *config*, throw an `unable to add a config to the env: ...`
    * bootstrap the worker for that *env* with that *config* otherwise
  * flag the *env* as known regardless
  * remove the `async` nature of the *MO* callback as that backfires with tons of errors otherwise and it wasn't needed anyway
  * test everything works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
