### PR TITLE
Use ubuntu-latest-8core everywhere

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
     prepare-release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-8core
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
     publish-release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-8core
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
     publish-snapshot:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-8core
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     publish-unstable:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-8core
         permissions:
             id-token: write
             contents: read


### PR DESCRIPTION
## Description

I am incapable of reproducing any issue other flows around publishing have hence I'd like to see if by using just the same machine we use to test, build, and validate our code would solve the issue around builds with a single core, also assuming our projects with *workers* inevitably needs multi-core targets, which is the norm.

## Changes

Use the same machine we use for CI

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [ ] All tests pass locally
-   [ ] I have created / updated documentation for this (if applicable)
