### PR TITLE
PyTerminal .process(code) utility

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.18",
+    "version": "0.4.20",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.18",
+            "version": "0.4.20",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.18",
+    "version": "0.4.20",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -1,7 +1,7 @@
 // PyScript py-terminal plugin
 import { TYPES, hooks } from "../core.js";
 import { notify } from "./error.js";
-import { customObserver, defineProperty } from "polyscript/exports";
+import { customObserver, defineProperties } from "polyscript/exports";
 
 // will contain all valid selectors
 const SELECTORS = [];
@@ -170,7 +170,22 @@ const pyTerminal = async (element) => {
         terminal.open(target);
         fitAddon.fit();
         terminal.focus();
-        defineProperty(element, "terminal", { value: terminal });
+        defineProperties(element, {
+            terminal: { value: terminal },
+            process: {
+                value: async (code) => {
+                    // this loop is the only way I could find to actually simulate
+                    // the user input char after char in a way that works in both
+                    // MicroPython and Pyodide
+                    for (const line of code.split(/(?:\r|\n|\r\n)/)) {
+                        terminal.paste(`${line}\n`);
+                        do { await new Promise(resolve => setTimeout(resolve, 0)); }
+                        while (!readline.instance.activeRead?.resolve);
+                        readline.instance.activeRead.resolve(line);
+                    }
+                },
+            }
+        });
         return terminal;
     };
 

--- a/pyscript.core/src/plugins/py-terminal.js
+++ b/pyscript.core/src/plugins/py-terminal.js
@@ -179,12 +179,15 @@ const pyTerminal = async (element) => {
                     // MicroPython and Pyodide
                     for (const line of code.split(/(?:\r|\n|\r\n)/)) {
                         terminal.paste(`${line}\n`);
-                        do { await new Promise(resolve => setTimeout(resolve, 0)); }
-                        while (!readline.instance.activeRead?.resolve);
-                        readline.instance.activeRead.resolve(line);
+                        do {
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, 0),
+                            );
+                        } while (!readline.activeRead?.resolve);
+                        readline.activeRead.resolve(line);
                     }
                 },
-            }
+            },
         });
         return terminal;
     };


### PR DESCRIPTION
## Description

This MR allows PyTerminal users to actually process imperatively some code which is something overly cumbersome otherwise within both interpreters, as these are orchestrated in a worker and not so easy to reach as both are constantly blocked due readline holding them on main.

## Changes

  * expose an utility to `process(code)` where each line is simulated as pasted on the terminal
  * verify everything works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
