### PR TITLE
Allow MicroPython input("...") to work beside the code.interact()

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -53,6 +53,12 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
     // This part patches it in a way that simulates
     // the code.interact() module in Pyodide.
     if (type === "mpy") {
+        // monkey patch global input otherwise broken in MicroPython
+        interpreter.registerJsModule("_pyscript_input", {
+            input: pyterminal_read,
+        });
+        run("from _pyscript_input import input");
+
         io.stdout = generic.write;
         // tiny shim of the code module with only interact
         // to bootstrap a REPL like environment
@@ -73,12 +79,6 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
                 };
 
                 interpreter.replInit();
-
-                // monkey patch global input otherwise broken in MicroPython
-                interpreter.registerJsModule("_pyscript_input", {
-                    input: pyterminal_read,
-                });
-                run("from _pyscript_input import input");
 
                 // loop forever waiting for user inputs
                 (function repl() {


### PR DESCRIPTION
## Description

This MR simply adds the global builtin `input(...)` utility even when `import code; code.interact()` is not used within the code, effectively behaving just like Pyodide when it comes to `input(...)` usage.

## Changes

  * move the `input` builtin monkey patch regardless of the *REPL* use case
  * test everything is fine

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
