### PR TITLE
Fix code example problem in the release HTML.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -137,12 +137,14 @@
     &lt;body&gt;
         &lt;h1&gt;Hello world!&lt;/h1&gt;
         &lt;p&gt;These are the Python interpreters in PyScript _VERSION_:&lt;/p&gt;
-        &lt;script type=&quot;py&quot;&gt;  &lt;!-- Pyodide --&gt;
+        &lt;script type=&quot;py&quot;&gt;
+            # Pyodide
             from pyscript import display
             import sys
             display(sys.version)
         &lt;/script&gt;
-        &lt;script type=&quot;mpy&quot;&gt;  &lt;!-- MicroPython --&gt;
+        &lt;script type=&quot;mpy&quot;&gt;
+            # MicroPython
             from pyscript import display
             import sys
             display(sys.version)


### PR DESCRIPTION
## Description

The code example in the template for the release page uses HTML comments rather than Python comments between the `<script>` tags. Unsurprisingly, this causes syntax errors if you actually try to cut and paste the example into actual code.

## Changes

Change the HTML comments into equivalent (and thus syntactically correct) Python comments.

## Checklist

-   [x] I have checked `make build` works locally.
-   [x] I have created / updated documentation for this change (if applicable).
