### PR TITLE
Expose pyscript.py_import and js_import for lazy Python/JS modules

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.41",
+    "version": "0.4.42",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.4.41",
+            "version": "0.4.42",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
@@ -17,11 +17,11 @@
                 "type-checked-collections": "^0.1.7"
             },
             "devDependencies": {
-                "@codemirror/commands": "^6.5.0",
+                "@codemirror/commands": "^6.6.0",
                 "@codemirror/lang-python": "^6.1.6",
-                "@codemirror/language": "^6.10.1",
+                "@codemirror/language": "^6.10.2",
                 "@codemirror/state": "^6.4.1",
-                "@codemirror/view": "^6.26.3",
+                "@codemirror/view": "^6.27.0",
                 "@playwright/test": "^1.44.1",
                 "@rollup/plugin-commonjs": "^25.0.8",
                 "@rollup/plugin-node-resolve": "^15.2.3",
@@ -62,15 +62,15 @@
             }
         },
         "node_modules/@codemirror/commands": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.5.0.tgz",
-            "integrity": "sha512-rK+sj4fCAN/QfcY9BEzYMgp4wwL/q5aj/VfNSoH1RWPF9XS/dUwBkvlL3hpWgEjOqlpdN1uLC9UkjJ4tmyjJYg==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.6.0.tgz",
+            "integrity": "sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.4.0",
-                "@codemirror/view": "^6.0.0",
+                "@codemirror/view": "^6.27.0",
                 "@lezer/common": "^1.1.0"
             }
         },
@@ -89,9 +89,9 @@
             }
         },
         "node_modules/@codemirror/language": {
-            "version": "6.10.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.1.tgz",
-            "integrity": "sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
+            "integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -135,9 +135,9 @@
             "license": "MIT"
         },
         "node_modules/@codemirror/view": {
-            "version": "6.26.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.26.3.tgz",
-            "integrity": "sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==",
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.27.0.tgz",
+            "integrity": "sha512-8kqX1sHbVW1lVzWwrjAbh4dR7eKhV8eIQ952JKaBXOoXE04WncoqCy4DMU701LSrPZ3N2Q4zsTawz7GQ+2mrUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.4.41",
+    "version": "0.4.42",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -49,11 +49,11 @@
         "type-checked-collections": "^0.1.7"
     },
     "devDependencies": {
-        "@codemirror/commands": "^6.5.0",
+        "@codemirror/commands": "^6.6.0",
         "@codemirror/lang-python": "^6.1.6",
-        "@codemirror/language": "^6.10.1",
+        "@codemirror/language": "^6.10.2",
         "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.26.3",
+        "@codemirror/view": "^6.27.0",
         "@playwright/test": "^1.44.1",
         "@rollup/plugin-commonjs": "^25.0.8",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -157,6 +157,7 @@ for (const [TYPE, interpreter] of TYPES) {
         // enrich the Python env with some JS utility for main
         interpreter.registerJsModule("_pyscript", {
             PyWorker,
+            js_import: (...urls) => Promise.all(urls.map(url => import(url))),
             get target() {
                 return isScript(currentElement)
                     ? currentElement.target.id

--- a/pyscript.core/src/core.js
+++ b/pyscript.core/src/core.js
@@ -157,7 +157,7 @@ for (const [TYPE, interpreter] of TYPES) {
         // enrich the Python env with some JS utility for main
         interpreter.registerJsModule("_pyscript", {
             PyWorker,
-            js_import: (...urls) => Promise.all(urls.map(url => import(url))),
+            js_import: (...urls) => Promise.all(urls.map((url) => import(url))),
             get target() {
                 return isScript(currentElement)
                     ? currentElement.target.id

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -38,8 +38,8 @@ from pyscript.magic_js import (
     config,
     current_target,
     document,
-    js_modules,
     js_import,
+    js_modules,
     sync,
     window,
 )

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -29,6 +29,7 @@
 #     pyscript.magic_js. This is the blessed way to access them from pyscript,
 #     as it works transparently in both the main thread and worker cases.
 
+from polyscript import lazy_py_modules as py_import
 from pyscript.display import HTML, display
 from pyscript.fetch import fetch
 from pyscript.magic_js import (
@@ -38,12 +39,11 @@ from pyscript.magic_js import (
     current_target,
     document,
     js_modules,
+    js_import,
     sync,
     window,
 )
 from pyscript.websocket import WebSocket
-
-from polyscript import lazy_py_modules as py_modules
 
 try:
     from pyscript.event_handling import when

--- a/pyscript.core/src/stdlib/pyscript/__init__.py
+++ b/pyscript.core/src/stdlib/pyscript/__init__.py
@@ -43,6 +43,8 @@ from pyscript.magic_js import (
 )
 from pyscript.websocket import WebSocket
 
+from polyscript import lazy_py_modules as py_modules
+
 try:
     from pyscript.event_handling import when
 except:

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -42,6 +42,8 @@ if RUNNING_IN_WORKER:
         window = polyscript.xworker.window
         document = window.document
         js.document = document
+        # this is the same as js_import on main and it lands modules on main
+        js_import = window.Function("return (...urls) => Promise.all(urls.map((url) => import(url)))")()
     except:
         globalThis.console.debug("SharedArrayBuffer is not available")
         # in this scenario none of the utilities would work
@@ -64,7 +66,7 @@ if RUNNING_IN_WORKER:
 
 else:
     import _pyscript
-    from _pyscript import PyWorker
+    from _pyscript import PyWorker, js_import
 
     window = globalThis
     document = globalThis.document

--- a/pyscript.core/src/stdlib/pyscript/magic_js.py
+++ b/pyscript.core/src/stdlib/pyscript/magic_js.py
@@ -43,7 +43,9 @@ if RUNNING_IN_WORKER:
         document = window.document
         js.document = document
         # this is the same as js_import on main and it lands modules on main
-        js_import = window.Function("return (...urls) => Promise.all(urls.map((url) => import(url)))")()
+        js_import = window.Function(
+            "return (...urls) => Promise.all(urls.map((url) => import(url)))"
+        )()
     except:
         globalThis.console.debug("SharedArrayBuffer is not available")
         # in this scenario none of the utilities would work

--- a/pyscript.core/test/py_modules.html
+++ b/pyscript.core/test/py_modules.html
@@ -8,11 +8,20 @@
 </head>
 <body>
   <script type="py" async>
-    from pyscript import py_modules
+    from pyscript import py_import, js_import, window
 
-    matplotlib, regex, = await py_modules("matplotlib", "regex")
+    window.console.time("first")
+    matplotlib, regex, = await py_import("matplotlib", "regex")
+    window.console.timeEnd("first")
+
+    window.console.time("second")
+    matplotlib, regex, = await py_import("matplotlib", "regex")
+    window.console.timeEnd("second")
 
     print(matplotlib, regex)
+
+    escaper, = await js_import("https://esm.run/html-escaper")
+    window.console.log(escaper)
   </script>
 </body>
 </html>

--- a/pyscript.core/test/py_modules.html
+++ b/pyscript.core/test/py_modules.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../dist/core.css">
+  <script type="module" src="../dist/core.js"></script>
+</head>
+<body>
+  <script type="py" async>
+    from pyscript import py_modules
+
+    matplotlib, regex, = await py_modules("matplotlib", "regex")
+
+    print(matplotlib, regex)
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Description

This MR forwards from *polyscript* the `lazy_py_modules` utility as `pyscript.py_import` and it offers a 1:1 API for *JS* via `pyscript.js_import`.

## Changes

  * expose `polyscript.lazy_py_modules` as `pyscript.py_import`
  * expose on both main and workers `pyscript.js_import` to land runtime JS modules on the main thread (usable from workers too)
  * test everything works just fine (integration tests in *polyscript* already for the `py_import` story)

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
