### PR TITLE
Added listeners to the constructing kw options

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.26",
+    "version": "0.4.27",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.26",
+            "version": "0.4.27",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.26",
+    "version": "0.4.27",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/pyscript.core/src/stdlib/pyscript/websocket.py
+++ b/pyscript.core/src/stdlib/pyscript/websocket.py
@@ -30,21 +30,24 @@ class WebSocket(object):
 
     def __init__(self, **kw):
         url = kw["url"]
-        socket = None
         if protocols in kw:
             socket = js.WebSocket.new(url, kw[protocols])
         else:
             socket = js.WebSocket.new(url)
         object.__setattr__(self, "_ws", socket)
 
+        for t in ["onclose", "onerror", "onmessage", "onopen"]:
+            if t in kw:
+                socket[t] = kw[t]
+
     def __getattr__(self, attr):
         return getattr(self._ws, attr)
 
     def __setattr__(self, attr, value):
         if attr == "onmessage":
-            setattr(self._ws, attr, lambda e: value(EventMessage(e)))
+            self._ws[attr] = lambda e: value(EventMessage(e))
         else:
-            setattr(self._ws, attr, value)
+            self._ws[attr] = value
 
     def close(self, **kw):
         if code in kw and reason in kw:

--- a/pyscript.core/test/ws/index.html
+++ b/pyscript.core/test/ws/index.html
@@ -22,10 +22,12 @@
         print(event.type)
         document.documentElement.classList.add("ok")
 
-    ws = WebSocket(url="ws://localhost:5037/")
-    ws.onopen = onopen
-    ws.onmessage = onmessage
-    ws.onclose = onclose
+    ws = WebSocket(
+      url="ws://localhost:5037/",
+      onopen=onopen,
+      onmessage=onmessage,
+      onclose=onclose
+    )
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

This MR adds a feature to pass `onopen`, `onmessage`, `onerror` and `onclose` listeners directly to the web socket once it gets initialized.

## Changes

  * optionally accepts `onopen`, `onmessage`, `onerror` and `onclose` as *kw* arguments and directly set this while initializing the web socket
  * test everything is fine

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
