### PR TITLE
Fix #2093 - Show setup errors with the editor

### DIFF
--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -1,6 +1,7 @@
 // PyScript py-editor plugin
 import { Hook, XWorker, dedent, defineProperties } from "polyscript/exports";
 import { TYPES, offline_interpreter, relative_url, stdlib } from "../core.js";
+import { notify } from "./error.js";
 
 const RUN_BUTTON = `<svg style="height:20px;width:20px;vertical-align:-.125em;transform-origin:center;overflow:visible;color:green" viewBox="0 0 384 512" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg"><g transform="translate(192 256)" transform-origin="96 0"><g transform="translate(0,0) scale(1,1)"><path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" fill="currentColor" transform="translate(-192 -256)"></path></g></g></svg>`;
 
@@ -91,6 +92,10 @@ async function execute({ currentTarget }) {
         sync.writeErr = (str) => {
             if (hasRunButton) {
                 outDiv.innerHTML += `<span style='color:red'>${str}</span>\n`;
+            }
+            else {
+                notify(str);
+                console.error(str);
             }
         };
         sync.runAsync(pySrc).then(enable, enable);

--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -88,12 +88,12 @@ async function execute({ currentTarget }) {
         const { sync } = xworker;
         sync.write = (str) => {
             if (hasRunButton) outDiv.innerText += `${str}\n`;
+            else console.log(str);
         };
         sync.writeErr = (str) => {
             if (hasRunButton) {
                 outDiv.innerHTML += `<span style='color:red'>${str}</span>\n`;
-            }
-            else {
+            } else {
                 notify(str);
                 console.error(str);
             }

--- a/pyscript.core/test/issue-2093/error.js
+++ b/pyscript.core/test/issue-2093/error.js
@@ -1,0 +1,6 @@
+const { error } = console;
+
+console.error = (...args) => {
+  error(...args);
+  document.documentElement.classList.add('errored');
+};

--- a/pyscript.core/test/issue-2093/index.html
+++ b/pyscript.core/test/issue-2093/index.html
@@ -9,6 +9,7 @@
     </head>
     <body>
       <script type="mpy-editor" setup>
+        print("Hello Editor")
         raise Exception("failure")
       </script>
     </body>

--- a/pyscript.core/test/issue-2093/index.html
+++ b/pyscript.core/test/issue-2093/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="../../dist/core.css">
+        <script type="module" src="./error.js"></script>
+        <script type="module" src="../../dist/core.js"></script>
+    </head>
+    <body>
+      <script type="mpy-editor" setup>
+        raise Exception("failure")
+      </script>
+    </body>
+</html>

--- a/pyscript.core/test/mpy.spec.js
+++ b/pyscript.core/test/mpy.spec.js
@@ -98,3 +98,8 @@ test('MicroPython + workers', async ({ page }) => {
   await page.goto('http://localhost:8080/test/workers/index.html');
   await page.waitForSelector('html.mpy.py');
 });
+
+test('MicroPython Editor setup error', async ({ page }) => {
+  await page.goto('http://localhost:8080/test/issue-2093/index.html');
+  await page.waitForSelector('html.errored');
+});


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/2093 .

Because a `setup` node doesn't have a related element to show eventually failures, issues in `setup` code were not spotted at all.

Now the `notify` is used but if the `error` plugin has been disabled, or its node made invisible, at least something is shown in the console.

## Changes

  * use the `notify(msg)` utility like we do in other places
  * test that failing setup nodes pass through such utility
  * since we are here ... a `setup` node now also logs if any `print` statement is used in there

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
