### PR TITLE
Follow up on autostart

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -21,6 +21,7 @@ def func_b():
 
 ### Options
 
+  * **pyscript**: the release version to automatically import if not already available on the page. If no version is provided the *developers' channel* version will be used instead (for developers' purposes only).
   * **type**: `py` by default to bootstrap *Pyodide*.
   * **worker**: `true` by default to bootstrap in a *Web Worker*.
   * **config**: either a *string* or a PyScript compatible config *JS literal* to make it possible to bootstrap files and whatnot. If specified, the `worker` becomes implicitly `true` to avoid multiple configs conflicting on the main thread.
@@ -39,6 +40,7 @@ no config
 
 The [test.js](./test/test.js) files uses the following defaults:
 
+  * `pyscript` as `"2025.8.1"`
   * `type` as `"mpy"`
   * `worker` as `false`
   * `config` as `undefined`

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyscript/bridge",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "A JS based way to use PyScript modules",
   "type": "module",
   "module": "./index.js",
@@ -13,6 +13,10 @@
     "JS",
     "Python",
     "bridge"
+  ],
+  "files": [
+    "index.js",
+    "README.md"
   ],
   "author": "Anaconda Inc.",
   "license": "APACHE-2.0",

--- a/bridge/test/test.js
+++ b/bridge/test/test.js
@@ -5,6 +5,7 @@ const { searchParams } = new URL(location.href);
 
 // the named (or default) export for test.py
 export const ffi = bridge(import.meta.url, {
+  pyscript: "2025.8.1",
   env: searchParams.get("env"),
   type: searchParams.get("type") || "mpy",
   worker: searchParams.has("worker"),


### PR DESCRIPTION
## Description

This MR simply improves what I've brough in before in a better way for both developers and production use cases.

## Changes

  * added a `pyscript` property that indicates the exact version of *PyScript* to use (a release number). The default is still our *developers' channel* but at least it's possible now to instead pin-point a precise release (better / suggested)
  * tested everything is fine with or without that property
  * updated the `package.json` to publish on *npm* **only the index.js** file

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
