### PR TITLE
PyEditor - Improved onbeforerun split in two different promises

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pyscript/core",
-    "version": "0.7.30",
+    "version": "0.7.31",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pyscript/core",
-            "version": "0.7.30",
+            "version": "0.7.31",
             "license": "APACHE-2.0",
             "dependencies": {
                 "@ungap/with-resolvers": "^0.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pyscript/core",
-    "version": "0.7.30",
+    "version": "0.7.31",
     "type": "module",
     "description": "PyScript",
     "module": "./index.js",

--- a/core/src/plugins/py-editor.js
+++ b/core/src/plugins/py-editor.js
@@ -156,7 +156,9 @@ async function execute({ currentTarget, script }, onBeforeRun = "") {
             }
         };
 
-        const run = onBeforeRun ? sync.runAsync(onBeforeRun) : Promise.resolve();
+        const run = onBeforeRun
+            ? sync.runAsync(onBeforeRun)
+            : Promise.resolve();
         run.then(() => sync.runAsync(pySrc), enable).then(enable, enable);
     });
 }

--- a/core/src/plugins/py-editor.js
+++ b/core/src/plugins/py-editor.js
@@ -155,8 +155,9 @@ async function execute({ currentTarget, script }, onBeforeRun = "") {
                 console.error(str);
             }
         };
-        if (onBeforeRun) onBeforeRun += ";";
-        sync.runAsync(onBeforeRun + pySrc).then(enable, enable);
+
+        const run = onBeforeRun ? sync.runAsync(onBeforeRun) : Promise.resolve();
+        run.then(() => sync.runAsync(pySrc), enable).then(enable, enable);
     });
 }
 


### PR DESCRIPTION
## Description

This MR enqueue the onBeforeRun as opposite of running both as unique first line.

This helps debugging evaluating code without leaking the details hidden in `onBeforeRun` directive.

## Changes

<!-- List the technical changes done to fix a bug or introduce a new feature. -->

## Checklist

-   [x] I have checked `make build` works locally.
-   [ ] I have created / updated documentation for this change (if applicable).
