### PR TITLE
Enable service-worker attribute for donkey worker

### DIFF
--- a/core/src/plugins/donkey.js
+++ b/core/src/plugins/donkey.js
@@ -5,7 +5,7 @@ const { stringify } = JSON;
 
 const invoke = (name, args) => `${name}(code, ${args.join(", ")})`;
 
-const donkey = ({ type = "py", persistent, terminal, config }) => {
+const donkey = ({ type = "py", persistent, terminal, config, serviceWorker }) => {
     const globals = terminal ? '{"__terminal__":__terminal__}' : "{}";
     const args = persistent ? ["globals()", "__locals__"] : [globals, "{}"];
 
@@ -46,6 +46,7 @@ const donkey = ({ type = "py", persistent, terminal, config }) => {
             typeof config === "string" ? config : stringify(config),
         );
     }
+    if (serviceWorker) script.setAttribute("service-worker", serviceWorker);
 
     return addPromiseListener(
         document.body.appendChild(script),

--- a/core/src/plugins/donkey.js
+++ b/core/src/plugins/donkey.js
@@ -5,7 +5,13 @@ const { stringify } = JSON;
 
 const invoke = (name, args) => `${name}(code, ${args.join(", ")})`;
 
-const donkey = ({ type = "py", persistent, terminal, config, serviceWorker }) => {
+const donkey = ({
+    type = "py",
+    persistent,
+    terminal,
+    config,
+    serviceWorker,
+}) => {
     const globals = terminal ? '{"__terminal__":__terminal__}' : "{}";
     const args = persistent ? ["globals()", "__locals__"] : [globals, "{}"];
 


### PR DESCRIPTION
## Description

Enables the service worker attribute for the donkey worker plugin to allow the [service worker operation mode](https://docs.pyscript.net/2024.8.2/user-guide/workers/#option-2-service-worker-attribute) 

## Changes

- Add `serviceWorker` option to enable `service-worker` attribute in donkey plugin

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
