### PR TITLE
Fix #2067 - Enable .whl packages

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.38",
+    "version": "0.4.40",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.38",
+            "version": "0.4.40",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.12.12",
+                "polyscript": "^0.12.14",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -2801,9 +2801,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.12.12",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.12.tgz",
-            "integrity": "sha512-W+bJ3Z8CnbGA6j/ShyWYbtSGhb3nABnA4g/2qtEHkf3JHem5NvFVYcPZ3UeECBbaRBLoHYle+pybozWrPddF6A==",
+            "version": "0.12.14",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.12.14.tgz",
+            "integrity": "sha512-inflltAxoMmZZ1qGYIPPBe8KZFPtcatqUCbJjvTzR/gRHpa6PfcZQi2p4HobqDVZLc3LXdODi/GtRxZuRK8a3w==",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.38",
+    "version": "0.4.40",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -43,7 +43,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.12.12",
+        "polyscript": "^0.12.14",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/discussions/2067 by using the latest *polyscript* which allows MicroPython to handle `.whl` packages (or files).

## Changes

  * update *polyscript* to its latest

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
