### PR TITLE
Avoid throwing if Pyodide does not await due missing arguments

### DIFF
--- a/pyscript.core/src/stdlib/pyscript/event_handling.py
+++ b/pyscript.core/src/stdlib/pyscript/event_handling.py
@@ -41,8 +41,13 @@ def when(event_type=None, selector=None):
             # Function doesn't receive events
             if not sig.parameters:
 
-                def wrapper(*args, **kwargs):
-                    func()
+                # Function is async: must be awaited
+                if inspect.iscoroutinefunction(func):
+                    async def wrapper(*args, **kwargs):
+                        await func()
+                else:
+                    def wrapper(*args, **kwargs):
+                        func()
 
             else:
                 wrapper = func

--- a/pyscript.core/src/stdlib/pyscript/event_handling.py
+++ b/pyscript.core/src/stdlib/pyscript/event_handling.py
@@ -43,9 +43,12 @@ def when(event_type=None, selector=None):
 
                 # Function is async: must be awaited
                 if inspect.iscoroutinefunction(func):
+
                     async def wrapper(*args, **kwargs):
                         await func()
+
                 else:
+
                     def wrapper(*args, **kwargs):
                         func()
 


### PR DESCRIPTION
## Description

In *Pyodide* (only) use case when a function has no args but it's `async`, the `wrapper` is not asynchronous and it doesn't *await* the passed callback. This results into hard to understand errors otherwise not present in MicroPython.

This MR fixes that by using the right *introspection* to decide how the *wrapper* should be defined (that is: either async or sync).

## Changes

  * define an `async` wrapper when the given function is *async* too
  * test all conditions (manually) that everything works:
    * test `async def click()` and `async def click(event)` after `@when`
    * test `def click()` and `def click(event)` after `@when`

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
