### PR TITLE
Fix broken link to core/README.md in the root README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ official calendar:
 
 ## Contribute
 
-For technical details of the code, please see the [README](core/README) in the
-`core` directory.
+For technical details of the code, please see the [README](core/README.md) in
+the `core` directory.
 
 Read the [contributing guide](https://docs.pyscript.net/latest/contributing/)
 to learn about our development process, reporting bugs and improvements,


### PR DESCRIPTION
## Description

The link to `core/README.md` was never correct.

## Changes

Ensures the link is now correct.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [X] All tests pass locally
-   [X] I have created / updated documentation for this (if applicable)
