### PR TITLE
Update/simplify our PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,10 @@
 
 ## Changes
 
-<!-- List the changes done to fix a bug or introduce a new feature.Please note both user-facing changes and changes to internal API's here -->
+<!-- List the technical changes done to fix a bug or introduce a new feature. -->
 
 ## Checklist
 
-<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->
-
--   [ ] All tests pass locally
--   [ ] I have created / updated documentation for this (if applicable)
+-   [ ] I have checked `make build` works locally.
+-   [ ] The `make precommit-check` passes without failures.
+-   [ ] I have created / updated documentation for this change (if applicable).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,4 @@
 ## Checklist
 
 -   [ ] I have checked `make build` works locally.
--   [ ] The `make precommit-check` passes without failures.
 -   [ ] I have created / updated documentation for this change (if applicable).


### PR DESCRIPTION
## Description

The PR template needed updating in light of recent refactoring.

## Changes

* Update language to make it more accurate about what the committer needs to have run (`make build` and `make precommit-check`).
* Add an item to ensure the committer has run/fixed the result of `make precommit-check`.
* Minor simplification of language.

## Checklist

<!-- Note: Only user-facing changes require a changelog entry. Internal-only API changes do not require a changelog entry. Changes in documentation do not require a changelog entry. -->

-   [X] All tests pass locally
-   [X] I have created / updated documentation for this (if applicable)
