### PR TITLE
Fix sed search/replace when creating static page for a specific PyScript release.

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -57,7 +57,7 @@ jobs:
 
             - name: Generate index.html
               working-directory: .
-              run: sed -e 's#_PATH_#./#' -e 's#_VERSION_#latest#' -e 's#_DOC_VERSION_#latest#' -e 's#_TAG_VERSION_##' ./public/index.html > ./core/dist/index.html
+              run: sed -e 's#_PATH_#./#' -e 's#_DOC_VERSION_#latest#' -e 's#_TAG_VERSION_##' -e 's#_VERSION_#latest#' ./public/index.html > ./core/dist/index.html
 
             - name: Zip dist folder
               run: zip -r -q ./build.zip ./dist

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Generate index.html in snapshot
               working-directory: .
-              run: sed -e 's#_PATH_#https://pyscript.net/releases/${{ github.ref_name }}/#' -e 's#_VERSION_#${{ github.ref_name }}#'  -e 's#_DOC_VERSION_#${{ github.ref_name }}#' -e 's#_TAG_VERSION_#/tag/${{ github.ref_name }}#' ./public/index.html > ./core/dist/index.html
+              run: sed -e 's#_PATH_#https://pyscript.net/releases/${{ github.ref_name }}/#' -e 's#_DOC_VERSION_#${{ github.ref_name }}#' -e 's#_TAG_VERSION_#/tag/${{ github.ref_name }}#' -e 's#_VERSION_#${{ github.ref_name }}#' ./public/index.html > ./core/dist/index.html
 
             - name: Generate release.tar from snapshot and put it in dist/
               working-directory: .

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -69,7 +69,7 @@ jobs:
 
             - name: Generate index.html in snapshot
               working-directory: .
-              run: sed -e 's#_PATH_#https://pyscript.net/snapshots/${{ inputs.snapshot_version }}/#' -e 's#_VERSION_#${{ inputs.snapshot_version }}#'  -e 's#_DOC_VERSION_#${{ inputs.snapshot_version }}#' -e 's#_TAG_VERSION_#/tag/${{ inputs.snapshot_version }}#' ./public/index.html > ./core/dist/index.html
+              run: sed -e 's#_PATH_#https://pyscript.net/snapshots/${{ inputs.snapshot_version }}/#' -e 's#_DOC_VERSION_#${{ inputs.snapshot_version }}#' -e 's#_TAG_VERSION_#/tag/${{ inputs.snapshot_version }}#' -e 's#_VERSION_#${{ inputs.snapshot_version }}#' ./public/index.html > ./core/dist/index.html
 
             - name: Copy to Snapshot
               run: >

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -64,7 +64,7 @@ jobs:
 
             - name: Generate index.html in snapshot
               working-directory: .
-              run: sed -e 's#_PATH_#./#' -e 's#_VERSION_#latest#' -e 's#_DOC_VERSION_#latest#' -e 's#_TAG_VERSION_##' ./public/index.html > ./core/dist/index.html
+              run: sed -e 's#_PATH_#./#' -e 's#_DOC_VERSION_#latest#' -e 's#_TAG_VERSION_##' -e 's#_VERSION_#latest#' ./public/index.html > ./core/dist/index.html
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Description

The `sed` based search/replace used for generating a static web page with all the details for a specific release of PyScript, was slightly broken.

## Changes

Reorder the search and replace so everything works.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [x] I have created / updated documentation for this (if applicable)
