### PR TITLE
Better MicroPython Terminal

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.12",
+            "version": "0.4.13",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.12.1",
+                "polyscript": "^0.12.2",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -31,7 +31,7 @@
                 "chokidar": "^3.6.0",
                 "codemirror": "^6.0.1",
                 "eslint": "^8.57.0",
-                "rollup": "^4.13.2",
+                "rollup": "^4.14.0",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -472,9 +472,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.2.tgz",
-            "integrity": "sha512-3XFIDKWMFZrMnao1mJhnOT1h2g0169Os848NhhmGweEcfJ4rCi+3yMCOLG4zA61rbJdkcrM/DjVZm9Hg5p5w7g==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.0.tgz",
+            "integrity": "sha512-jwXtxYbRt1V+CdQSy6Z+uZti7JF5irRKF8hlKfEnF/xJpcNGuuiZMBvuoYM+x9sr9iWGnzrlM0+9hvQ1kgkf1w==",
             "cpu": [
                 "arm"
             ],
@@ -485,9 +485,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.2.tgz",
-            "integrity": "sha512-GdxxXbAuM7Y/YQM9/TwwP+L0omeE/lJAR1J+olu36c3LqqZEBdsIWeQ91KBe6nxwOnb06Xh7JS2U5ooWU5/LgQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.0.tgz",
+            "integrity": "sha512-fI9nduZhCccjzlsA/OuAwtFGWocxA4gqXGTLvOyiF8d+8o0fZUeSztixkYjcGq1fGZY3Tkq4yRvHPFxU+jdZ9Q==",
             "cpu": [
                 "arm64"
             ],
@@ -498,9 +498,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.2.tgz",
-            "integrity": "sha512-mCMlpzlBgOTdaFs83I4XRr8wNPveJiJX1RLfv4hggyIVhfB5mJfN4P8Z6yKh+oE4Luz+qq1P3kVdWrCKcMYrrA==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.0.tgz",
+            "integrity": "sha512-BcnSPRM76/cD2gQC+rQNGBN6GStBs2pl/FpweW8JYuz5J/IEa0Fr4AtrPv766DB/6b2MZ/AfSIOSGw3nEIP8SA==",
             "cpu": [
                 "arm64"
             ],
@@ -511,9 +511,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.2.tgz",
-            "integrity": "sha512-yUoEvnH0FBef/NbB1u6d3HNGyruAKnN74LrPAfDQL3O32e3k3OSfLrPgSJmgb3PJrBZWfPyt6m4ZhAFa2nZp2A==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.0.tgz",
+            "integrity": "sha512-LDyFB9GRolGN7XI6955aFeI3wCdCUszFWumWU0deHA8VpR3nWRrjG6GtGjBrQxQKFevnUTHKCfPR4IvrW3kCgQ==",
             "cpu": [
                 "x64"
             ],
@@ -524,9 +524,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.2.tgz",
-            "integrity": "sha512-GYbLs5ErswU/Xs7aGXqzc3RrdEjKdmoCrgzhJWyFL0r5fL3qd1NPcDKDowDnmcoSiGJeU68/Vy+OMUluRxPiLQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.0.tgz",
+            "integrity": "sha512-ygrGVhQP47mRh0AAD0zl6QqCbNsf0eTo+vgwkY6LunBcg0f2Jv365GXlDUECIyoXp1kKwL5WW6rsO429DBY/bA==",
             "cpu": [
                 "arm"
             ],
@@ -537,9 +537,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.2.tgz",
-            "integrity": "sha512-L1+D8/wqGnKQIlh4Zre9i4R4b4noxzH5DDciyahX4oOz62CphY7WDWqJoQ66zNR4oScLNOqQJfNSIAe/6TPUmQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.0.tgz",
+            "integrity": "sha512-x+uJ6MAYRlHGe9wi4HQjxpaKHPM3d3JjqqCkeC5gpnnI6OWovLdXTpfa8trjxPLnWKyBsSi5kne+146GAxFt4A==",
             "cpu": [
                 "arm64"
             ],
@@ -550,9 +550,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.2.tgz",
-            "integrity": "sha512-tK5eoKFkXdz6vjfkSTCupUzCo40xueTOiOO6PeEIadlNBkadH1wNOH8ILCPIl8by/Gmb5AGAeQOFeLev7iZDOA==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.0.tgz",
+            "integrity": "sha512-nrRw8ZTQKg6+Lttwqo6a2VxR9tOroa2m91XbdQ2sUUzHoedXlsyvY1fN4xWdqz8PKmf4orDwejxXHjh7YBGUCA==",
             "cpu": [
                 "arm64"
             ],
@@ -563,9 +563,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.13.2.tgz",
-            "integrity": "sha512-zvXvAUGGEYi6tYhcDmb9wlOckVbuD+7z3mzInCSTACJ4DQrdSLPNUeDIcAQW39M3q6PDquqLWu7pnO39uSMRzQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.0.tgz",
+            "integrity": "sha512-xV0d5jDb4aFu84XKr+lcUJ9y3qpIWhttO3Qev97z8DKLXR62LC3cXT/bMZXrjLF9X+P5oSmJTzAhqwUbY96PnA==",
             "cpu": [
                 "ppc64le"
             ],
@@ -576,9 +576,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.2.tgz",
-            "integrity": "sha512-C3GSKvMtdudHCN5HdmAMSRYR2kkhgdOfye4w0xzyii7lebVr4riCgmM6lRiSCnJn2w1Xz7ZZzHKuLrjx5620kw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.0.tgz",
+            "integrity": "sha512-SDDhBQwZX6LPRoPYjAZWyL27LbcBo7WdBFWJi5PI9RPCzU8ijzkQn7tt8NXiXRiFMJCVpkuMkBf4OxSxVMizAw==",
             "cpu": [
                 "riscv64"
             ],
@@ -589,9 +589,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.13.2.tgz",
-            "integrity": "sha512-l4U0KDFwzD36j7HdfJ5/TveEQ1fUTjFFQP5qIt9gBqBgu1G8/kCaq5Ok05kd5TG9F8Lltf3MoYsUMw3rNlJ0Yg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.0.tgz",
+            "integrity": "sha512-RxB/qez8zIDshNJDufYlTT0ZTVut5eCpAZ3bdXDU9yTxBzui3KhbGjROK2OYTTor7alM7XBhssgoO3CZ0XD3qA==",
             "cpu": [
                 "s390x"
             ],
@@ -602,9 +602,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.2.tgz",
-            "integrity": "sha512-xXMLUAMzrtsvh3cZ448vbXqlUa7ZL8z0MwHp63K2IIID2+DeP5iWIT6g1SN7hg1VxPzqx0xZdiDM9l4n9LRU1A==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.0.tgz",
+            "integrity": "sha512-C6y6z2eCNCfhZxT9u+jAM2Fup89ZjiG5pIzZIDycs1IwESviLxwkQcFRGLjnDrP+PT+v5i4YFvlcfAs+LnreXg==",
             "cpu": [
                 "x64"
             ],
@@ -615,9 +615,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.2.tgz",
-            "integrity": "sha512-M/JYAWickafUijWPai4ehrjzVPKRCyDb1SLuO+ZyPfoXgeCEAlgPkNXewFZx0zcnoIe3ay4UjXIMdXQXOZXWqA==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.0.tgz",
+            "integrity": "sha512-i0QwbHYfnOMYsBEyjxcwGu5SMIi9sImDVjDg087hpzXqhBSosxkE7gyIYFHgfFl4mr7RrXksIBZ4DoLoP4FhJg==",
             "cpu": [
                 "x64"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.2.tgz",
-            "integrity": "sha512-2YWwoVg9KRkIKaXSh0mz3NmfurpmYoBBTAXA9qt7VXk0Xy12PoOP40EFuau+ajgALbbhi4uTj3tSG3tVseCjuA==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.0.tgz",
+            "integrity": "sha512-Fq52EYb0riNHLBTAcL0cun+rRwyZ10S9vKzhGKKgeD+XbwunszSY0rVMco5KbOsTlwovP2rTOkiII/fQ4ih/zQ==",
             "cpu": [
                 "arm64"
             ],
@@ -641,9 +641,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.2.tgz",
-            "integrity": "sha512-2FSsE9aQ6OWD20E498NYKEQLneShWes0NGMPQwxWOdws35qQXH+FplabOSP5zEe1pVjurSDOGEVCE2agFwSEsw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.0.tgz",
+            "integrity": "sha512-e/PBHxPdJ00O9p5Ui43+vixSgVf4NlLsmV6QneGERJ3lnjIua/kim6PRFe3iDueT1rQcgSkYP8ZBBXa/h4iPvw==",
             "cpu": [
                 "ia32"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.2.tgz",
-            "integrity": "sha512-7h7J2nokcdPePdKykd8wtc8QqqkqxIrUz7MHj6aNr8waBRU//NLDVnNjQnqQO6fqtjrtCdftpbTuOKAyrAQETQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.0.tgz",
+            "integrity": "sha512-aGg7iToJjdklmxlUlJh/PaPNa4PmqHfyRMLunbL3eaMO0gp656+q1zOKkpJ/CVe9CryJv6tAN1HDoR8cNGzkag==",
             "cpu": [
                 "x64"
             ],
@@ -2440,9 +2440,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.1.tgz",
-            "integrity": "sha512-fQtpelwephyl34UMHxPwKNpGkUDbAIEMa09EFLthBpvThRSmrNQrus/WuouGKjqedK5dv+qCwP5RU1Lbe1bQLA==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.2.tgz",
+            "integrity": "sha512-qHZbcSVhp4bDW9YjcPyYw2AWDRrBEDUVxKMuvjACjQK7O891H6x7dNKVYNjij75Ygn9akma+X1n6eTW4syBFmQ==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
@@ -3162,9 +3162,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.2.tgz",
-            "integrity": "sha512-MIlLgsdMprDBXC+4hsPgzWUasLO9CE4zOkj/u6j+Z6j5A4zRY+CtiXAdJyPtgCsc42g658Aeh1DlrdVEJhsL2g==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.0.tgz",
+            "integrity": "sha512-Qe7w62TyawbDzB4yt32R0+AbIo6m1/sqO7UPzFS8Z/ksL5mrfhA0v4CavfdmFav3D+ub4QeAgsGEe84DoWe/nQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -3177,21 +3177,21 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.13.2",
-                "@rollup/rollup-android-arm64": "4.13.2",
-                "@rollup/rollup-darwin-arm64": "4.13.2",
-                "@rollup/rollup-darwin-x64": "4.13.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.13.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.13.2",
-                "@rollup/rollup-linux-arm64-musl": "4.13.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.13.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.13.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.13.2",
-                "@rollup/rollup-linux-x64-gnu": "4.13.2",
-                "@rollup/rollup-linux-x64-musl": "4.13.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.13.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.13.2",
-                "@rollup/rollup-win32-x64-msvc": "4.13.2",
+                "@rollup/rollup-android-arm-eabi": "4.14.0",
+                "@rollup/rollup-android-arm64": "4.14.0",
+                "@rollup/rollup-darwin-arm64": "4.14.0",
+                "@rollup/rollup-darwin-x64": "4.14.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.14.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.14.0",
+                "@rollup/rollup-linux-arm64-musl": "4.14.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.14.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.14.0",
+                "@rollup/rollup-linux-x64-gnu": "4.14.0",
+                "@rollup/rollup-linux-x64-musl": "4.14.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.14.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.14.0",
+                "@rollup/rollup-win32-x64-msvc": "4.14.0",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.12.1",
+        "polyscript": "^0.12.2",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
@@ -62,7 +62,7 @@
         "chokidar": "^3.6.0",
         "codemirror": "^6.0.1",
         "eslint": "^8.57.0",
-        "rollup": "^4.13.2",
+        "rollup": "^4.14.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -36,7 +36,7 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
     const { pyterminal_read, pyterminal_write } = sync;
     const decoder = new TextDecoder();
     const generic = {
-        isatty: true,
+        isatty: false,
         write(buffer) {
             data = decoder.decode(buffer);
             pyterminal_write(data);
@@ -74,18 +74,16 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
                     data = out.split("\n").at(-1);
                     input = encoder.encode(`${pyterminal_read(data)}\r`);
                     length = 0;
-                    for (const c of input)
-                        interpreter.replProcessChar(c);
+                    for (const c of input) interpreter.replProcessChar(c);
                     repl();
-                }());
+                })();
             },
         });
-    }
-    else {
+    } else {
         interpreter.setStdout(generic);
         interpreter.setStderr(generic);
         interpreter.setStdin({
-            isatty: true,
+            isatty: false,
             stdin: () => pyterminal_read(data),
         });
     }
@@ -181,7 +179,7 @@ const pyTerminal = async (element) => {
             };
 
             if (type === "mpy") {
-                interpreter.setStdin = Object;  // as no-op
+                interpreter.setStdin = Object; // as no-op
                 interpreter.setStderr = Object; // as no-op
                 interpreter.setStdout = ({ write }) => {
                     io.stdout = write;
@@ -191,7 +189,7 @@ const pyTerminal = async (element) => {
             let data = "";
             const decoder = new TextDecoder();
             const generic = {
-                isatty: true,
+                isatty: false,
                 write(buffer) {
                     data = decoder.decode(buffer);
                     readline.write(data);
@@ -201,7 +199,7 @@ const pyTerminal = async (element) => {
             interpreter.setStdout(generic);
             interpreter.setStderr(generic);
             interpreter.setStdin({
-                isatty: true,
+                isatty: false,
                 stdin: () => readline.read(data),
             });
         });

--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -9,28 +9,9 @@
         <style>.xterm { padding: .5rem; }</style>
     </head>
     <body>
-        <script type="py">
-            def greetings(event):
-                print('hello world')
-        </script>
         <script type="mpy" worker terminal>
-            # works on both worker and main scripts
-            print("__terminal__", __terminal__)
-
-            import sys
-            from pyscript import display, document
-            display("Hello", "PyScript Next - PyTerminal", append=False)
-            print("this should go to the terminal")
-            print("another line")
-
-            # this works as expected
-            print("this goes to stderr", file=sys.stderr)
-            document.addEventListener('click', lambda event: print(event.type))
-
-            # this works on MicroPython too
             import code
             code.interact()
         </script>
-        <button id="my-button" py-click="greetings">Click me</button>
     </body>
 </html>


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/2002 by **not** using *tty* as it looks like XTerm is not fully compatible with that.

This MR also fixes the previous (ugly) attempt to ignore `linebuffer` in MicroPython.

It is now based on [latest polyscript](https://github.com/pyscript/polyscript/pull/91) which switched from `linebuffer` `true` (default) to `linebuffer` `false` and it's now working as expected without weird duplicated output or impossible to define multiline code.

## Changes

  * force Pyodide to use `isatty: false` due issues with XTerm when full *tty* is expected
  * update *polyscript* to its latest
  * refactor the whole code around MicroPython within the terminal
  * smoke test everything is fine with multi-line definitions, errors, both interactive and not

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
