### PR TITLE
Forgot to update current npm version

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",


### PR DESCRIPTION
## Description

In this MR https://github.com/pyscript/pyscript/pull/2014 I've updated and published to *npm* latest PyScript which is 0.4.14 ... I forgot to push that change 🤦‍♂️

## Changes

  * actually update the current published version of PyScript

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
