### PR TITLE
Follow up - Remove all innerHTML += for consistency sake

### DIFF
--- a/pyscript.core/src/plugins/py-editor.js
+++ b/pyscript.core/src/plugins/py-editor.js
@@ -91,9 +91,12 @@ async function execute({ currentTarget }) {
     return envs.get(env).then((xworker) => {
         xworker.onerror = ({ error }) => {
             if (hasRunButton) {
-                outDiv.innerHTML += `<span style='color:red'>${
-                    error.message || error
-                }</span>\n`;
+                outDiv.insertAdjacentHTML(
+                    "beforeend",
+                    `<span style='color:red'>${
+                        error.message || error
+                    }</span>\n`,
+                );
             }
             console.error(error);
         };
@@ -108,7 +111,10 @@ async function execute({ currentTarget }) {
         };
         sync.writeErr = (str) => {
             if (hasRunButton) {
-                outDiv.innerHTML += `<span style='color:red'>${str}</span>\n`;
+                outDiv.insertAdjacentHTML(
+                    "beforeend",
+                    `<span style='color:red'>${str}</span>\n`,
+                );
             } else {
                 notify(str);
                 console.error(str);


### PR DESCRIPTION
## Description

This is just a followup for this MR https://github.com/pyscript/pyscript/pull/2151 and it uses the right tool for the job, making the code also more consistent across JS/Python code.

## Changes

  * use `insertAdjacentHTML` instead of `innerHTML +=`
  * test everything works fine

PyEditor test:

```python
# doubled a
i = 0
while i < 5:
    i = i + 1
    print(i)
    import asyncio
    await asyncio.sleep(1)

# this append an error without trashing the layout
print(shenanigans)
```

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
