### PR TITLE
Added __terminal__ in non-persistent donkey

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.20",
+    "version": "0.6.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.6.20",
+            "version": "0.6.22",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",
@@ -14,7 +14,7 @@
                 "add-promise-listener": "^0.1.3",
                 "basic-devtools": "^0.1.6",
                 "polyscript": "^0.16.10",
-                "sabayon": "^0.6.0",
+                "sabayon": "^0.6.1",
                 "sticky-module": "^0.1.1",
                 "to-json-callback": "^0.1.1",
                 "type-checked-collections": "^0.1.7"
@@ -39,7 +39,7 @@
                 "codemirror": "^6.0.1",
                 "eslint": "^9.16.0",
                 "flatted": "^3.3.2",
-                "rollup": "^4.28.0",
+                "rollup": "^4.28.1",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-string": "^3.0.0",
                 "static-handler": "^0.5.3",
@@ -675,9 +675,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.0.tgz",
-            "integrity": "sha512-wLJuPLT6grGZsy34g4N1yRfYeouklTgPhH1gWXCYspenKYD0s3cR99ZevOGw5BexMNywkbV3UkjADisozBmpPQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+            "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
             "cpu": [
                 "arm"
             ],
@@ -689,9 +689,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.0.tgz",
-            "integrity": "sha512-eiNkznlo0dLmVG/6wf+Ifi/v78G4d4QxRhuUl+s8EWZpDewgk7PX3ZyECUXU0Zq/Ca+8nU8cQpNC4Xgn2gFNDA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+            "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
             "cpu": [
                 "arm64"
             ],
@@ -703,9 +703,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.0.tgz",
-            "integrity": "sha512-lmKx9yHsppblnLQZOGxdO66gT77bvdBtr/0P+TPOseowE7D9AJoBw8ZDULRasXRWf1Z86/gcOdpBrV6VDUY36Q==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+            "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
             "cpu": [
                 "arm64"
             ],
@@ -717,9 +717,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.0.tgz",
-            "integrity": "sha512-8hxgfReVs7k9Js1uAIhS6zq3I+wKQETInnWQtgzt8JfGx51R1N6DRVy3F4o0lQwumbErRz52YqwjfvuwRxGv1w==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+            "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
             "cpu": [
                 "x64"
             ],
@@ -731,9 +731,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.0.tgz",
-            "integrity": "sha512-lA1zZB3bFx5oxu9fYud4+g1mt+lYXCoch0M0V/xhqLoGatbzVse0wlSQ1UYOWKpuSu3gyN4qEc0Dxf/DII1bhQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+            "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
             "cpu": [
                 "arm64"
             ],
@@ -745,9 +745,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.0.tgz",
-            "integrity": "sha512-aI2plavbUDjCQB/sRbeUZWX9qp12GfYkYSJOrdYTL/C5D53bsE2/nBPuoiJKoWp5SN78v2Vr8ZPnB+/VbQ2pFA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+            "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
             "cpu": [
                 "x64"
             ],
@@ -759,9 +759,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.0.tgz",
-            "integrity": "sha512-WXveUPKtfqtaNvpf0iOb0M6xC64GzUX/OowbqfiCSXTdi/jLlOmH0Ba94/OkiY2yTGTwteo4/dsHRfh5bDCZ+w==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+            "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
             "cpu": [
                 "arm"
             ],
@@ -773,9 +773,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.0.tgz",
-            "integrity": "sha512-yLc3O2NtOQR67lI79zsSc7lk31xjwcaocvdD1twL64PK1yNaIqCeWI9L5B4MFPAVGEVjH5k1oWSGuYX1Wutxpg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+            "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
             "cpu": [
                 "arm"
             ],
@@ -787,9 +787,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.0.tgz",
-            "integrity": "sha512-+P9G9hjEpHucHRXqesY+3X9hD2wh0iNnJXX/QhS/J5vTdG6VhNYMxJ2rJkQOxRUd17u5mbMLHM7yWGZdAASfcg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+            "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
             "cpu": [
                 "arm64"
             ],
@@ -801,9 +801,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.0.tgz",
-            "integrity": "sha512-1xsm2rCKSTpKzi5/ypT5wfc+4bOGa/9yI/eaOLW0oMs7qpC542APWhl4A37AENGZ6St6GBMWhCCMM6tXgTIplw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+            "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
             "cpu": [
                 "arm64"
             ],
@@ -814,10 +814,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.0.tgz",
-            "integrity": "sha512-zgWxMq8neVQeXL+ouSf6S7DoNeo6EPgi1eeqHXVKQxqPy1B2NvTbaOUWPn/7CfMKL7xvhV0/+fq/Z/J69g1WAQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+            "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
             "cpu": [
                 "ppc64"
             ],
@@ -829,9 +843,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.0.tgz",
-            "integrity": "sha512-VEdVYacLniRxbRJLNtzwGt5vwS0ycYshofI7cWAfj7Vg5asqj+pt+Q6x4n+AONSZW/kVm+5nklde0qs2EUwU2g==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
             "cpu": [
                 "riscv64"
             ],
@@ -843,9 +857,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.0.tgz",
-            "integrity": "sha512-LQlP5t2hcDJh8HV8RELD9/xlYtEzJkm/aWGsauvdO2ulfl3QYRjqrKW+mGAIWP5kdNCBheqqqYIGElSRCaXfpw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+            "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
             "cpu": [
                 "s390x"
             ],
@@ -857,9 +871,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.0.tgz",
-            "integrity": "sha512-Nl4KIzteVEKE9BdAvYoTkW19pa7LR/RBrT6F1dJCV/3pbjwDcaOq+edkP0LXuJ9kflW/xOK414X78r+K84+msw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+            "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
             "cpu": [
                 "x64"
             ],
@@ -871,9 +885,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.0.tgz",
-            "integrity": "sha512-eKpJr4vBDOi4goT75MvW+0dXcNUqisK4jvibY9vDdlgLx+yekxSm55StsHbxUsRxSTt3JEQvlr3cGDkzcSP8bw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+            "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
             "cpu": [
                 "x64"
             ],
@@ -885,9 +899,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.0.tgz",
-            "integrity": "sha512-Vi+WR62xWGsE/Oj+mD0FNAPY2MEox3cfyG0zLpotZdehPFXwz6lypkGs5y38Jd/NVSbOD02aVad6q6QYF7i8Bg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+            "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
             "cpu": [
                 "arm64"
             ],
@@ -899,9 +913,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.0.tgz",
-            "integrity": "sha512-kN/Vpip8emMLn/eOza+4JwqDZBL6MPNpkdaEsgUtW1NYN3DZvZqSQrbKzJcTL6hd8YNmFTn7XGWMwccOcJBL0A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
             "cpu": [
                 "ia32"
             ],
@@ -913,9 +927,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.0.tgz",
-            "integrity": "sha512-Bvno2/aZT6usSa7lRDL2+hMjVAGjuqaymF1ApZm31JXzniR/hvr14jpU+/z4X6Gt5BPlzosscyJZGUvguXIqeQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
             "cpu": [
                 "x64"
             ],
@@ -3411,9 +3425,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.0.tgz",
-            "integrity": "sha512-G9GOrmgWHBma4YfCcX8PjH0qhXSdH8B4HDE2o4/jaxj93S4DPCIDoLcXz99eWMji4hB29UFCEd7B2gwGJDR9cQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+            "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3427,24 +3441,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.28.0",
-                "@rollup/rollup-android-arm64": "4.28.0",
-                "@rollup/rollup-darwin-arm64": "4.28.0",
-                "@rollup/rollup-darwin-x64": "4.28.0",
-                "@rollup/rollup-freebsd-arm64": "4.28.0",
-                "@rollup/rollup-freebsd-x64": "4.28.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.28.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.28.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.28.0",
-                "@rollup/rollup-linux-arm64-musl": "4.28.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.28.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.28.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.28.0",
-                "@rollup/rollup-linux-x64-gnu": "4.28.0",
-                "@rollup/rollup-linux-x64-musl": "4.28.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.28.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.28.0",
-                "@rollup/rollup-win32-x64-msvc": "4.28.0",
+                "@rollup/rollup-android-arm-eabi": "4.28.1",
+                "@rollup/rollup-android-arm64": "4.28.1",
+                "@rollup/rollup-darwin-arm64": "4.28.1",
+                "@rollup/rollup-darwin-x64": "4.28.1",
+                "@rollup/rollup-freebsd-arm64": "4.28.1",
+                "@rollup/rollup-freebsd-x64": "4.28.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+                "@rollup/rollup-linux-arm64-musl": "4.28.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-musl": "4.28.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+                "@rollup/rollup-win32-x64-msvc": "4.28.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3504,9 +3519,9 @@
             "license": "MIT"
         },
         "node_modules/sabayon": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/sabayon/-/sabayon-0.6.0.tgz",
-            "integrity": "sha512-7SAj50w4xoers9QTTF3yoH0sNBU6lk284FmJpG6pXTG3XOZ1L/qwHIYV0TiQYUtN1hma8FccnfIz+DKiHRlokA==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/sabayon/-/sabayon-0.6.1.tgz",
+            "integrity": "sha512-X3S9vBVEecMTHGKl0pjlU69DxAp7OGV8PdoSPLxz3jbU2mRLNpffUNlm8TmDW4FNXi8nkQ7B8lOJEmnr7jsy7w==",
             "license": "MIT",
             "dependencies": {
                 "@ungap/raw-json": "^0.3.7"

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.20",
+    "version": "0.6.22",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",
@@ -63,7 +63,7 @@
         "add-promise-listener": "^0.1.3",
         "basic-devtools": "^0.1.6",
         "polyscript": "^0.16.10",
-        "sabayon": "^0.6.0",
+        "sabayon": "^0.6.1",
         "sticky-module": "^0.1.1",
         "to-json-callback": "^0.1.1",
         "type-checked-collections": "^0.1.7"
@@ -88,7 +88,7 @@
         "codemirror": "^6.0.1",
         "eslint": "^9.16.0",
         "flatted": "^3.3.2",
-        "rollup": "^4.28.0",
+        "rollup": "^4.28.1",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-string": "^3.0.0",
         "static-handler": "^0.5.3",

--- a/core/src/plugins/donkey.js
+++ b/core/src/plugins/donkey.js
@@ -6,7 +6,8 @@ const { stringify } = JSON;
 const invoke = (name, args) => `${name}(code, ${args.join(", ")})`;
 
 const donkey = ({ type = "py", persistent, terminal, config }) => {
-    const args = persistent ? ["globals()", "__locals__"] : ["{}", "{}"];
+    const globals = terminal ? '{"__terminal__":__terminal__}' : "{}";
+    const args = persistent ? ["globals()", "__locals__"] : [globals, "{}"];
 
     const src = URL.createObjectURL(
         new Blob([


### PR DESCRIPTION
## Description

This MR fixes an issue encountered by @JoshuaLowe1002 where the `__terminal__` special variable is not exposed if the *donkey* is not persistent.

## Changes

  * add a `__terminal__` reference when `terminal` option is present and the `persistent` one is not *True*
  * test everything works as expected

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
