### PR TITLE
Fix Makefile so JS dependencies don't get into a bad state.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ check-python:
 
 # Check the environment, install the dependencies.
 setup: check-node check-npm check-python
-	cd core && npm install && cd ..
+	cd core && npm ci && cd ..
 ifeq ($(VIRTUAL_ENV),)
 	echo "\n\n\033[0;31mCannot install Python dependencies. Your virtualenv is not activated.\033[0m"
 	false
@@ -60,7 +60,6 @@ build:
 
 # Update the dependencies.
 update:
-	cd core && npm update && cd ..
 	python -m pip install -r requirements.txt --upgrade
 
 # Run the precommit checks (run eslint).


### PR DESCRIPTION
## Description

The `make update` command broke the JS dependencies (thanks to `npm update`).

## Changes

Update `make setup` and `make update` to use `npm ci` (in setup) and remove `npm update` (in update).

## Checklist

-   [x] I have checked `make build` works locally.
-   [x] I have created / updated documentation for this change (if applicable).
