### PR TITLE
Donkey clear and reset now terminate when busy

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/core/src/plugins/donkey.js
+++ b/core/src/plugins/donkey.js
@@ -73,13 +73,22 @@ const utils = async (options) => {
 export default async (options = {}) => {
     let farmer = await utils(options);
     let working = false;
+    const kill = () => {
+        if (farmer) {
+            farmer.xworker.terminate();
+            farmer.terminal.dispose();
+            farmer = null;
+        }
+        working = false;
+    };
+    const reload = async () => {
+        kill();
+        farmer = await utils(options);
+    };
     const asyncTask = (method) => async (code) => {
         // race condition ... a new task has been
         // assigned while the previous one didn't finish
-        if (working) {
-            kill();
-            farmer = await utils(options);
-        }
+        if (working) await reload();
         working = true;
         try {
             return await farmer[method](dedent(code));
@@ -89,20 +98,16 @@ export default async (options = {}) => {
             working = false;
         }
     };
-    const kill = () => {
-        if (farmer) {
-            farmer.xworker.terminate();
-            farmer.terminal.dispose();
-            farmer = null;
-            working = false;
-        }
+    const asyncMethod = method => async () => {
+        if (working) await reload();
+        else farmer?.terminal[method]();
     };
     return {
         process: asyncTask("process"),
         execute: asyncTask("execute"),
         evaluate: asyncTask("evaluate"),
-        clear: () => farmer?.terminal.clear(),
-        reset: () => farmer?.terminal.reset(),
+        clear: asyncMethod("clear"),
+        reset: asyncMethod("reset"),
         kill,
     };
 };

--- a/core/src/plugins/donkey.js
+++ b/core/src/plugins/donkey.js
@@ -98,7 +98,7 @@ export default async (options = {}) => {
             working = false;
         }
     };
-    const asyncMethod = method => async () => {
+    const asyncMethod = (method) => async () => {
         if (working) await reload();
         else farmer?.terminal[method]();
     };

--- a/core/tests/manual/donkey/index.js
+++ b/core/tests/manual/donkey/index.js
@@ -12,13 +12,23 @@ const {
   kill,
 } = await donkey({ terminal: '#container' });
 
-clearButton.onclick = clear;
-killButton.onclick = kill;
+clearButton.onclick = async () => {
+  killButton.disabled = true;
+  clearButton.disabled = true;
+  await clear();
+  runButton.disabled = false;
+};
+killButton.onclick = () => {
+  killButton.disabled = true;
+  clearButton.disabled = true;
+  runButton.disabled = true;
+  kill();
+};
 
 runButton.disabled = false;
 runButton.onclick = async () => {
   killButton.disabled = false;
-  clearButton.disabled = true;
+  clearButton.disabled = false;
   runButton.disabled = true;
   // multiline code
   await execute(`
@@ -29,6 +39,5 @@ runButton.onclick = async () => {
   const name = await evaluate('input("what is your name? ")');
   alert(`Hello ${name}`);
   killButton.disabled = true;
-  clearButton.disabled = false;
   runButton.disabled = false;
 };

--- a/core/types/core.d.ts
+++ b/core/types/core.d.ts
@@ -2,8 +2,8 @@ export function donkey(options: any): Promise<{
     process: (code: any) => Promise<any>;
     execute: (code: any) => Promise<any>;
     evaluate: (code: any) => Promise<any>;
-    clear: () => any;
-    reset: () => any;
+    clear: () => Promise<void>;
+    reset: () => Promise<void>;
     kill: () => void;
 }>;
 export function offline_interpreter(config: any): string;

--- a/core/types/plugins/donkey.d.ts
+++ b/core/types/plugins/donkey.d.ts
@@ -2,8 +2,8 @@ declare function _default(options?: {}): Promise<{
     process: (code: any) => Promise<any>;
     execute: (code: any) => Promise<any>;
     evaluate: (code: any) => Promise<any>;
-    clear: () => any;
-    reset: () => any;
+    clear: () => Promise<void>;
+    reset: () => Promise<void>;
     kill: () => void;
 }>;
 export default _default;


### PR DESCRIPTION
## Description

This MR goal is to satisfy latest @JoshuaLowe1002 requirement around the *donkey* functionality, so that if not available both `clear` and `reset` methods now terminate the worker and terminal and re-bootstrap the whole thing.

Everything else works as before *except* both `clear` and `reset` are now async, letting `kill` be the only synchronous method out of exposed utilities.

## Changes

  * if the donkey is working and `clear` or `reset` are invoked, "*kill previous terminal and farmer*" and bootstrap again
  * if the donkey is not working, simply try to invoke `clear` or `reset` as it was before
  * change the manual test to be sure everything works as expected

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
