### PR TITLE
Bump version referenced in README to 2026.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Using PyScript is as simple as:
         <title>PyScript!</title>
         <link
             rel="stylesheet"
-            href="https://pyscript.net/releases/2026.2.1/core.css"
+            href="https://pyscript.net/releases/2026.3.1/core.css"
         />
         <script
             type="module"
-            src="https://pyscript.net/releases/2026.2.1/core.js"
+            src="https://pyscript.net/releases/2026.3.1/core.js"
         ></script>
     </head>
     <body>


### PR DESCRIPTION
## Description

Readme needs to reflect the latest version of PyScript.

## Changes

Updated version to 2026.3.1

## Checklist

-   [ ] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
