### PR TITLE
Back to 8 cores

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
     prepare-release:
-        runs-on: ubuntu-latest-4core
+        runs-on: ubuntu-latest-8core
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
     publish-release:
-        runs-on: ubuntu-latest-4core
+        runs-on: ubuntu-latest-8core
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
     publish-snapshot:
-        runs-on: ubuntu-latest-4core
+        runs-on: ubuntu-latest-8core
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     publish-unstable:
-        runs-on: ubuntu-latest-4core
+        runs-on: ubuntu-latest-8core
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     BuildAndTest:
-        runs-on: ubuntu-latest-4core
+        runs-on: ubuntu-latest-8core
         env:
             MINICONDA_PYTHON_VERSION: py38
             MINICONDA_VERSION: 4.11.0


### PR DESCRIPTION
## Description

Reverted 4core because our tests require more cores to run in parallel by math.

## Changes

  * reverted 4core ... we're back to 8

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [x] All tests pass locally
-   [ ] I have created / updated documentation for this (if applicable)
