### PR TITLE
Add step in build process to publish a tarfile

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,6 +46,10 @@ jobs:
               working-directory: .
               run: sed 's#_PATH_#https://pyscript.net/releases/${{ github.ref_name }}/#' ./public/index.html > ./pyscript.core/dist/index.html
 
+            - name: Generate release.tar from snapshot and put it in dist/
+              working-directory: .
+              run: tar -cvf ../release.tar * && mv ../release.tar .
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:


### PR DESCRIPTION
## Description

In preparation for a feature to convert projects for offline in the `pyscript-cli`, adding a step to generate a tarball of the complied files available to for download.

## Changes

Added a single step in the build process for generating a tarball.

## Checklist

-   [ ] All tests pass locally # I'm unable to test it locally since it's the build process
-   [ ] I have updated `CHANGELOG.md` # Since it's just a step in the build process I haven't added anything to CHANGELOG.md
-   [ ] I have created documentation for this(if applicable)
