### PR TITLE
Added .sh utility to generate PyScript <-> Pyodide versions map

### DIFF
--- a/core/pyodide.sh
+++ b/core/pyodide.sh
@@ -23,7 +23,7 @@
 #
 # The last empty key with `null` value is used just to close the JSON object.
 # One could remove manually that entry as long as there are no dangling commas.
-# 
+#
 
 current_pyscript=$(git branch | grep \\* | cut -d ' ' -f2)
 


### PR DESCRIPTION
## Description

This MR places a handy utility able to generate a map between PyScript releases (Calver based tags) and Pyodide versions provided by Polyscript (semver based tags).

## Changes

* added a `pyodide.sh` file that requires some folder structure and `jq` available
* tested that the generated output works at least on Linux / WSL

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
