### PR TITLE
pre-commit: Upgrade the Python linter ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
                 - tomli
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.11.8
+      rev: v0.12.8
       hooks:
           - id: ruff
             exclude: core/tests

--- a/core/tests/manual/issue-2302/main.py
+++ b/core/tests/manual/issue-2302/main.py
@@ -10,7 +10,7 @@ from pyscript import document, window, PyWorker
 from libthree import THREE, clear, SoundPlayer
 from libthree import get_renderer, get_ortho_camera
 from libthree import get_loading_manager, get_stats_gl
-from libthree import lsgeo, line2, linemat, lsgeo
+from libthree import line2, linemat, lsgeo
 from libfft import BeatSync
 
 from multipyjs import MICROPYTHON, new, call, to_js, create_proxy

--- a/core/tests/python/tests/test_js_modules.py
+++ b/core/tests/python/tests/test_js_modules.py
@@ -32,7 +32,7 @@ def test_js_module_is_available_on_worker():
 
 
 @upytest.skip("Worker only.", skip_when=not RUNNING_IN_WORKER)
-def test_js_module_is_available_on_worker():
+def test_js_module_is_available_on_greeting_worker():
     """
     The "hello" function in the example_js_worker_module.js file is available
     via the js_modules object while running in a worker.

--- a/core/tests/python/tests/test_media.py
+++ b/core/tests/python/tests/test_media.py
@@ -2,7 +2,6 @@
 Tests for the PyScript media module.
 """
 
-from pyscript import media
 import upytest
 
 from pyscript import media

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ skip = "*.js,*.json"
 [tool.ruff]
 line-length = 114
 lint.select = ["C4", "C90", "E", "EM", "F", "PIE", "PYI", "PLC", "Q", "RET", "W"]
-lint.ignore = ["E402", "E722", "E731", "E741", "F401", "F704", "F811", "F821"]
+lint.ignore = ["E402", "E722", "E731", "E741", "F401", "F704", "F821", "PLC0415"]
 lint.mccabe.max-complexity = 27


### PR DESCRIPTION
## Description

Fixes:
* #2350

Upgrade the Python linter [`ruff`](https://docs.astral.sh/ruff) in pre-commit by:
* Ignoring the unreasonable `ruff rule PLC0415` discussed at https://docs.astral.sh/ruff/rules/import-outside-top-level
    * We already ignore `ruff rule E402` discussed at https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
* Fixing three violations of `ruff rule F811` discussed at https://docs.astral.sh/ruff/rules/redefined-while-unused

## Changes

Fix three redefinitions (the last defined persists in Python).

## Checklist

-   [ ] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
