### PR TITLE
Update Pyodide to its 0.26.2 version

### DIFF
--- a/pyscript.core/package-lock.json
+++ b/pyscript.core/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.14.3",
+                "polyscript": "^0.14.4",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -2935,9 +2935,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.14.3.tgz",
-            "integrity": "sha512-8+BAF9QNO6VQtq4srNQP4KoPI0fX0TqOfXReSFrIqg6zL7WgxQana3UKFqqqSPgxmhaFPdltPqwRLnBD6hIxAQ==",
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.14.4.tgz",
+            "integrity": "sha512-3bmc0Gh/etQOpGZ+P19JrYocSzyruYKA7Jim4Fzviv0WXGd97F9Y0B7aNyjpTeRKgGynvLwfJVADJOaQfODWXQ==",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",

--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@ungap/with-resolvers": "^0.1.0",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.14.3",
+        "polyscript": "^0.14.4",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"


### PR DESCRIPTION
## Description

This MR brings in the latest *polyscript* **AS IS** and it just updates Pyodide to its recent 0.26.2 release.

For reference: https://github.com/pyscript/polyscript/commit/6e981f5902f7f61906434044e0a3b07037295f97

## Changes

  * update polyscript that was updated to have latest pyodide

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
