### PR TITLE
Only use a single worker for playwright tests.

### DIFF
--- a/pyscript.core/package.json
+++ b/pyscript.core/package.json
@@ -40,7 +40,7 @@
         "build:3rd-party": "node rollup/3rd-party.cjs",
         "build:tests-index": "node rollup/build_test_index.cjs",
         "clean:3rd-party": "rm src/3rd-party/*.js && rm src/3rd-party/*.css",
-        "test:integration": "static-handler --coi . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test --fully-parallel tests/js_tests.spec.js tests/py_tests.spec.js || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
+        "test:integration": "static-handler --coi . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test --workers=1 tests/js_tests.spec.js tests/py_tests.spec.js || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
         "test:ws": "bun tests/ws/index.js & playwright test tests/ws.spec.js",
         "dev": "node dev.cjs",
         "release": "npm run build && npm run zip",


### PR DESCRIPTION
## Description

In our continuing question to figure out why CI resources appear to affect our test run, we're trying to make our tests run sequentially, one at a time.

## Changes

Playwright runs with only one worker.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have updated `CHANGELOG.md`
-   [ ] I have created documentation for this(if applicable)
