### PR TITLE
Provide index_urls via config to override the default.

### DIFF
--- a/pyscript.core/tests/integration/test_01_basic.py
+++ b/pyscript.core/tests/integration/test_01_basic.py
@@ -221,6 +221,27 @@ class TestBasic(PyScriptTest):
             "hello asciitree",  # printed by us
         ]
 
+    def test_packages_custom_pypi(self):
+        self.pyscript_run(
+            """
+            <py-config>
+                packages = ["test-foo"]
+                index_urls = ["https://test.pypi.org/simple"]
+            </py-config>
+            <script type="py">
+                import js
+                import test_foo
+                js.console.log('hello', test_foo.__name__)
+            </script>
+            """
+        )
+
+        assert self.console.log.lines[-3:] == [
+            "Loading test_foo",  # printed by pyodide
+            "Loaded test_foo",  # printed by pyodide
+            "hello test_foo",  # printed by us
+        ]
+
     @pytest.mark.skip("NEXT: No banner")
     def test_non_existent_package(self):
         self.pyscript_run(

--- a/pyscript.sw/src/sw.js
+++ b/pyscript.sw/src/sw.js
@@ -89,9 +89,10 @@
                                 deps[0].then((b) => b.json()) :
                                 deps[0].then((b) => b.text()).then(parse);
 
-                            const [{ packages }] = await Promise.all(deps);
+                            const [{ packages, index_urls }] = await Promise.all(deps);
+
                             const micropip = await pyodide.pyimport("micropip");
-                            await micropip.install(packages);
+                            await micropip.install(packages, index_urls=index_urls);
                         }
                         handlerPath = handler;
                         const result = await getHandler();


### PR DESCRIPTION
## Description

Add a config option to optionally provide `index_urls` that can override the default python package index url. 

## Changes

A new config option called `index_urls` that can provide a list of URLs that can act as an alternate source of python packages. 

I haven't been able to get the tests passing locally. I'm unable to figure out a how to debug this locally. 

I would like some help with the PR. I spoke with @FabioRosado at PyCon about the feature and he offered to help. 