### PR TITLE
Fixed typo in docstring, so API doc is rendered properly.

### DIFF
--- a/core/src/stdlib/pyscript/workers.py
+++ b/core/src/stdlib/pyscript/workers.py
@@ -49,6 +49,7 @@ print(result)
 ```
 
 Key features:
+
 - Access (`await`) named workers via dictionary-like syntax.
 - Dynamically create workers from Python.
 - Cross-interpreter support (Pyodide and MicroPython).


### PR DESCRIPTION
## Description

There was some incorrect markdown in the worker docstring.

## Changes

A very minor edit to the docstring so it renders properly.

## Checklist

-   [x] I have checked `make build` works locally.
-   [x] I have created / updated documentation for this change (if applicable).
