### PR TITLE
Fix #2040 - Polyscript update to provide config dictionary

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.22",
+    "version": "0.4.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.22",
+            "version": "0.4.24",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,14 +11,14 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.12.6",
+                "polyscript": "^0.12.7",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
                 "@codemirror/commands": "^6.5.0",
-                "@codemirror/lang-python": "^6.1.5",
+                "@codemirror/lang-python": "^6.1.6",
                 "@codemirror/language": "^6.10.1",
                 "@codemirror/state": "^6.4.1",
                 "@codemirror/view": "^6.26.3",
@@ -32,7 +32,7 @@
                 "chokidar": "^3.6.0",
                 "codemirror": "^6.0.1",
                 "eslint": "^9.1.1",
-                "rollup": "^4.16.4",
+                "rollup": "^4.17.2",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.4.3",
@@ -81,9 +81,9 @@
             }
         },
         "node_modules/@codemirror/lang-python": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.5.tgz",
-            "integrity": "sha512-hCm+8X6wrnXJCGf+QhmFu1AXkdTVG7dHy0Ly6SI1N3SRPptaMvwX6oNQonOXOMPvmcjiB0xq342KAxX3BYpijw==",
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.6.tgz",
+            "integrity": "sha512-ai+01WfZhWqM92UqjnvorkxosZ2aq2u28kHvr+N3gu012XqY2CThD67JPMHnGceRfXPDBmn1HnyqowdpF57bNg==",
             "dev": true,
             "dependencies": {
                 "@codemirror/autocomplete": "^6.3.2",
@@ -486,9 +486,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.16.4.tgz",
-            "integrity": "sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.2.tgz",
+            "integrity": "sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==",
             "cpu": [
                 "arm"
             ],
@@ -499,9 +499,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz",
-            "integrity": "sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.17.2.tgz",
+            "integrity": "sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==",
             "cpu": [
                 "arm64"
             ],
@@ -512,9 +512,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.16.4.tgz",
-            "integrity": "sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.17.2.tgz",
+            "integrity": "sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==",
             "cpu": [
                 "arm64"
             ],
@@ -525,9 +525,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz",
-            "integrity": "sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.17.2.tgz",
+            "integrity": "sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==",
             "cpu": [
                 "x64"
             ],
@@ -538,9 +538,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.16.4.tgz",
-            "integrity": "sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.17.2.tgz",
+            "integrity": "sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==",
             "cpu": [
                 "arm"
             ],
@@ -551,9 +551,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.16.4.tgz",
-            "integrity": "sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.17.2.tgz",
+            "integrity": "sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==",
             "cpu": [
                 "arm"
             ],
@@ -564,9 +564,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.16.4.tgz",
-            "integrity": "sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.17.2.tgz",
+            "integrity": "sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==",
             "cpu": [
                 "arm64"
             ],
@@ -577,9 +577,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.16.4.tgz",
-            "integrity": "sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.17.2.tgz",
+            "integrity": "sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==",
             "cpu": [
                 "arm64"
             ],
@@ -590,9 +590,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.16.4.tgz",
-            "integrity": "sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.17.2.tgz",
+            "integrity": "sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -603,9 +603,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.16.4.tgz",
-            "integrity": "sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.17.2.tgz",
+            "integrity": "sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==",
             "cpu": [
                 "riscv64"
             ],
@@ -616,9 +616,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.16.4.tgz",
-            "integrity": "sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.17.2.tgz",
+            "integrity": "sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==",
             "cpu": [
                 "s390x"
             ],
@@ -629,9 +629,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.16.4.tgz",
-            "integrity": "sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.17.2.tgz",
+            "integrity": "sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==",
             "cpu": [
                 "x64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.16.4.tgz",
-            "integrity": "sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.17.2.tgz",
+            "integrity": "sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==",
             "cpu": [
                 "x64"
             ],
@@ -655,9 +655,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.16.4.tgz",
-            "integrity": "sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.17.2.tgz",
+            "integrity": "sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==",
             "cpu": [
                 "arm64"
             ],
@@ -668,9 +668,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.16.4.tgz",
-            "integrity": "sha512-9m/ZDrQsdo/c06uOlP3W9G2ENRVzgzbSXmXHT4hwVaDQhYcRpi9bgBT0FTG9OhESxwK0WjQxYOSfv40cU+T69w==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.17.2.tgz",
+            "integrity": "sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==",
             "cpu": [
                 "ia32"
             ],
@@ -681,9 +681,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.16.4.tgz",
-            "integrity": "sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.2.tgz",
+            "integrity": "sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==",
             "cpu": [
                 "x64"
             ],
@@ -2465,9 +2465,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.12.6",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.6.tgz",
-            "integrity": "sha512-tvVuPp+ygyDSqtLiNbbGZRUHvBz594xAao0bq0fg6JYcnidmuhZhgFiwwMC3tw/eJKKlBPKKc60UnYr6lvNH4A==",
+            "version": "0.12.7",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.7.tgz",
+            "integrity": "sha512-Aaw/UCFNEuBkEcT00wok8ks+llVINunx98x4FdXZueUlFsr5+B41OVV3DptsJ3+7tzjqmJwhxe7cBTpMolLG/Q==",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",
                 "@ungap/with-resolvers": "^0.1.0",
@@ -3152,9 +3152,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.16.4.tgz",
-            "integrity": "sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
+            "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -3167,22 +3167,22 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.16.4",
-                "@rollup/rollup-android-arm64": "4.16.4",
-                "@rollup/rollup-darwin-arm64": "4.16.4",
-                "@rollup/rollup-darwin-x64": "4.16.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.16.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.16.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.16.4",
-                "@rollup/rollup-linux-arm64-musl": "4.16.4",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.16.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.16.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.16.4",
-                "@rollup/rollup-linux-x64-gnu": "4.16.4",
-                "@rollup/rollup-linux-x64-musl": "4.16.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.16.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.16.4",
-                "@rollup/rollup-win32-x64-msvc": "4.16.4",
+                "@rollup/rollup-android-arm-eabi": "4.17.2",
+                "@rollup/rollup-android-arm64": "4.17.2",
+                "@rollup/rollup-darwin-arm64": "4.17.2",
+                "@rollup/rollup-darwin-x64": "4.17.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.17.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.17.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.17.2",
+                "@rollup/rollup-linux-arm64-musl": "4.17.2",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.17.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.17.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.17.2",
+                "@rollup/rollup-linux-x64-gnu": "4.17.2",
+                "@rollup/rollup-linux-x64-musl": "4.17.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.17.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.17.2",
+                "@rollup/rollup-win32-x64-msvc": "4.17.2",
                 "fsevents": "~2.3.2"
             }
         },

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.22",
+    "version": "0.4.24",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -42,14 +42,14 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.12.6",
+        "polyscript": "^0.12.7",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {
         "@codemirror/commands": "^6.5.0",
-        "@codemirror/lang-python": "^6.1.5",
+        "@codemirror/lang-python": "^6.1.6",
         "@codemirror/language": "^6.10.1",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.26.3",
@@ -63,7 +63,7 @@
         "chokidar": "^3.6.0",
         "codemirror": "^6.0.1",
         "eslint": "^9.1.1",
-        "rollup": "^4.16.4",
+        "rollup": "^4.17.2",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.4.3",

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -34,6 +34,7 @@ from pyscript.fetch import fetch
 from pyscript.magic_js import (
     RUNNING_IN_WORKER,
     PyWorker,
+    config,
     current_target,
     document,
     js_modules,

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,11 +1,13 @@
 import sys
+import json
 
 import js as globalThis
-from polyscript import js_modules
+from polyscript import js_modules, config as _config
 from pyscript.util import NotSupported
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")
 
+config = json.loads(globalThis.JSON.stringify(_config))
 
 # allow `from pyscript.js_modules.xxx import yyy`
 class JSModule:

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -1,13 +1,15 @@
-import sys
 import json
+import sys
 
 import js as globalThis
-from polyscript import js_modules, config as _config
+from polyscript import config as _config
+from polyscript import js_modules
 from pyscript.util import NotSupported
 
 RUNNING_IN_WORKER = not hasattr(globalThis, "document")
 
 config = json.loads(globalThis.JSON.stringify(_config))
+
 
 # allow `from pyscript.js_modules.xxx import yyy`
 class JSModule:

--- a/pyscript.core/test/config-url.html
+++ b/pyscript.core/test/config-url.html
@@ -8,9 +8,17 @@
   <script type="module" src="../dist/core.js"></script>
   <mpy-config src="config-url/config.json"></mpy-config>
   <script type="mpy">
+    from pyscript import config
+    if config["files"]["{TO}"] != "./runtime":
+        raise Exception("wrong config tree")
+
     from runtime import test
   </script>
   <script type="mpy" worker>
+    from pyscript import config
+    if config["files"]["{TO}"] != "./runtime":
+        raise Exception("wrong config tree")
+
     from runtime import test
   </script>
 </head>


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/discussions/2040 by providing a `config` entry in the *pyscript* module.

/cc @ntoll 

## Changes

  * updated *polyscript* to its latest which augments custom scripts on both *main* and *worker* with an extra `config` object literal
  * change the *pyscript* `stdlib` to provide a *Pythonic* version of such config instead
  * test via integration both *main* and *worker* scripts get the config and can introspect it

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [x] I have created documentation for this(if applicable) - **documentation** actually on *polyscript* side
