### PR TITLE
Avoid PyWeb as part of stdlib on MicroPython

### DIFF
--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -26,8 +26,8 @@ import { ErrorCode } from "./exceptions.js";
 import { robustFetch as fetch, getText } from "./fetch.js";
 import { hooks, main, worker, codeFor, createFunction } from "./hooks.js";
 
-import stdlib from "./stdlib.js";
-export { stdlib };
+import { stdlib, optional } from "./stdlib.js";
+export { stdlib, optional };
 
 // generic helper to disambiguate between custom element and script
 const isScript = ({ tagName }) => tagName === "SCRIPT";
@@ -168,7 +168,7 @@ for (const [TYPE, interpreter] of TYPES) {
             // specific main and worker hooks
             const hooks = {
                 main: {
-                    ...codeFor(main),
+                    ...codeFor(main, TYPE),
                     async onReady(wrap, element) {
                         registerModule(wrap);
 
@@ -265,7 +265,7 @@ for (const [TYPE, interpreter] of TYPES) {
                     },
                 },
                 worker: {
-                    ...codeFor(worker),
+                    ...codeFor(worker, TYPE),
                     // these are lazy getters that returns a composition
                     // of the current hooks or undefined, if no hook is present
                     get onReady() {

--- a/pyscript.core/src/hooks.js
+++ b/pyscript.core/src/hooks.js
@@ -2,7 +2,7 @@ import { typedSet } from "type-checked-collections";
 import { dedent } from "polyscript/exports";
 import toJSONCallback from "to-json-callback";
 
-import stdlib from "./stdlib.js";
+import { stdlib, optional } from "./stdlib.js";
 
 export const main = (name) => hooks.main[name];
 export const worker = (name) => hooks.worker[name];
@@ -15,10 +15,11 @@ const code = (hooks, branch, key, lib) => {
     };
 };
 
-export const codeFor = (branch) => {
+export const codeFor = (branch, type) => {
+    const pylib = type === 'mpy' ? stdlib.replace(optional, '') : stdlib;
     const hooks = {};
-    code(hooks, branch, `codeBeforeRun`, stdlib);
-    code(hooks, branch, `codeBeforeRunAsync`, stdlib);
+    code(hooks, branch, `codeBeforeRun`, pylib);
+    code(hooks, branch, `codeBeforeRunAsync`, pylib);
     code(hooks, branch, `codeAfterRun`);
     code(hooks, branch, `codeAfterRunAsync`);
     return hooks;

--- a/pyscript.core/src/hooks.js
+++ b/pyscript.core/src/hooks.js
@@ -16,7 +16,7 @@ const code = (hooks, branch, key, lib) => {
 };
 
 export const codeFor = (branch, type) => {
-    const pylib = type === 'mpy' ? stdlib.replace(optional, '') : stdlib;
+    const pylib = type === "mpy" ? stdlib.replace(optional, "") : stdlib;
     const hooks = {};
     code(hooks, branch, `codeBeforeRun`, pylib);
     code(hooks, branch, `codeBeforeRunAsync`, pylib);

--- a/pyscript.core/src/stdlib.js
+++ b/pyscript.core/src/stdlib.js
@@ -37,7 +37,7 @@ const python = [
     "_path = None",
 ];
 
-const ignore = new Ignore(python, './pyweb');
+const ignore = new Ignore(python, "./pyweb");
 
 const write = (base, literal) => {
     for (const [key, value] of entries(literal)) {

--- a/pyscript.core/types/core.d.ts
+++ b/pyscript.core/types/core.d.ts
@@ -1,4 +1,5 @@
-import stdlib from "./stdlib.js";
+import { stdlib } from "./stdlib.js";
+import { optional } from "./stdlib.js";
 import TYPES from "./types.js";
 /**
  * A `Worker` facade able to bootstrap on the worker thread only a PyScript module.
@@ -51,4 +52,4 @@ declare const exportedHooks: {
 };
 declare const exportedConfig: {};
 declare const exportedWhenDefined: (type: string) => Promise<any>;
-export { stdlib, TYPES, exportedPyWorker as PyWorker, exportedMPWorker as MPWorker, exportedHooks as hooks, exportedConfig as config, exportedWhenDefined as whenDefined };
+export { stdlib, optional, TYPES, exportedPyWorker as PyWorker, exportedMPWorker as MPWorker, exportedHooks as hooks, exportedConfig as config, exportedWhenDefined as whenDefined };

--- a/pyscript.core/types/hooks.d.ts
+++ b/pyscript.core/types/hooks.d.ts
@@ -1,6 +1,6 @@
 export function main(name: any): any;
 export function worker(name: any): any;
-export function codeFor(branch: any): {};
+export function codeFor(branch: any, type: any): {};
 export function createFunction(self: any, name: any): any;
 export namespace hooks {
     namespace main {

--- a/pyscript.core/types/stdlib.d.ts
+++ b/pyscript.core/types/stdlib.d.ts
@@ -1,2 +1,2 @@
-declare const _default: string;
-export default _default;
+export const stdlib: string;
+export const optional: string;


### PR DESCRIPTION
## Description

This MR goal is to unlock https://github.com/pyscript/pyscript/pull/1960 issues with MicroPython currently being unable to deal with too much code to `run` at once: see https://github.com/micropython/micropython/issues/14307

## Changes

  * created an ad-hoc solution that is the least obtrusive around our stack, so that we can fine-tune what's undesired on specific target side (in this case the `mpy` custom type)
  * test results are satisfying all over the place

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
