### PR TITLE
Try to find out what we really need in CI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
     prepare-release:
-        runs-on: ubuntu-latest-8core
+        runs-on: ubuntu-latest-4core
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
     publish-release:
-        runs-on: ubuntu-latest-8core
+        runs-on: ubuntu-latest-4core
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
     publish-snapshot:
-        runs-on: ubuntu-latest-8core
+        runs-on: ubuntu-latest-4core
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     publish-unstable:
-        runs-on: ubuntu-latest-8core
+        runs-on: ubuntu-latest-4core
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     BuildAndTest:
-        runs-on: ubuntu-latest-8core
+        runs-on: ubuntu-latest-4core
         env:
             MINICONDA_PYTHON_VERSION: py38
             MINICONDA_VERSION: 4.11.0


### PR DESCRIPTION
## Description

With this MR https://github.com/pyscript/pyscript/pull/2196 we managed to fix flaky tests that were impossible to reproduce locally after dozen consecutive runs but it's not clear why standard *ubuntu-latest* would fail so I'd like to find out worker boundaries with this MR that:

  * if it works out of the box, should be tested with other flows that used to fail before
  * as we improved already testing time and required dependencies, we might as well use a larger worker but the minimum possible needed otherwise we're paying (each minute) for something that is not fully used (we use 2 workers for playwright) and it might not even bring performance benefits
  * as in CI we run a lot the flow, if the overall time is still under 3 minutes and nothing ever fail, I think we'd be better with a less capable worker to keep in mind and observe when that's not the case anymore (and eventually start another investigation around multiple WASM in multiple workers)
  * I am not even excluding the issue is beyond our reach, as example it's always one test with multiple parallel Pyodide bootstraps that fail so the sooner we hit eventually that issue again, the better

## Changes

  * just use less powerful workers for our CI workflows

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have created / updated documentation for this (if applicable)
