### PR TITLE
[Proposal] - Introduce `t` as in PEP750 to play around with it

### DIFF
--- a/core/src/stdlib/pyscript/__init__.py
+++ b/core/src/stdlib/pyscript/__init__.py
@@ -46,6 +46,7 @@ from pyscript.fetch import fetch
 from pyscript.storage import Storage, storage
 from pyscript.websocket import WebSocket
 from pyscript.events import when, Event
+from pyscript.t import t
 
 if not RUNNING_IN_WORKER:
     from pyscript.workers import create_named_worker, workers

--- a/core/src/stdlib/pyscript/t.py
+++ b/core/src/stdlib/pyscript/t.py
@@ -1,0 +1,70 @@
+class Interpolation:
+    def __init__(self, expr):
+        self.expr = expr
+    def __getattr__(self, name):
+        expr = getattr(self, "expr")
+        if name == "value":
+            return eval(expr)
+        if name == "expr":
+            return expr
+        if name == "conv":
+            return None
+        if name == "format_spec":
+            return ""
+
+class Template:
+    def __init__(self, args):
+        self.args = tuple(args)
+    def __getattr__(self, name):
+        args = getattr(self, "args")
+        if name == "args":
+            return args
+        if name == "strings":
+            return args[::2]
+        if name == "values":
+            return [i.value for i in args[1::2]]
+        if name == "interpolations":
+            return args[1::2]
+    def __str__(self):
+        out = []
+        i = 0
+        for arg in getattr(self, "args"):
+            out.append(i % 2 and str(arg.value) or arg)
+            i += 1
+        return "".join(out)
+
+drop = lambda s: s.replace("{{", "\x01").replace("}}", "\x02")
+add = lambda s: s.replace("\x01", "{{").replace("\x02", "}}")
+
+"""
+PEP750 shim for MicroPython or Pyodide until it lands
+"""
+def t(content):
+    # sanitize brackets (drop double brackets)
+    content = drop(content)
+    # fail if the format string is not balanced
+    if content.count("{") != content.count("}"):
+        raise ValueError("single '{' or '}' encountered in format string")
+    # find outer most interesting curly braces
+    l = len(content)
+    i = 0
+    j = 0
+    start = 0
+    opened = 0
+    args = []
+    for c in content:
+        if c == "{":
+            if opened == 0:
+                j = i
+            opened += 1
+        elif c == "}":
+            opened -= 1
+            if opened == 0:
+                args.append(add(content[start:j:]))
+                args.append(Interpolation(add(content[j+1:i:])))
+                start = i + 1
+        i += 1
+    args.append(add(content[start::]))
+    return Template(args)
+
+__all__ = ["t"]

--- a/core/src/stdlib/pyscript/t.py
+++ b/core/src/stdlib/pyscript/t.py
@@ -15,7 +15,7 @@ class Template:
         self.strings = args[::2]
         self.values = [i.value for i in args[1::2]]
         self.interpolations = args[1::2]
-  
+
     def __str__(self):
         out = []
         i = 0


### PR DESCRIPTION
## Description

The goal of this MR is to provide an "*experimental shim*" for the PEP750 so that both Pyodide and MicroPython can start playing around its wonderful and simple beauty with the following caveats:

  * `t` in here is a function, not a special syntax as we cannot provide that out of the box
  * `t` in `t` interpolations are a bit ugly to write, still these work without issues
  * `t` in-string interpolations are pretty simple ... nothing fancy, only outer curly braces are considered and yet everything seems to be fine
  * `t` interpolations are not highlighted in my IDE, pretty annoying, still this is a temporary experiment

/cc @ntoll ... what are your thoughts?

## Changes

  * add a `t.py` module that provides functionalities meant to land in PEP750 as `t"..."` special string, once passed as function parameter

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
