### PR TITLE
fix: broken methods video.snap and canvas.download

### DIFF
--- a/pyscript.core/src/stdlib/pyscript/web/elements.py
+++ b/pyscript.core/src/stdlib/pyscript/web/elements.py
@@ -622,7 +622,7 @@ class canvas(ContainerElement):
 
         download_link._dom_element.click()
 
-    def draw(self, what, width, height):
+    def draw(self, what, width=None, height=None):
         """Draw `what` on the current element
 
         Inputs:
@@ -637,7 +637,12 @@ class canvas(ContainerElement):
             what = what._dom_element
 
         # https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-        self._dom_element.getContext("2d").drawImage(what, 0, 0, width, height)
+        ctx = self._dom_element.getContext("2d")
+        if width or height:
+            ctx.drawImage(what, 0, 0, width, height)
+
+        else:
+            ctx.drawImage(what, 0, 0)
 
 
 class caption(ContainerElement):


### PR DESCRIPTION
## Description

video.snap and canvas.download methods used an obsolete method (self.create). They don't anymore.

## Changes

Replace use of create with call to the appropriate Element instance e.g. self/create("canvas") -> canvas())

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
