### PR TITLE
Fix #2326 - Redirect to localhost when on 0.0.0.0

### DIFF
--- a/core/src/core.js
+++ b/core/src/core.js
@@ -1,5 +1,6 @@
 /*! (c) PyScript Development Team */
 
+import "./zero-redirect.js";
 import stickyModule from "sticky-module";
 import "@ungap/with-resolvers";
 

--- a/core/src/zero-redirect.js
+++ b/core/src/zero-redirect.js
@@ -1,0 +1,8 @@
+/* eslint no-unused-vars: 0 */
+try {
+  crypto.randomUUID();
+}
+catch (_) {
+  if (location.href.startsWith('http://0.0.0.0'))
+    location.href = location.href.replace('0.0.0.0', 'localhost');
+}

--- a/core/src/zero-redirect.js
+++ b/core/src/zero-redirect.js
@@ -1,8 +1,7 @@
 /* eslint no-unused-vars: 0 */
 try {
-  crypto.randomUUID();
-}
-catch (_) {
-  if (location.href.startsWith('http://0.0.0.0'))
-    location.href = location.href.replace('0.0.0.0', 'localhost');
+    crypto.randomUUID();
+} catch (_) {
+    if (location.href.startsWith("http://0.0.0.0"))
+        location.href = location.href.replace("0.0.0.0", "localhost");
 }


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/2326 by simply avoiding users to visit directly `http://0.0.0.0` as:

  * most browsers refuse to even visit that address anyway (Windows)
  * Firefox redirects automatically to `127.0.0.1` for loopback
  * the `0.0.0.0` is not really an address and nothing on the Web can reach that address

So with this simple check that error people using `python -m http.server`, which hints to reach that broken address by default, will be redirected to `localhost`.

## Changes

  * add a top-level import that triggers a redirect if the address is wrong

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
