### PR TITLE
Increase timeout for heavy-load test.

### DIFF
--- a/pyscript.core/tests/js_tests.spec.js
+++ b/pyscript.core/tests/js_tests.spec.js
@@ -94,6 +94,7 @@ test('MicroPython + JS Storage', async ({ page }) => {
 });
 
 test('MicroPython + workers', async ({ page }) => {
+  test.setTimeout(120*1000);  // Increase timeout for this test.
   await page.goto('http://localhost:8080/tests/javascript/workers/index.html');
   await page.waitForSelector('html.mpy.py');
 });


### PR DESCRIPTION
## Description
The "MicroPython + workers" JavaScript test **sometimes** times out when running in CI. This is because PyScript is starting 2 MicroPython and 2 Pyodide workers, which can be processor and resource intensive (and thus slow).

## Changes

This PR increases the timeout for this test to 2 minutes. If it doesn't complete by then, there's definitely a problem.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
