### PR TITLE
PyGame - TOML + JSON absolute URL + input patch

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.36",
+    "version": "0.6.39",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.6.36",
+            "version": "0.6.39",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.6.36",
+    "version": "0.6.39",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/core/src/plugins/py-game.js
+++ b/core/src/plugins/py-game.js
@@ -11,6 +11,17 @@ import { getText } from "../fetch.js";
 
 const progress = createProgress("py-game");
 
+const inputPatch = `
+import builtins
+def input(prompt=""):
+    import js
+    return js.prompt(prompt)
+
+builtins.input = input
+del builtins
+del input
+`;
+
 let toBeWarned = true;
 
 const hooks = {
@@ -63,6 +74,7 @@ const hooks = {
             });
 
             await wrap.interpreter.runPythonAsync(stdlib);
+            wrap.interpreter.runPython(inputPatch);
 
             let code = dedent(script.textContent);
             if (script.src) code = await fetch(script.src).then(getText);

--- a/core/src/plugins/py-game.js
+++ b/core/src/plugins/py-game.js
@@ -45,7 +45,7 @@ const hooks = {
                     progress,
                     wrap.interpreter,
                     config,
-                    url || location.href,
+                    url ? new URL(url, location.href).href : location.href,
                 );
             }
 

--- a/core/tests/manual/game/index.html
+++ b/core/tests/manual/game/index.html
@@ -8,7 +8,7 @@
       <script type="module" src="../../../dist/core.js"></script>
   </head>
   <body>
-      <script type="py-game" src="aliens.py" config="{}"></script>
+      <script type="py-game" src="aliens.py" config="./config.toml"></script>
       <div class="demo">
           <div class="demo-header">pygame.examples.aliens</div>
           <div class="demo-content">


### PR DESCRIPTION
## Description

This MR fixes an issue with not fully resolved URLs as `config` attribute + it patches the `builtins.input` function to avoid surprises, using the native `js.prompt` function as least surprise/solution.

## Changes

  * enforced fully qualified *url* resolution for the config, when it's known
  * patched `input` so that it's usable as it's common for games to ask for inputs

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
