### PR TITLE
Expose py-editor code content read/write

### DIFF
--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -184,6 +184,21 @@ const init = async (script, type, interpreter) => {
     let target;
     defineProperties(script, {
         target: { get: () => target },
+        code: {
+            get: () => context.pySrc,
+            set: (insert) => {
+                if (isSetup) return;
+                editor.update([
+                    editor.state.update({
+                        changes: {
+                            from: 0,
+                            to: editor.state.doc.length,
+                            insert,
+                        },
+                    }),
+                ]);
+            }
+        },
         process: {
             /**
              * Simulate a setup node overriding the source to evaluate.


### PR DESCRIPTION
## Description

This *MR* allows easy read/write of the related editor content through the `script` reference for such editor.

```js
editor = document.querySelector("script[type=py-editor]")

# read the code in it
print(editor.code)

# change the code in it
editor.code = "print(1 + 2)"
```

## Changes

  * expose a `code` accessor that reads and writes to the underlying codemirror editor
  * test everything works as expected

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
