### PR TITLE
Fix #2065 - Allow usage of index_urls for Pyodide

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.13",
+    "version": "0.6.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.6.13",
+            "version": "0.6.14",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
                 "@webreflection/idb-map": "^0.3.2",
                 "add-promise-listener": "^0.1.3",
                 "basic-devtools": "^0.1.6",
-                "polyscript": "^0.16.4",
+                "polyscript": "^0.16.5",
                 "sabayon": "^0.6.0",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
@@ -2667,9 +2667,9 @@
             }
         },
         "node_modules/polyscript": {
-            "version": "0.16.4",
-            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.16.4.tgz",
-            "integrity": "sha512-Sth8HFEjK8MY1zJ90fVMy1xiDlHWheq+BxiNOg2wyvsGDZHgLbnt4LCpiLisBnFEsBX6/pj2OJbgATnXnxp6jA==",
+            "version": "0.16.5",
+            "resolved": "https://registry.npmjs.org/polyscript/-/polyscript-0.16.5.tgz",
+            "integrity": "sha512-wxSRmwhWW/uGIhmiQWgMGV9nzYNUIjsjdpYLswanue0BCmu2i6xIZPOtionTwgSwu99SQy+aEr13cm2L6nsJiw==",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/structured-clone": "^1.2.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.13",
+    "version": "0.6.14",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -62,7 +62,7 @@
         "@webreflection/idb-map": "^0.3.2",
         "add-promise-listener": "^0.1.3",
         "basic-devtools": "^0.1.6",
-        "polyscript": "^0.16.4",
+        "polyscript": "^0.16.5",
         "sabayon": "^0.6.0",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/pull/2065 by updating Polyscript after https://github.com/pyscript/polyscript/pull/124 landed.

## Changes

  * update Polyscript to its latest

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
