### PR TITLE
Fix MicroPython badly handling unicode chars

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.16",
+    "version": "0.4.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.16",
+            "version": "0.4.18",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.12.2",
+                "polyscript": "^0.12.3",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -2435,9 +2435,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.2.tgz",
-            "integrity": "sha512-qHZbcSVhp4bDW9YjcPyYw2AWDRrBEDUVxKMuvjACjQK7O891H6x7dNKVYNjij75Ygn9akma+X1n6eTW4syBFmQ==",
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.3.tgz",
+            "integrity": "sha512-aekNrFZzdLe0KQuSMWKFsUwkv414hIIjDgqzCbEXl4l5xZA8vgiv+jFFOZnkJk9/HeybLRPJBRdlhBxfdKVV0Q==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.16",
+    "version": "0.4.18",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -42,7 +42,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.12.2",
+        "polyscript": "^0.12.3",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -15,8 +15,8 @@ const hooks = {
         codeBeforeRun: () => stdlib,
         // works on both Pyodide and MicroPython
         onReady: ({ runAsync, io }, { sync }) => {
-            io.stdout = (line) => sync.write(line);
-            io.stderr = (line) => sync.writeErr(line);
+            io.stdout = io.buffered(sync.write);
+            io.stderr = io.buffered(sync.writeErr);
             sync.revoke();
             sync.runAsync = runAsync;
         },

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -59,7 +59,37 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
         });
         run("from _pyscript_input import input");
 
-        io.stdout = generic.write;
+        // this is needed to avoid truncated unicode in MicroPython
+        // the reason is that `linebuffer` false just send one byte
+        // per time and readline here doesn't like it much.
+        // MicroPython also has issues with code-points and
+        // replProcessChar(byte) but that function accepts only
+        // one byte per time so ... we have an issue!
+        const bufferPoints = callback => {
+            const acc = [];
+            let points = 0;
+            return buffer => {
+                for (const c of buffer) {
+                    acc.push(c);
+                    if (points)
+                        points--;
+                    else {
+                        // @see https://encoding.spec.whatwg.org/#utf-8-bytes-needed
+                        if (0xC2 <= c && c <= 0xDF)
+                            points = 1;
+                        else if (0xE0 <= c && c <= 0xEF)
+                            points = 2;
+                        else if (0xF0 <= c && c <= 0xF4)
+                            points = 3;
+                        else
+                            callback(new Uint8Array(acc.splice(0)));
+                    }
+                }
+            };
+        };
+
+        io.stdout = bufferPoints(generic.write);
+
         // tiny shim of the code module with only interact
         // to bootstrap a REPL like environment
         interpreter.registerJsModule("code", {
@@ -69,13 +99,14 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
 
                 const encoder = new TextEncoder();
                 const acc = [];
+                const handlePoints = bufferPoints(buffer => {
+                    acc.push(...buffer);
+                    pyterminal_write(decoder.decode(buffer));
+                });
 
                 io.stdout = (buffer) => {
                     // avoid duplicating the output produced by the input
-                    if (length++ > input.length) {
-                        acc.push(...buffer);
-                        pyterminal_write(decoder.decode(buffer));
-                    }
+                    if (length++ > input.length) handlePoints(buffer);
                 };
 
                 interpreter.replInit();

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -70,7 +70,7 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
         const bufferPoints = (stdio) => {
             const bytes = [];
             let needed = 0;
-            return buffer => {
+            return (buffer) => {
                 let written = 0;
                 for (const byte of buffer) {
                     bytes.push(byte);
@@ -105,9 +105,8 @@ const workerReady = ({ interpreter, io, run, type }, { sync }) => {
                 });
 
                 // avoid duplicating the output produced by the input
-                io.stdout = (buffer) => (
-                    length++ > input.length ? handlePoints(buffer) : 0
-                );
+                io.stdout = (buffer) =>
+                    length++ > input.length ? handlePoints(buffer) : 0;
 
                 interpreter.replInit();
 

--- a/pyscript.core/test/py-terminal.html
+++ b/pyscript.core/test/py-terminal.html
@@ -10,6 +10,7 @@
     </head>
     <body>
         <script type="mpy" worker terminal>
+            print("µpython")
             import code
             code.interact()
         </script>


### PR DESCRIPTION
## Description

**Ready to land**: this MR is the best we can do to offer unicode sequences in MicroPython.

The [underlying issue](https://github.com/micropython/micropython/issues/14255) is likely bigger than just `replProcessChar` exposed API and it should be tackled upstream but meanwhile we can at least explain that typing emoji or non ASCII chars might fail but that having these already in the output or the external file *or* asking for any input works.

Accordingly, if anyone would like to review it I think this should land sooner than later.

P.S. this has been already published as latest *npm* package.

- - -

This MR tries to tackle the fact that MiroPython doesn't really like unicode chars.

The irony lands in a simple `print("µpython")` neither the Linux REPL nor the PyScript one are able to handle in any meaningful way:

  * on the Linux REPL native shell it just ignores that `µ`
  * on the Web (WASM) PyScript port it forwards unicode sequences **only** if I handle these manually
  * a simple `test = input("unicode? ")` can accept `µpython` because that's just returned as `'\xb5python'` string from *Readline* and one can use and `print(test)` after without any issue ... however ...
  * if the entry is manually typed as in `test = "µpython"` something weird happens because `replProcessChar(byte)` passes along the whole string but that char gets ignored/discarded and the `test` reference will contain only `"python"` without the `µ`

I am pinging @dpgeorge here because I don't really think this MR should ever land or better, if it has to, I need `replProcessChar` to not mess up with code points because otherwise the `input` length in bytes mismatches the actual output produced by `replProcessChar` via **stdout** and this is looking pretty ugly to me or surely hard to explain.

/cc @ntoll too as this might be the last thing to solve before having a terminal parity with *Pyodide* which suffers none of these issues.

- - -

**Update** if I enter explicitly in paste mode (modified version of the terminal) and I type `test = "µpython"` and then I get out of paste mode, the `test` reference rightly points at the right thing ... now I wonder why the paste mode is not the default or why that would work while normal REPL mode wouldn't without the past mode ... I could maybe circumvent this but it would feel super awkward to \5 and \4 the terminal around users' inputs to simply be able to let them ... well, input whatever they want ... I couldn't find the culprit in MicroPython repository but I suggest to make the REPL "*past mode*" by defaut as that works!

**Update**

I have created a module that might help dealing with these cases in the future and it code covered everything so that I have spot an issue with current code but I'll fix that tomorrow: https://github.com/WebReflection/buffer-points

- - -

## Changes

  * fixed an issue with the **py-editor** related to the new `linebuffer` directive
  * provide in worker hook scope a simple callback that pre-buffers unicode sequences [accordingly to the standard](https://encoding.spec.whatwg.org/#utf-8-bytes-needed) so that the buffer is sent to the terminal only once those sequences are fulfilled
  * test with both `µ` and way more convoluted sequences such as 👩‍❤️‍👨 that the output, if either requested as input or already evaluated from the page works ... in latter case `test = "👩‍❤️‍👨"` completely messes up the program and the resulting string is empty

## Checklist

  * create a function that accumulate chars and eventually write whole sequences in the terminal as opposite of "vomiting" one char after the other which results in unreadable output
  * test simple to convoluted unicode cases work

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
