### PR TITLE
Fixed py-editor offline use case

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.25",
+    "version": "0.4.26",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.25",
+            "version": "0.4.26",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.25",
+    "version": "0.4.26",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -42,6 +42,8 @@ async function execute({ currentTarget }) {
                 ? await import(/* webpackIgnore: true */ "../3rd-party/toml.js")
                 : JSON;
             details.config = parse(await fetch(config).then((r) => r.text()));
+            const { interpreter } = details.config;
+            if (interpreter) details.version = interpreter;
         }
 
         const xworker = XWorker.call(new Hook(null, hooks), srcLink, details);


### PR DESCRIPTION
## Description

This MR addresses the [concern exposed in Discord](https://discord.com/channels/972017612454232116/972020206538997822/1235662529447858288) where indeed the `interpreter` *config* property gets fully ignored when present.

## Changes

  * pass along the `version` to bootstrap the right interpreter when defined as such in the `config` file

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
