### PR TITLE
Provide input("") and sync output to MicroPython

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -76,7 +76,7 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
 
                 // monkey patch global input otherwise broken in MicroPython
                 interpreter.registerJsModule("_pyscript_input", {
-                    input: pyterminal_read
+                    input: pyterminal_read,
                 });
                 run("from _pyscript_input import input");
 

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -58,22 +58,35 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
         // to bootstrap a REPL like environment
         interpreter.registerJsModule("code", {
             interact() {
-                const encoder = new TextEncoder();
-                const acc = [];
                 let input = "";
                 let length = 1;
-                io.stdout = ([c]) => {
+
+                const encoder = new TextEncoder();
+                const acc = [];
+
+                io.stdout = (buffer) => {
                     // avoid duplicating the output produced by the input
-                    if (length++ > input.length) acc.push(c);
+                    if (length++ > input.length) {
+                        acc.push(...buffer);
+                        pyterminal_write(decoder.decode(buffer));
+                    }
                 };
+
                 interpreter.replInit();
+
+                // monkey patch global input otherwise broken in MicroPython
+                interpreter.registerJsModule("_pyscript_input", {
+                    input: pyterminal_read
+                });
+                run("from _pyscript_input import input");
+
+                // loop forever waiting for user inputs
                 (function repl() {
                     const out = decoder.decode(new Uint8Array(acc.splice(0)));
-                    pyterminal_write(out);
                     // print in current line only the last line produced by the REPL
-                    data = out.split("\n").at(-1);
-                    input = encoder.encode(`${pyterminal_read(data)}\r`);
+                    const data = `${pyterminal_read(out.split("\n").at(-1))}\r`;
                     length = 0;
+                    input = encoder.encode(data);
                     for (const c of input) interpreter.replProcessChar(c);
                     repl();
                 })();

--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -10,6 +10,11 @@
     </head>
     <body>
         <script type="mpy" worker terminal>
+            def sleepy():
+                import time
+                for i in range(20):
+                    print(i)
+                    time.sleep(1)
             import code
             code.interact()
         </script>

--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -10,11 +10,6 @@
     </head>
     <body>
         <script type="mpy" worker terminal>
-            def sleepy():
-                import time
-                for i in range(20):
-                    print(i)
-                    time.sleep(1)
             import code
             code.interact()
         </script>


### PR DESCRIPTION
## Description

This MR solves even more gotchas with MicroPython editor by providing an `input("...")` builtin utility that just works and by passing the output directly to the terminal whenever processed (the `time.sleep(1)` use case).

## Changes

  * move the `pyterminal_write` utility where it belongs
  * create a builtin `input` function that simply returns whatever `pyterminal_read` returns
  * test all cases are covered

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
