### PR TITLE
Fix #2427 - Show bootstrap config errors

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.7.14",
+    "version": "0.7.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.7.14",
+            "version": "0.7.15",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.7.14",
+    "version": "0.7.15",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/core/src/core.js
+++ b/core/src/core.js
@@ -254,12 +254,7 @@ for (const [TYPE, interpreter] of TYPES) {
                 },
                 onBeforeRun(wrap, element) {
                     currentElement = element;
-                    bootstrapNodeAndPlugins(
-                        main,
-                        wrap,
-                        element,
-                        "onBeforeRun",
-                    );
+                    bootstrapNodeAndPlugins(main, wrap, element, "onBeforeRun");
                 },
                 onBeforeRunAsync(wrap, element) {
                     currentElement = element;
@@ -271,12 +266,7 @@ for (const [TYPE, interpreter] of TYPES) {
                     );
                 },
                 onAfterRun(wrap, element) {
-                    bootstrapNodeAndPlugins(
-                        main,
-                        wrap,
-                        element,
-                        "onAfterRun",
-                    );
+                    bootstrapNodeAndPlugins(main, wrap, element, "onAfterRun");
                 },
                 onAfterRunAsync(wrap, element) {
                     return bootstrapNodeAndPlugins(
@@ -354,8 +344,7 @@ for (const [TYPE, interpreter] of TYPES) {
                     if (!this.executed) {
                         this.executed = true;
                         const isAsync = !isSync(this);
-                        const { io, run, runAsync } = await this._wrap
-                            .promise;
+                        const { io, run, runAsync } = await this._wrap.promise;
                         this.srcCode = await fetchSource(
                             this,
                             io,


### PR DESCRIPTION
## Description

This MR fixes https://github.com/pyscript/pyscript/issues/2427 by showing through eventual error plugin the error caused by the config in case it was not possible to bootstrap this.

## Changes

  * moved the `if (error)` **after** the plugins bootstrap so that errors are correctly shown if found during bootstrap

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
